### PR TITLE
Swallow 404 when received for submissions when none exist

### DIFF
--- a/src/filing/actions/fetchLatestSubmission.js
+++ b/src/filing/actions/fetchLatestSubmission.js
@@ -12,6 +12,8 @@ export default function fetchLatestSubmission(lei, filing) {
       .then(json => {
         return hasHttpError(json).then(hasError => {
           if (!hasError) return dispatch(receiveLatestSubmission(json))
+          if (json && json.status === 404)
+            return dispatch(receiveLatestSubmission({id:{lei}}))
           if (hasError) {
             dispatch(receiveError(json))
             throw new Error(json && `${json.status}: ${json.statusText}`)

--- a/src/filing/institutions/index.jsx
+++ b/src/filing/institutions/index.jsx
@@ -89,7 +89,7 @@ const _whatToRender = ({ filings, institutions, submission, latestSubmissions })
 export default class Institutions extends Component {
   render() {
     const { error, filingPeriod, filingYears, location } = this.props
-    
+
     return (
       <main id="main-content" className="Institutions full-width">
         {error ? <ErrorWarning error={error} /> : null}


### PR DESCRIPTION
Companion to #56, fixes a display bug when a filing has no submissions