### PR TITLE
Handle buggy browsers without webgl support

### DIFF
--- a/src/data-browser/charts/MapContainer.jsx
+++ b/src/data-browser/charts/MapContainer.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef }  from 'react'
 import Select from 'react-select'
 import LoadingButton from '../geo/LoadingButton.jsx'
+import Alert from '../../common/Alert.jsx'
 import COUNTS from '../constants/countyCounts.js'
 import COUNTIES from '../constants/counties.js'
 import VARIABLES from '../constants/variables.js'
@@ -237,12 +238,20 @@ const MapContainer = props => {
 
   useEffect(() => {
     if(!data) return
-    const map = new mapbox.Map({
-      container: mapContainer.current,
-      style: 'mapbox://styles/mapbox/light-v10',
-      zoom: 3.5,
-      center: [-96, 38]
-    })
+    let map
+
+    try {
+      map = new mapbox.Map({
+        container: mapContainer.current,
+        style: 'mapbox://styles/mapbox/light-v10',
+        zoom: 3.5,
+        center: [-96, 38]
+      })
+    } catch (e){
+      setMap(false)
+      return
+    }
+
     const stops = makeStops(data, selectedVariable, selectedValue)
 
     setMap(map)
@@ -380,7 +389,14 @@ const MapContainer = props => {
         options={getValuesForVariable(selectedVariable)}
       />
       <h3>{selectedVariable && selectedValue ? `${selectedVariable.label}: "${selectedValue.label}" for US Counties`: 'US Counties'}</h3>
-      <div className="mapContainer" ref={mapContainer}/>
+      <div className="mapContainer" ref={mapContainer}>
+        {map === false
+          ? <Alert type="error">
+              <p>Your browser does not support WebGL, which is needed to run this application.</p>
+            </Alert>
+          : null
+        }
+      </div>
       {data && selectedVariable && fips ? buildTable() : null}
     </div>
   )


### PR DESCRIPTION
Closes #251 

If a browser doesn't support WebGL, we can't do anything other than inform the user. This does so via a handy error message if the map fails to initialize.

<img width="1088" alt="Screen Shot 2020-02-27 at 12 06 10 PM" src="https://user-images.githubusercontent.com/1558033/75482577-f2483000-5959-11ea-929c-a92720f1896a.png">
