### PR TITLE
Maintenance Message bottom banner

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,7 +43,7 @@ const App = () => {
         <Route path = "/filing" component={Filing} />
         <Route component={NotFound} />
       </Switch>
-      {isFiling ? null : <Footer />}
+      {isFiling ? null : <Footer config={config} />}
     </AppContext.Provider>
   )
 }

--- a/src/MaintenanceMessage.css
+++ b/src/MaintenanceMessage.css
@@ -1,0 +1,82 @@
+#maintenance-message {
+  position: fixed;
+  display: flex;
+  flex-flow: row nowrap;
+  width: 100%;
+  line-height: 20px;
+  bottom: 0;
+  left:0;
+  color: black;
+  padding: 2rem;
+  align-items: center;
+  justify-content: center;
+  border-top: 2px solid black;
+  animation: 1s ease-in-out 1s slideUp;
+  animation-fill-mode: forwards;
+  opacity: 0;
+}
+
+#maintenance-message .closer {
+  line-height: 20px;
+  display: none;
+  margin: 0;
+}
+
+#maintenance-message p {
+  margin: 0;
+}
+
+#maintenance-message .closer button {
+  margin: 0;
+  margin-right: 1rem;
+  padding: .5rem 1rem;
+}
+
+#maintenance-message.success {
+  background-color: #e7f4e4;
+  border-color: #2e8540;
+}
+
+#maintenance-message.warning {
+  background-color: #fff1d2;
+  border-color: #fff1d2;
+}
+
+#maintenance-message.error {
+  background-color: #f9dede;
+  border-color: #e31c3d;
+}
+
+#maintenance-message.closed {
+  animation: 1s ease-in-out slideDown;
+  animation-fill-mode: forwards;
+}
+
+@keyframes slideUp {
+    0% {
+        transform: translateY(100%);
+        opacity: 0;
+    }
+    100% {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+@keyframes slideDown {
+    0% {
+        transform: translateY(0);
+        opacity: 1;
+    }
+    100% {
+        transform: translateY(100%);
+        opacity: 0;
+    }
+}
+
+/* Only allow dismissal of message banner on mobile */
+@media screen and (max-width: 768px) {
+  #maintenance-message .closer {
+    display: inline-block;
+  }
+}

--- a/src/MaintenanceMessage.jsx
+++ b/src/MaintenanceMessage.jsx
@@ -1,0 +1,29 @@
+import React, { useState } from "react"
+import './MaintenanceMessage.css'
+
+const MaintenanceMessage = ({ config, closeCallback }) => {
+  const { announcement, maintenanceMode } = config
+  const [isOpen, setIsOpen] = useState(config.maintenanceMode)
+  const cname = announcement.type + (!isOpen ? " closed" : "")
+
+  if(!maintenanceMode) return null
+
+  const closeHandler = e => {
+    e.preventDefault()
+    setIsOpen(false)
+    if(closeCallback) closeCallback()
+  }
+
+  return (
+    <div id="maintenance-message" className={cname}>
+      <p className="closer">
+        <button title="Dismiss" onClick={closeHandler}>
+          x
+        </button>
+      </p>
+      <p>{announcement.message}</p>
+    </div>
+  )
+}
+
+export default MaintenanceMessage

--- a/src/common/Footer.css
+++ b/src/common/Footer.css
@@ -50,6 +50,10 @@
   margin-bottom: 0;
 }
 
