### PR TITLE
Enable download of mLAR with header row

### DIFF
--- a/src/data-publication/reports/Results.css
+++ b/src/data-publication/reports/Results.css
@@ -23,6 +23,5 @@
 }
 
 .Results p {
-  color: $color-gray;
   margin: 0;
 }

--- a/src/data-publication/reports/Results.jsx
+++ b/src/data-publication/reports/Results.jsx
@@ -97,10 +97,9 @@ class Results extends React.Component {
           }
         : { title: 'LEI', id: institution.lei }
 
-    const headeredFile =
-      !this.is2017() && this.state.withHeader
-        ? { dir: 'header/', fname: '_header' }
-        : { dir: '', fname: '' }
+    const headeredFile = this.state.withHeader
+      ? { dir: 'header/', fname: '_header' }
+      : { dir: '', fname: '' }
 
     const href = `https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/${this.props.year}/${headeredFile.dir}${normalizedInstitution.id}${headeredFile.fname}.txt`
     return (
@@ -135,8 +134,6 @@ class Results extends React.Component {
   }
 
   renderIncludeFileHeader() {
-    if (this.is2017()) return null
-
     return (
       <p>
         Include File Header{' '}

--- a/src/data-publication/reports/Results.jsx
+++ b/src/data-publication/reports/Results.jsx
@@ -3,7 +3,8 @@ import React from 'react'
 import './Results.css'
 
 const defaultState = {
-  showAll: false
+  showAll: false,
+  withHeader: false,
 }
 
 const DEFAULT_NUMBER_OF_INSTITUTIONS = 10
@@ -89,15 +90,19 @@ class Results extends React.Component {
 
   makeListItem(institution, index) {
     const normalizedInstitution =
-      this.props.year === '2017'
+      this.is2017()
         ? {
             title: 'Institution ID',
             id: institution.institutionId
           }
         : { title: 'LEI', id: institution.lei }
-    const href = `https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/${
-      this.props.year
-    }/${normalizedInstitution.id}.txt`
+
+    const headeredFile =
+      !this.is2017() && this.state.withHeader
+        ? { dir: 'header/', fname: '_header' }
+        : { dir: '', fname: '' }
+
+    const href = `https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/${this.props.year}/${headeredFile.dir}${normalizedInstitution.id}${headeredFile.fname}.txt`
     return (
       <li key={index}>
         <h4>{institution.name}</h4>
@@ -105,7 +110,7 @@ class Results extends React.Component {
           {normalizedInstitution.title}: {normalizedInstitution.id}
         </p>
         <a className="font-small" href={href} download>
-          Download Modified LAR
+          {`Download Modified LAR ${this.state.withHeader ? 'with Header' : ''}`}
         </a>
       </li>
     )
@@ -121,7 +126,29 @@ class Results extends React.Component {
     if (nextProps.inputValue !== this.props.inputValue) return true
     if (nextProps.year !== this.props.year) return true
     if (nextState.showAll !== this.state.showAll) return true
+    if (nextState.withHeader !== this.state.withHeader) return true
     return false
+  }
+
+  is2017() {
+    return this.props.year === '2017'
+  }
+
+  renderIncludeFileHeader() {
+    if (this.is2017()) return null
+
+    return (
+      <p>
+        Include File Header{' '}
+        <input
+          type='checkbox'
+          name='inclHeader'
+          id='inclHeader'
+          value={this.state.withHeader}
+          onChange={e => this.setState({ withHeader: e.target.checked })}
+        />
+      </p>
+    )
   }
 
   render() {
@@ -141,6 +168,7 @@ class Results extends React.Component {
 
     return (
       <React.Fragment>
+        {this.renderIncludeFileHeader()}
         {this.renderHeading(
           this.props.institutions.length,
           this.props.inputValue

--- a/src/data-publication/reports/SearchList.css
+++ b/src/data-publication/reports/SearchList.css
@@ -17,6 +17,8 @@
   max-width: 46rem;
 }
 
-.SearchList input[disabled] {
-  background-color: $color-gray-lightest;
+.SearchList #inclHeader {
+  display: inline-block;
+  margin-left: 5px;
+  width: 20px;
 }


### PR DESCRIPTION
Closes #167 

- S3 files have been updated as required
- Latest commit enables download for 2017 as well

## Changes
- Added checkbox for inclusion of header row (2017 & 2018)
- Removed orphaned Sass variable references

## Screenshots
![mlar-with-header](https://user-images.githubusercontent.com/2592907/72914365-d2d73b00-3cfb-11ea-9bfd-74151ac2e721.gif)


