### PR TITLE
Update announcement and default documentation year

### DIFF
--- a/src/common/constants/config.json
+++ b/src/common/constants/config.json
@@ -1,23 +1,23 @@
 {
   "prod": {
-    "announcement": "On September 25th, 2019, the Bureau released the 2020 FIG and the Supplemental Guide for Quarterly Filers.",
+    "announcement": "HMDA Filing season begins Jan. 1st. See our 2019 Documentation page for filing FAQs and other useful information.",
     "defaultPeriod": "2018",
-    "defaultDocsPeriod": "2018",
+    "defaultDocsPeriod": "2019",
     "filingPeriods": ["2018"],
     "beta": {
-      "announcement": "On September 25th, 2019, the Bureau released the 2020 FIG and the Supplemental Guide for Quarterly Filers.",
+      "announcement": "HMDA Filing season begins Jan. 1st. See our 2019 Documentation page for filing FAQs and other useful information.",
       "defaultPeriod": "2019",
-      "defaultDocsPeriod": "2018",
+      "defaultDocsPeriod": "2019",
       "filingPeriods": ["2019", "2018"]
     }
   },
   "dev": {
-    "announcement": "On September 25th, 2019, the Bureau released the 2020 FIG and the Supplemental Guide for Quarterly Filers.",
+    "announcement": "HMDA Filing season begins Jan. 1st. See our 2019 Documentation page for filing FAQs and other useful information.",
     "defaultPeriod": "2019",
     "defaultDocsPeriod": "2019",
     "filingPeriods": ["2019", "2018"],
     "beta": {
-      "announcement": "On September 25th, 2019, the Bureau released the 2020 FIG and the Supplemental Guide for Quarterly Filers.",
+      "announcement": "HMDA Filing season begins Jan. 1st. See our 2019 Documentation page for filing FAQs and other useful information.",
       "defaultPeriod": "2019",
       "defaultDocsPeriod": "2019",
       "filingPeriods": ["2019", "2018"]


### PR DESCRIPTION

## Notes
This PR will be used to test updating the Env. config after tonight's initial prod-beta deployment.

Closes #58

## Changes

- Update homepage announcement
- Update Documentation's default year

## Testing

1. Prior to merging
- Homepage announcement should begin 'On September...'
- Clicking the `Documentation` link in the header should default to 2018 documentation
2. After merging
- Homepage announcement should begin 'HMDA Filing...'
- Clicking the `Documentation` link in the header should default to 2019 documentation

