### PR TITLE
Read file bytes

### DIFF
--- a/src/filing/actions/handleFile.js
+++ b/src/filing/actions/handleFile.js
@@ -8,17 +8,18 @@ import checkFileErrors from '../utils/checkFileErrors.js'
 
 export default function handleFile(file, code, error) {
   return dispatch => {
-    const fileErrors = checkFileErrors(file)
+    checkFileErrors(file, fileErrors => {
+console.log('FILE ERRORS', fileErrors)
+      if (fileErrors.length)
+        return dispatch(processFileErrors(fileErrors, file.name))
 
-    if (fileErrors.length)
-      return dispatch(processFileErrors(fileErrors, file.name))
-
-    if (code >= STATUS.UPLOADING || error) {
-      dispatch(showConfirm())
-      dispatch(selectNewFile(file))
-    } else {
-      dispatch(selectFile(file))
-      dispatch(fetchUpload(file))
-    }
+      if (code >= STATUS.UPLOADING || error) {
+        dispatch(showConfirm())
+        dispatch(selectNewFile(file))
+      } else {
+        dispatch(selectFile(file))
+        dispatch(fetchUpload(file))
+      }
+    })
   }
 }

--- a/src/filing/actions/handleFile.js
+++ b/src/filing/actions/handleFile.js
@@ -9,7 +9,7 @@ import checkFileErrors from '../utils/checkFileErrors.js'
 export default function handleFile(file, code, error) {
   return dispatch => {
     checkFileErrors(file, fileErrors => {
-console.log('FILE ERRORS', fileErrors)
+
       if (fileErrors.length)
         return dispatch(processFileErrors(fileErrors, file.name))
 

--- a/src/filing/modals/confirmationModal/container.jsx
+++ b/src/filing/modals/confirmationModal/container.jsx
@@ -34,13 +34,16 @@ export function mapDispatchToProps(dispatch, ownProps) {
   const triggerRefile = (lei, period, page = '', file) => {
     dispatch(refreshState())
     if (page === 'upload' && file) {
-      const fileErrors = checkFileErrors(file)
-      if (fileErrors.length)
-        return dispatch(processFileErrors(fileErrors, file.name))
+      console.log('MODAL')
+      checkFileErrors(file, fileErrors => {
+        console.log('FILE ERRORS MODAL', fileErrors)
+        if (fileErrors.length)
+          return dispatch(processFileErrors(fileErrors, file.name))
 
-      return dispatch(fetchNewSubmission(lei, period)).then(() => {
-        dispatch(selectFile(file))
-        dispatch(fetchUpload(file))
+        return dispatch(fetchNewSubmission(lei, period)).then(() => {
+          dispatch(selectFile(file))
+          dispatch(fetchUpload(file))
+        })
       })
     } else {
       return dispatch(fetchNewSubmission(lei, period)).then(() => {

--- a/src/filing/modals/confirmationModal/container.jsx
+++ b/src/filing/modals/confirmationModal/container.jsx
@@ -34,9 +34,7 @@ export function mapDispatchToProps(dispatch, ownProps) {
   const triggerRefile = (lei, period, page = '', file) => {
     dispatch(refreshState())
     if (page === 'upload' && file) {
-      console.log('MODAL')
       checkFileErrors(file, fileErrors => {
-        console.log('FILE ERRORS MODAL', fileErrors)
         if (fileErrors.length)
           return dispatch(processFileErrors(fileErrors, file.name))
 

--- a/src/filing/utils/checkFileErrors.js
+++ b/src/filing/utils/checkFileErrors.js
@@ -3,9 +3,7 @@ export default function checkFileErrors(file, cb) {
   const reader = new window.FileReader()
 
   reader.addEventListener('load', () => {
-    const firstBytes = reader.readAsText(fileSlice)
-    console.log(firstBytes)
-
+    const firstBytes = reader.result
     const errors = []
 
     if (file && file.size !== undefined && file.name !== undefined) {
@@ -31,4 +29,5 @@ export default function checkFileErrors(file, cb) {
 
     cb(errors)
   })
+  reader.readAsText(fileSlice)
 }

--- a/src/filing/utils/checkFileErrors.js
+++ b/src/filing/utils/checkFileErrors.js
@@ -1,23 +1,34 @@
-export default function checkFileErrors(file) {
-  const errors = []
-  if (file && file.size !== undefined && file.name !== undefined) {
-    if (file.size === 0) {
-      errors.push(
-        'The file you uploaded does not contain any data. Please check your file and re-upload.'
-      )
+export default function checkFileErrors(file, cb) {
+  const fileSlice = file.slice(0, 2)
+  const reader = new window.FileReader()
+
+  reader.addEventListener('load', () => {
+    const firstBytes = reader.readAsText(fileSlice)
+    console.log(firstBytes)
+
+    const errors = []
+
+    if (file && file.size !== undefined && file.name !== undefined) {
+      if (file.size === 0) {
+        errors.push(
+          'The file you uploaded does not contain any data. Please check your file and re-upload.'
+        )
+      }
+      if (
+        file.name
+          .split('.')
+          .slice(-1)[0]
+          .toLowerCase() !== 'txt' ||
+        firstBytes !== ('1|')
+      ) {
+        errors.push(
+          'The file you uploaded is not a text file (.txt). Please check your file and re-upload.'
+        )
+      }
+    } else {
+      errors.push('Your file was not uploaded. Please try again.')
     }
-    if (
-      file.name
-        .split('.')
-        .slice(-1)[0]
-        .toLowerCase() !== 'txt'
-    ) {
-      errors.push(
-        'The file you uploaded is not a text file (.txt). Please check your file and re-upload.'
-      )
-    }
-  } else {
-    errors.push('Your file was not uploaded. Please try again.')
-  }
-  return errors
+
+    cb(errors)
+  })
 }

--- a/src/filing/utils/checkFileErrors.js
+++ b/src/filing/utils/checkFileErrors.js
@@ -7,21 +7,19 @@ export default function checkFileErrors(file, cb) {
     const errors = []
 
     if (file && file.size !== undefined && file.name !== undefined) {
+      const notTxt = file.name.split('.').slice(-1)[0].toLowerCase() !== 'txt'
       if (file.size === 0) {
         errors.push(
           'The file you uploaded does not contain any data. Please check your file and re-upload.'
         )
       }
-      if (
-        file.name
-          .split('.')
-          .slice(-1)[0]
-          .toLowerCase() !== 'txt' ||
-        firstBytes !== ('1|')
-      ) {
+      if (notTxt) {
         errors.push(
           'The file you uploaded is not a text file (.txt). Please check your file and re-upload.'
         )
+      }
+      if(firstBytes !== ('1|') && !notTxt){
+        errors.push('Your file appears to be a text file (.txt) but has invalid content. Please ensure you are uploading a true text file and your transmittal sheet begins with 1.')
       }
     } else {
       errors.push('Your file was not uploaded. Please try again.')


### PR DESCRIPTION
Closes https://github.com/cfpb/hmda-platform-ui/issues/1249

Reads the first two bytes of the file, which (in a valid hmda file) will always be '1|'. Displays a unique error message when the file is `.txt` but this invariant is violated.