### PR TITLE
Update announcement, filing season is not open

### DIFF
--- a/src/common/constants/config.json
+++ b/src/common/constants/config.json
@@ -1,7 +1,7 @@
 {
   "prod": {
     "announcement": {
-      "message": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
+      "message": "Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
       "type": "info",
       "heading": "Announcement"
     },
@@ -13,7 +13,7 @@
     "filingAnnouncement": null,
     "beta": {
       "announcement": {
-        "message": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
+        "message": "Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
         "type": "info",
         "heading": "Announcement"
       },
@@ -29,7 +29,7 @@
   },
   "dev": {
     "announcement": {
-      "message": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
+      "message": "Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
       "type": "info",
       "heading": "Announcement"
     },
@@ -43,7 +43,7 @@
     "filingAnnouncement": null,
     "beta": {
       "announcement": {
-        "message": "The filing period is open. Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
+        "message": "Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
         "type": "info",
         "heading": "Announcement"
       },


### PR DESCRIPTION
## Changes

- Remove "Filing season is open." from homepage announcement.

<img width="806" alt="Screen Shot 2020-03-03 at 7 55 13 AM" src="https://user-images.githubusercontent.com/2592907/75787720-59802e80-5d24-11ea-933a-f9a814b89051.png">

