### PR TITLE
Remove method not supported by IE

### DIFF
--- a/src/tools/file-format-verification/actions/index.js
+++ b/src/tools/file-format-verification/actions/index.js
@@ -78,7 +78,7 @@ export function triggerParse(file, filingPeriod) {
         .catch(err => console.error(err))
     }
 
-    if (['2019', '2018'].includes(filingPeriod)) {
+    if (['2019', '2018'].indexOf(filingPeriod) > -1) {
       var formData = new FormData()
       formData.append('file', file)
 


### PR DESCRIPTION
Closes #199 

Used `includes` which is not supported by IE.

