### PR TITLE
Update FFVT API return format

### DIFF
--- a/src/tools/file-format-verification/actions/index.js
+++ b/src/tools/file-format-verification/actions/index.js
@@ -78,7 +78,7 @@ export function triggerParse(file, filingPeriod) {
         .catch(err => console.error(err))
     }
 
-    if (filingPeriod === '2018') {
+    if (['2019', '2018'].includes(filingPeriod)) {
       var formData = new FormData()
       formData.append('file', file)
 
@@ -100,14 +100,17 @@ export function triggerParse(file, filingPeriod) {
         })
         .then(success => {
           let data = { transmittalSheetErrors: [], larErrors: [] }
-          success.validated.forEach(error => {
-            if (error.lineNumber === 1) {
-              data.transmittalSheetErrors.push(error.errors)
+          success.forEach(error => {
+            if (error.rowNumber === 1) {
+              data.transmittalSheetErrors.push(...error.errorMessages)
             } else {
-              data.larErrors.push({
-                error: error.errors,
-                row: error.lineNumber
-              })
+              const messages = error.errorMessages.map(emsg => ({
+                ...emsg,
+                uli: error.estimatedULI,
+                row: error.rowNumber
+              }))
+              
+              data.larErrors.push(...messages)
             }
           })
           dispatch(endParse(data))

--- a/src/tools/file-format-verification/components/FilingPeriodSelector.jsx
+++ b/src/tools/file-format-verification/components/FilingPeriodSelector.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import './FilingPeriodSelector.css'
 
-const filingPeriods = ['2018', '2017']
+const filingPeriods = ['2019', '2018', '2017']
 
 const FilingPeriodSelector = props => {
   return (

--- a/src/tools/file-format-verification/components/ParseErrors.css
+++ b/src/tools/file-format-verification/components/ParseErrors.css
@@ -25,7 +25,7 @@
 
 #parseErrors table thead th {
   font-family: SourceSansProBold;
-  text-align: center;
+  text-align: left;
 }
 
 #parseErrors table tfoot th,
@@ -41,4 +41,9 @@
 #parseErrors .table-large td,
 #parseErrors .table-large th {
   padding: 0.5rem 1rem;
+}
+
+#parseErrors table td:first-of-type {
+  text-align: right;
+  width: 1px;
 }

--- a/src/tools/file-format-verification/components/ParseErrors.jsx
+++ b/src/tools/file-format-verification/components/ParseErrors.jsx
@@ -22,8 +22,7 @@ const renderLarErrors = (larErrors, pagination) => {
 
     currentErrs.push(
       <tr key={i}>
-        <td>{err.row}</td>
-        <td>{err.error}</td>
+        {renderErrorColumns(err)}
       </tr>
     )
   }
@@ -40,7 +39,10 @@ const renderLarErrors = (larErrors, pagination) => {
       <thead>
         <tr>
           <th>Row</th>
-          <th>Errors</th>
+          <th>ULI</th>
+          <th>LAR Data Field</th>
+          <th>Found Value</th>
+          <th>Valid Value</th>
         </tr>
       </thead>
       <tbody>{currentErrs}</tbody>
@@ -62,7 +64,9 @@ const renderTSErrors = transmittalSheetErrors => {
       <thead>
         <tr>
           <th>Row</th>
-          <th>Transmittal Sheet Errors</th>
+          <th>TS Data Field</th>
+          <th>Found Value</th>
+          <th>Valid Value</th>
         </tr>
       </thead>
       <tbody>
@@ -70,7 +74,7 @@ const renderTSErrors = transmittalSheetErrors => {
           return (
             <tr key={i}>
               <td>1</td>
-              <td>{tsError}</td>
+              {renderErrorColumns(tsError)}
             </tr>
           )
         })}
@@ -103,6 +107,23 @@ const renderParseResults = (count, errors) => {
       </p>
     </Alert>
   )
+}
+
+function renderErrorColumns(err){
+  const columns = []
+  const { fieldName, inputValue, row, validValues, uli } = err
+  const userInput = inputValue === '' ? <em>(blank)</em> : inputValue
+
+  columns.push(<td key='1'>{fieldName}</td>)
+  columns.push(<td key='2'>{userInput}</td>)
+  columns.push(<td key='3'>{validValues}</td>)
+
+  if(uli) {
+    columns.unshift(<td key='4'>{uli}</td>)
+    columns.unshift(<td key='5'>{row}</td>)
+  }
+
+  return columns
 }
 
 const ParseErrors = props => {

--- a/src/tools/file-format-verification/reducers/index.js
+++ b/src/tools/file-format-verification/reducers/index.js
@@ -37,7 +37,7 @@ const defaultPagination = {
   fade: 0
 }
 
-const defaultFilingPeriod = '2018'
+const defaultFilingPeriod = '2019'
 
 //empty action logger, temporary / for debugging
 export const empty = (state = {}, action) => {


### PR DESCRIPTION
Closes #22 

## Changes
- Updates expected return format for FFVT API
- Updates UI to better align with errors shown in Filing app
- Add 2019 as a drop-down option and as the default period

## Testing
1. Manual - Multiple errors on LAR row
![lar](https://user-images.githubusercontent.com/2592907/70655718-f9db2100-1c15-11ea-91a3-04c3a46d0e8f.png)

2. Manual - TS & LAR errors
![ts-lar](https://user-images.githubusercontent.com/2592907/70655747-0790a680-1c16-11ea-96da-167cc0c6554f.png)


