### PR TITLE
Depend on node 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.16.0-alpine as build-stage
+FROM node:12.14.1-alpine3.11 as build-stage
 WORKDIR /usr/src/app
 
 # install build dependencies

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Collection of HMDA frontend apps",
   "main": "./src/index.js",
   "engines": {
-    "node": ">=8.x"
+    "node": ">=12.x"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Node v8 has been EOL'd, so this switches us to the latest LTS version of node