### PR TITLE
Router cleanup and specifically render loader on submission page

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "csv-parse": "4.6.3",
     "detect-browser": "4.7.0",
+    "fast-deep-equal": "2.0.1",
     "file-saver": "2.0.2",
     "filereader-stream": "2.0.0",
     "hmda-file-parser": "1.18.0",

--- a/src/filing/modals/confirmationModal/container.jsx
+++ b/src/filing/modals/confirmationModal/container.jsx
@@ -46,7 +46,8 @@ export function mapDispatchToProps(dispatch, ownProps) {
     } else {
       return dispatch(fetchNewSubmission(lei, period)).then(() => {
         const pathname = `/filing/${period}/${lei}/upload`
-        ownProps.history.replace(pathname)
+        if(page === 'institutions') ownProps.history.push(pathname)
+        else ownProps.history.replace(pathname)
       })
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4052,7 +4052,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^2.0.1:
+fast-deep-equal@2.0.1, fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=


### PR DESCRIPTION
Closes #90 

Cleans up some router code and specifically blocks rendering router children on the submission page if the code isn't right.

Somewhat more idiomatic version of https://github.com/cfpb/hmda-frontend/pull/93 which will also prevent users from incorrectly getting to macro/submission page if they've unchecked the verification checkbox.