### PR TITLE
Fix 'Loading' institutions without failed network calls.

### DIFF
--- a/src/filing/actions/fetchNewFiling.js
+++ b/src/filing/actions/fetchNewFiling.js
@@ -18,7 +18,7 @@ export default function fetchNewFiling(filing) {
           }
           if (!hasError) {
             dispatch(receiveFiling(json))
-            return dispatch(receiveLatestSubmission({ lei: filing.lei }))
+            return dispatch(receiveLatestSubmission({ id: { lei: filing.lei } }))
           }
         })
       })

--- a/src/filing/reducers/latestSubmissions.js
+++ b/src/filing/reducers/latestSubmissions.js
@@ -16,6 +16,7 @@ export default (state = defaultLatestSubmissions, action) => {
       return {
         ...state,
         latestSubmissions: {
+          ...state.latestSubmissions,
           [action.lei]: {
             isFetching: true
           }


### PR DESCRIPTION
Closes #76 

- Avoid overwriting latestSubmissions in reducer when dealing with multiple institutions
- Fix action format for creating dummy submission after creating a new filing
