### PR TITLE
Change the faq link to be an in-app link rather than an anchor

### DIFF
--- a/src/data-browser/Home.jsx
+++ b/src/data-browser/Home.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { Link } from 'react-router-dom'
 import ImageCard from './ImageCard.jsx'
 import Heading from '../common/Heading.jsx'
 import { withAppContext } from '../common/appContextHOC'
@@ -13,7 +14,7 @@ class Home extends Component {
         <div className="intro">
           <Heading type={1} headingText="HMDA Data Browser">
             <p className="lead">The HMDA Data Browser allows users to filter, analyze, and download HMDA datasets and visualize data through charts, graphs, and maps.</p>
-            <p className="lead">For questions about the HMDA Data Browser, visit our <a target="_blank" rel="noopener noreferrer" href="/documentation/2018/data-browser-faq/">FAQ page</a>.</p>
+            <p className="lead">For questions about the HMDA Data Browser, visit our <Link to="/documentation/2018/data-browser-faq/">FAQ page</Link>.</p>
           </Heading>
         </div>
 


### PR DESCRIPTION
Assists with #277, but the real fix there is in Kubernetes.

We should prefer in-app `Link`s where they make sense, since they are lower overhead once the user has already loaded the main bundle.