### PR TITLE
Config in frontend repo

### DIFF
--- a/src/common/configUtils.js
+++ b/src/common/configUtils.js
@@ -1,6 +1,6 @@
 import { isBeta } from './Beta'
 
-const CONFIG_URL = 'https://raw.githubusercontent.com/cfpb/hmda-frontend/src/common/constants/config.json'
+const CONFIG_URL = 'https://raw.githubusercontent.com/cfpb/hmda-frontend/master/src/common/constants/config.json'
 
 export function fetchEnvConfig(setFn, host) {
   return fetch(CONFIG_URL)

--- a/src/common/configUtils.js
+++ b/src/common/configUtils.js
@@ -1,5 +1,6 @@
-import { CONFIG_URL } from './constants/config'
 import { isBeta } from './Beta'
+
+const CONFIG_URL = 'https://raw.githubusercontent.com/cfpb/hmda-frontend/src/common/constants/config.json'
 
 export function fetchEnvConfig(setFn, host) {
   return fetch(CONFIG_URL)

--- a/src/common/constants/config.js
+++ b/src/common/constants/config.js
@@ -1,8 +1,0 @@
-import { FILING_PERIODS } from '../../filing/constants/dates'
-
-export const CONFIG_URL = 'https://raw.githubusercontent.com/cfpb/hmda-platform/master/frontend/config.json'
-
-export const defaultConfig = {
-  defaultPeriod: FILING_PERIODS[0],
-  filingPeriods: FILING_PERIODS
-}

--- a/src/common/useEnvironmentConfig.jsx
+++ b/src/common/useEnvironmentConfig.jsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'react'
 import defaultConfig from './constants/config.json'
-import { fetchEnvConfig } from './configUtils'
+import { fetchEnvConfig, getEnvConfig } from './configUtils'
 
 export function useEnvironmentConfig(host) {
-  const [config, setConfig] = useState(defaultConfig)
-
+  const [config, setConfig] = useState(getEnvConfig(defaultConfig, host))
   useEffect(() => {
     fetchEnvConfig(setConfig, host).catch(() => null)
   }, [host])

--- a/src/common/useEnvironmentConfig.jsx
+++ b/src/common/useEnvironmentConfig.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { defaultConfig } from './constants/config'
+import defaultConfig from './constants/config.json'
 import { fetchEnvConfig } from './configUtils'
 
 export function useEnvironmentConfig(host) {


### PR DESCRIPTION
Closes #44 

## Changes

- Uses the `config.json` which I snuck into master instead of the smaller default made in the former `config.js`

## Testing

1. Load the homepage and note that the announcement text is immediately available.
2. Change the announcement text for dev in `config.json` to something else and reload the page.
3. Note how it will use the default but then pull in the github version when available

## Notes

For some reason we haven't really been importing json files directly, instead opting to make json-like JS files and importing those. I believe I had some performance concerns for our large json files, but that's pretty much irrelevant for this small stuff (for large files, I wanted to make sure we were shipping a json string that gets `JSON.parsed()` at runtime, because parsing JSON is considerably faster than parsing JS). Looks like create-react-app outputs on build a json string that is `JSON.parse()`d, when you use the json loader, so looks like there's no benefit to the json-hidden-in-js approach instead of just saving json files.