### PR TITLE
Pass config to all <AppContainer>

### DIFF
--- a/src/filing/index.js
+++ b/src/filing/index.js
@@ -63,12 +63,12 @@ const Filing = ({ config }) => {
             </AppContainer>
           }}/>
           <Route exact path={'/filing/:filingPeriod/:lei/'} render={props => {
-            return <AppContainer {...props}>
+            return <AppContainer {...props} config={config}>
               <SubmissionRouter/>
             </AppContainer>
           }}/>
           <Route path={'/filing/:filingPeriod/:lei/:splat'} render={props => {
-            return <AppContainer {...props}>
+            return <AppContainer {...props} config={config}>
               <SubmissionRouter/>
             </AppContainer>
           }}/>


### PR DESCRIPTION
Filing app was crashing when clicking into the Submission page due to missing config.

closes #62 