+.Footer.maintenance .content-wrapper {
+  padding-bottom: 5rem;
+}
+
 .return-to-top {
   margin: 0 auto 1em;
   max-width: 1040px;

--- a/src/common/Footer.jsx
+++ b/src/common/Footer.jsx
@@ -1,11 +1,20 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import './Footer.css'
 import logo from './images/ffiec-logo.svg'
+import MaintenanceMessage from '../MaintenanceMessage'
 
-const Footer = () => {
+const Footer = ({ config }) => {
+  const [maintenance, setMaintenance] = React.useState(null)
+
+  useEffect(() => {
+    if(config.maintenanceMode) setMaintenance(true)
+  }, [config])
+
+  const cname = "Footer" + (maintenance ? " maintenance" : "")
+
   return (
-    <footer className="Footer" role="contentinfo">
+    <footer className={cname} role="contentinfo">
       <div className="return-to-top">
         <button className="button-link" onClick={e=> {
           e.preventDefault()
@@ -46,6 +55,10 @@ const Footer = () => {
           </div>
         </div>
       </div>
+      <MaintenanceMessage 
+        config={config}
+        closeCallback={() => setMaintenance(false)} 
+      />
     </footer>
   )
 }

--- a/src/filing/App.jsx
+++ b/src/filing/App.jsx
@@ -99,7 +99,7 @@ export class AppContainer extends Component {
   }
 
   render() {
-    const { match: { params }, location, config: { filingAnnouncement } } = this.props
+    const { match: { params }, location, config: { filingAnnouncement, maintenanceMode } } = this.props
     const validFilingPeriod = this.isValidPeriod(params.filingPeriod)
 
     return (
@@ -117,7 +117,7 @@ export class AppContainer extends Component {
             ? <p className="full-width">Files are no longer being accepted for the 2017 filing period. For further assistance, please contact <a href="mailto:hmdahelp@cfpb.gov">HMDA Help</a>.</p>
             : <p className="full-width">The {params.filingPeriod} filing period does not exist. If this seems wrong please contact <a href="mailto:hmdahelp@cfpb.gov">HMDA Help</a>.</p>
         }
-        <Footer filingPeriod={params.filingPeriod}/>
+        <Footer filingPeriod={params.filingPeriod} maintenanceMode={maintenanceMode} />
       </div>
     )
   }

--- a/src/filing/common/Footer.css
+++ b/src/filing/common/Footer.css
@@ -37,7 +37,7 @@
 
 
 .Filing.App footer.maintenance {
-  padding-bottom: 7rem;
+  padding-bottom: 6.5rem;
 }
 
 @media screen and (max-width: 679px) {

--- a/src/filing/common/Footer.css
+++ b/src/filing/common/Footer.css
@@ -35,6 +35,11 @@
   margin-bottom: 1em;
 }
 
+
+.Filing.App footer.maintenance {
+  padding-bottom: 7rem;
+}
+
 @media screen and (max-width: 679px) {
   .Filing .Footer .nav-link > span {
     display: none;

--- a/src/filing/common/Footer.jsx
+++ b/src/filing/common/Footer.jsx
@@ -10,8 +10,10 @@ export const getLink = filingPeriod => {
 }
 
 const Footer = props => {
+  const cname = "Footer footer footer-slim" + (props.maintenanceMode ? " maintenance" : "")
+
   return (
-    <footer className="Footer footer footer-slim" role="contentinfo">
+    <footer className={cname} role="contentinfo">
       <div className="full-width">
         <button className="return-to-top button-link" onClick={e => {
           e.preventDefault()

--- a/src/filing/home/Home.css
+++ b/src/filing/home/Home.css
@@ -67,3 +67,7 @@
   pointer-events: visible;
   cursor: not-allowed;
 }
+
+#main-content.maintenance {
+  margin-bottom: 7rem;
+}

--- a/src/filing/home/index.jsx
+++ b/src/filing/home/index.jsx
@@ -7,9 +7,10 @@ import './Home.css'
 const Home = props => {
   const buttonTitle = props.maintenanceMode ? 'Unavailable during maintenance' : undefined
   const buttonsDisabled = !!props.maintenanceMode
+  const cname = "FilingHome" + (props.maintenanceMode ? " maintenance" : "")
 
   return (
-    <main className="FilingHome" id="main-content">
+    <main className={cname} id="main-content">
       <section className="hero">
         <div className="full-width">
           {!!props.maintenanceMode && (

--- a/src/filing/index.js
+++ b/src/filing/index.js
@@ -15,6 +15,7 @@ import { setKeycloak } from './utils/keycloak.js'
 import { setStore } from './utils/store.js'
 import appReducer from './reducers'
 import { withAppContext } from '../common/appContextHOC'
+import MaintenanceMessage from '../MaintenanceMessage'
 
 const middleware = [thunkMiddleware]
 
@@ -74,6 +75,7 @@ const Filing = ({ config }) => {
           }}/>
         </Switch>
       </Provider>
+      <MaintenanceMessage config={config} />
     </div>
   )
 }


### PR DESCRIPTION
Closes #263 

## Changes
- Adds a persistent Maintenance message banner to the bottom of pages when `maintenanceMode` is enabled.
- Banner is only dismissible on mobile devices (per team feedback). 
- Banner reflects the same maintenance message used for the homepage/filing app 

## Testing

1. Set `maintenanceMode: true` in config.json for the `dev` environment
2. Maintenance banner will reflect the announcement message and be colored to match the announcement type.

## Screenshots

## Mobile
<img width="429" alt="Screen Shot 2020-03-17 at 1 26 14 PM" src="https://user-images.githubusercontent.com/2592907/77013579-eb4b8680-6935-11ea-8454-d9e3ed4a60cb.png">

## Desktop
<img width="1064" alt="Screen Shot 2020-03-17 at 1 26 58 PM" src="https://user-images.githubusercontent.com/2592907/77013855-96f4d680-6936-11ea-8062-894064a70328.png">

