### PR TITLE
Updates LARFT text

### DIFF
--- a/src/tools/lar-formatting/AppIntro.jsx
+++ b/src/tools/lar-formatting/AppIntro.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import Heading from '../../common/Heading.jsx'
 
 const AppIntro = () => {
@@ -13,21 +14,10 @@ const AppIntro = () => {
     >
       <React.Fragment>
         <p>
-          Filers will not need to use the LAR Formatting Tool if they are able
-          to format their HMDA data into a pipe delimited text file by using,
-          for example, vendor HMDA software, the financial institution’s current
-          Loan Origination Software (LOS), or applications such as Microsoft®
-          Access® or Excel® that may be used for data entry and formatting.
+          The HMDA LAR formatting tool is a Microsoft® Excel® workbook created by the Bureau for HMDA filers, who do not have another means of doing so, to enter and format data into a pipe delimited text file. A pipe delimited text file is the required format beginning for data collected in 2017 for financial institutions to file their loan/application register (LAR) using the HMDA Platform.
         </p>
         <p>
-          Please review Section 2 of the{' '}
-          <a
-            href="https://s3.amazonaws.com/cfpb-hmda-public/prod/tools/HMDA-Tools-Instructions.pdf"
-            download={true}
-          >
-            HMDA Tools Instructions
-          </a>{' '}
-          guide prior to downloading the tool.
+          Follow the <Link to="/documentation/2019/tools/lar-formatting/">LAR Formatting Tool instructions</Link> to format your data into a pipe delimited text file.
         </p>
       </React.Fragment>
     </Heading>,


### PR DESCRIPTION
Closes #149 

Currently the link to the larft documentation is speculative and 404s (since it still needs to be created in #137).