### PR TITLE
Filing links need ending slash

### DIFF
--- a/src/common/constants/links.js
+++ b/src/common/constants/links.js
@@ -15,7 +15,7 @@ export const defaultLinks = [
 export const updateFilingLink = (config, links) => {
   return links.map(link => {
     if(link.name !== 'Filing') return link
-    link.href = `/filing/${config.defaultPeriod}`
+    link.href = `/filing/${config.defaultPeriod}/`
     return link
   })
 }

--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -32,7 +32,7 @@ const Home = ({ config }) => {
             <header>
               <h3>
                 <a
-                  href={`/filing/${defaultPeriod}`}
+                  href={`/filing/${defaultPeriod}/`}
                   rel="noopener noreferrer"
                   target="_blank"
                 >


### PR DESCRIPTION
Without slash, logged-out users are redirected to Auth instead of Filing landing page