### PR TITLE
add self to csp

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,7 +23,7 @@ http {
   add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
 
   # CSP
-  add_header Content-Security-Policy "default-src 'self' blob:; script-src 'self' 'unsafe-inline' blob: data: https://www.googletagmanager.com https://www.google-analytics.com; img-src 'self' blob: data: https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; frame-src https://www.youtube.com/; connect-src 'self' https://raw.githubusercontent.com https://ffiec-api.cfpb.gov https://ffiec.cfpb.gov https://*.mapbox.com https://www.google-analytics.com https://s3.amazonaws.com;";
+  add_header Content-Security-Policy "default-src 'self' blob:; script-src 'self' 'unsafe-inline' blob: data: https://www.googletagmanager.com https://www.google-analytics.com; img-src 'self' blob: data: https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; frame-src 'self' https://www.youtube.com/; connect-src 'self' https://raw.githubusercontent.com https://ffiec-api.cfpb.gov https://ffiec.cfpb.gov https://*.mapbox.com https://www.google-analytics.com https://s3.amazonaws.com;";
 
   # Prevent buffer tampering
   client_body_buffer_size  16k;


### PR DESCRIPTION
Keycloak uses frames to reauthorize its JWT, it requires 'self' in the frame-src
Closes #59
Closes #60