### PR TITLE
Tools: Set print styles to full width

### DIFF
--- a/src/tools/index.css
+++ b/src/tools/index.css
@@ -14,3 +14,15 @@
   margin: 3rem 0;
   padding-right: 75px;
 }
+
+@media print {
+  .Tools #main-content{
+    width: 100%;
+  }
+
+  .Tools #main-content .grid .item {
+    flex: 0 450px;
+    margin: 3rem 0;
+    padding-right: 75px;
+  }
+}


### PR DESCRIPTION
Closes #98 

Print preview in Chrome
<img width="508" alt="Screen Shot 2019-12-31 at 4 49 25 PM" src="https://user-images.githubusercontent.com/2592907/71636452-9c6f3a00-2bed-11ea-9314-ac3facde9900.png">


Print preview in Safari
<img width="244" alt="Screen Shot 2019-12-31 at 4 49 39 PM" src="https://user-images.githubusercontent.com/2592907/71636453-a6913880-2bed-11ea-862e-2e14ca5b3875.png">
