### PR TITLE
Update beta configs with new filing dates

### DIFF
--- a/src/common/constants/config.json
+++ b/src/common/constants/config.json
@@ -20,6 +20,8 @@
       "defaultPeriod": "2019",
       "defaultDocsPeriod": "2019",
       "filingPeriods": ["2019", "2018"],
+      "filingQuarters": { "Q1": "01/01 - 05/30", "Q2": "07/01 - 08/29", "Q3": "10/01 - 11/29" },
+      "filingQuartersLate": { "Q1": "05/31 - 06/30", "Q2": "08/30 - 09/30", "Q3": "11/30 - 12/31" },
       "showMaps": false,
       "maintenanceMode": false,
       "filingAnnouncement": null
@@ -33,7 +35,9 @@
     },
     "defaultPeriod": "2019",
     "defaultDocsPeriod": "2019",
-    "filingPeriods": ["2019", "2018"],
+    "filingPeriods": ["2020-Q1",  "2019", "2018"],
+    "filingQuarters": { "Q1": "01/01 - 05/30", "Q2": "07/01 - 08/29", "Q3": "10/01 - 11/29" },
+    "filingQuartersLate": { "Q1": "05/31 - 06/30", "Q2": "08/30 - 09/30", "Q3": "11/30 - 12/31" },
     "showMaps": true,
     "maintenanceMode": false,
     "filingAnnouncement": null,
@@ -47,8 +51,9 @@
       "defaultDocsPeriod": "2019",
       "maintenanceMode": false,
       "filingAnnouncement": null,
-      "filingPeriods": ["2020-Q1", "2020-Q2", "2020-Q3", "2019", "2018"],
-      "filingQuarters": { "Q1": "01/01 - 06/30", "Q2": "01/01 - 09/30", "Q3": "01/01 - 12/31" },
+      "filingPeriods": ["2020-Q1", "2019", "2018"],
+      "filingQuarters": { "Q1": "01/01 - 05/30", "Q2": "07/01 - 08/29", "Q3": "10/01 - 11/29" },
+      "filingQuartersLate": { "Q1": "05/31 - 06/30", "Q2": "08/30 - 09/30", "Q3": "11/30 - 12/31" },
       "showMaps": true
     }
   }

--- a/src/common/constants/config.json
+++ b/src/common/constants/config.json
@@ -20,8 +20,6 @@
       "defaultPeriod": "2019",
       "defaultDocsPeriod": "2019",
       "filingPeriods": ["2019", "2018"],
-      "filingQuarters": { "Q1": "01/01 - 05/30", "Q2": "07/01 - 08/29", "Q3": "10/01 - 11/29" },
-      "filingQuartersLate": { "Q1": "05/31 - 06/30", "Q2": "08/30 - 09/30", "Q3": "11/30 - 12/31" },
       "showMaps": false,
       "maintenanceMode": false,
       "filingAnnouncement": null


### PR DESCRIPTION
Closes #203 

Add configuration for testing of Quarterly filing in Beta environments.  

- Creates the `filingQuartersLate` entries (Late Quarterly filing dates)
- Updates `filingQuarters` dates to only include the "timely" filing dates.

Note: This will not open any new filingPeriods in `prod` or `prod-beta`, it simply sets up some supporting information ahead of time.  And is needed to continue testing in `dev-beta`...