### PR TITLE
Replace use of Object.entries()

### DIFF
--- a/src/filing/submission/parseErrors/index.jsx
+++ b/src/filing/submission/parseErrors/index.jsx
@@ -133,9 +133,9 @@ class ParseErrors extends Component {
 function errorResponseParser(errorResponse, uliNeeded) {
   let apiErrorMessages = []
 
-  errorResponse.forEach(function(errorsFound,i) {
-    if(errorsFound && errorsFound.errorMessages) {
-      for (const [index, errorMessage] of errorsFound.errorMessages.entries()) {
+  errorResponse.forEach(function (errorsFound, i) {
+    if (errorsFound && errorsFound.errorMessages) {
+      errorsFound.errorMessages.forEach(function (errorMessage, index) {
         let inputContent = errorMessage.inputValue
 
         if (errorMessage.inputValue === '') inputContent = <em>(blank)</em>
@@ -143,15 +143,16 @@ function errorResponseParser(errorResponse, uliNeeded) {
         apiErrorMessages.push(
           <tr key={`${i}${index}`}>
             <td>{errorsFound.rowNumber}</td>
-            {uliNeeded ? <td>{errorsFound.estimatedULI}</td>:null}
+            {uliNeeded ? <td>{errorsFound.estimatedULI}</td> : null}
             <td>{errorMessage.fieldName}</td>
             <td>{inputContent}</td>
-            <td>{errorMessage.validValues}</td>
-           </tr>
+            <td> {errorMessage.validValues}</td>
+          </tr>
         )
-      }
+      })
     }
   })
+
   return apiErrorMessages
 }
 


### PR DESCRIPTION
Closes #83 

## Changes

- Remove use of `entries()` method, which is not supported by IE.

## Notes
This was a change already implemented in `hmda-platform-ui` but just got missed in the transition. 