### PR TITLE
Add helpful links to refilewarning banner

### DIFF
--- a/src/filing/refileWarning/index.jsx
+++ b/src/filing/refileWarning/index.jsx
@@ -70,6 +70,7 @@ export const getText = props => {
       {text}
       {button}
       {periodAfter ? '.' : null}
+      <p style={{marginTop: '2px'}}>Need help? Visit our <a target="_blank" rel="noopener noreferrer" href={`/documentation/${props.match.params.filingPeriod}/`}>documentation page</a> or contact <a href="https://hmdahelp.consumerfinance.gov" target="_blank" rel="noopener noreferrer">HMDA Help</a>.</p>
     </div>
   )
 }

--- a/src/filing/refileWarning/index.jsx
+++ b/src/filing/refileWarning/index.jsx
@@ -70,7 +70,7 @@ export const getText = props => {
       {text}
       {button}
       {periodAfter ? '.' : null}
-      <p style={{marginTop: '2px'}}>Need help? Visit our <a target="_blank" rel="noopener noreferrer" href={`/documentation/${props.match.params.filingPeriod}/`}>documentation page</a> or contact <a href="https://hmdahelp.consumerfinance.gov" target="_blank" rel="noopener noreferrer">HMDA Help</a>.</p>
+      <p style={{marginTop: '15px'}}>Need help? Visit our <a target="_blank" rel="noopener noreferrer" href={`/documentation/${props.match.params.filingPeriod}/`}>documentation page</a> or contact <a href="https://hmdahelp.consumerfinance.gov" target="_blank" rel="noopener noreferrer">HMDA Help</a>.</p>
     </div>
   )
 }


### PR DESCRIPTION
## Changes

- Adds links to documentation and hmda help to the end of all refile banners:
<img width="994" alt="Screen Shot 2020-01-03 at 10 53 34 AM" src="https://user-images.githubusercontent.com/1558033/71742830-d58af280-2e17-11ea-941f-7a4f9fb30bca.png">
<img width="1000" alt="Screen Shot 2020-01-03 at 10 54 02 AM" src="https://user-images.githubusercontent.com/1558033/71742831-d58af280-2e17-11ea-9f62-4a3f5ea07796.png">