### PR TITLE
[Dec 31] Open and announce 2019 filing season

### DIFF
--- a/src/common/constants/config.json
+++ b/src/common/constants/config.json
@@ -4,6 +4,7 @@
     "defaultPeriod": "2019",
     "defaultDocsPeriod": "2019",
     "filingPeriods": ["2019", "2018"],
+    "show2017": true,
     "beta": {
       "announcement": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
       "defaultPeriod": "2019",

--- a/src/common/constants/config.json
+++ b/src/common/constants/config.json
@@ -4,14 +4,13 @@
     "defaultPeriod": "2019",
     "defaultDocsPeriod": "2019",
     "filingPeriods": ["2019", "2018"],
-    "show2017": true,
+    "show2017": false,
     "beta": {
       "announcement": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
       "defaultPeriod": "2019",
       "defaultDocsPeriod": "2019",
       "filingPeriods": ["2019", "2018"],
-      "show2017": true,
-      "showMaps": false
+      "show2017": false
     }
   },
   "dev": {
@@ -19,15 +18,13 @@
     "defaultPeriod": "2019",
     "defaultDocsPeriod": "2019",
     "filingPeriods": ["2019", "2018"],
-    "show2017": true,
-    "showMaps": true,
+    "show2017": false,
     "beta": {
       "announcement": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
       "defaultPeriod": "2019",
       "defaultDocsPeriod": "2019",
       "filingPeriods": ["2019", "2018"],
-      "show2017": true,
-      "showMaps": true
+      "show2017": false
     }
   }
 }

--- a/src/common/constants/config.json
+++ b/src/common/constants/config.json
@@ -1,13 +1,11 @@
 {
   "prod": {
-    "announcement": "HMDA Filing season begins Jan. 1st. See our 2019 Documentation page for filing FAQs and other useful information.",
-    "defaultPeriod": "2018",
+    "announcement": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
+    "defaultPeriod": "2019",
     "defaultDocsPeriod": "2019",
-    "filingPeriods": ["2018"],
-    "show2017": true,
-    "showMaps": false,
+    "filingPeriods": ["2019", "2018"],
     "beta": {
-      "announcement": "HMDA Filing season begins Jan. 1st. See our 2019 Documentation page for filing FAQs and other useful information.",
+      "announcement": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
       "defaultPeriod": "2019",
       "defaultDocsPeriod": "2019",
       "filingPeriods": ["2019", "2018"],
@@ -16,14 +14,14 @@
     }
   },
   "dev": {
-    "announcement": "HMDA Filing season begins Jan. 1st. See our 2019 Documentation page for filing FAQs and other useful information.",
+    "announcement": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
     "defaultPeriod": "2019",
     "defaultDocsPeriod": "2019",
     "filingPeriods": ["2019", "2018"],
     "show2017": true,
     "showMaps": true,
     "beta": {
-      "announcement": "HMDA Filing season begins Jan. 1st. See our 2019 Documentation page for filing FAQs and other useful information.",
+      "announcement": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
       "defaultPeriod": "2019",
       "defaultDocsPeriod": "2019",
       "filingPeriods": ["2019", "2018"],

--- a/src/common/constants/config.json
+++ b/src/common/constants/config.json
@@ -5,12 +5,14 @@
     "defaultDocsPeriod": "2019",
     "filingPeriods": ["2019", "2018"],
     "show2017": false,
+    "showMaps": false,
     "beta": {
       "announcement": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
       "defaultPeriod": "2019",
       "defaultDocsPeriod": "2019",
       "filingPeriods": ["2019", "2018"],
-      "show2017": false
+      "show2017": false,
+      "showMaps": false
     }
   },
   "dev": {
@@ -19,12 +21,14 @@
     "defaultDocsPeriod": "2019",
     "filingPeriods": ["2019", "2018"],
     "show2017": false,
+    "showMaps": true,
     "beta": {
       "announcement": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
       "defaultPeriod": "2019",
       "defaultDocsPeriod": "2019",
       "filingPeriods": ["2019", "2018"],
-      "show2017": false
+      "show2017": false,
+      "showMaps": true
     }
   }
 }


### PR DESCRIPTION
## Don't merge until Dec 31

Closes #50 

## Changes

- Updated Homepage announcement text
- Added 2019 as default filing period
- Added 2019 as an available filing period

## Testing

1. Comment `src/common/useEnvironmentConfig.jsx` line 8 to test locally
2. Verify that Homepage show correct message
3. Click over to Filing
4. Verify that 2019 is available and selected by default.



