### PR TITLE
Open 2020 annual in dev-beta

### DIFF
--- a/src/common/constants/config.json
+++ b/src/common/constants/config.json
@@ -1,10 +1,10 @@
 {
   "prod": {
     "announcement": {
-        "message": "Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
-        "type": "info",
-        "heading": "Announcement"
-      },
+      "message": "Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
+      "type": "info",
+      "heading": "Announcement"
+    },
     "defaultPeriod": "2019",
     "defaultDocsPeriod": "2019",
     "filingPeriods": ["2019", "2018"],
@@ -31,13 +31,13 @@
   },
   "dev": {
     "announcement": {
-        "message": "Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
-        "type": "info",
-        "heading": "Announcement"
-      },
+      "message": "Submissions of 2019 HMDA data will be considered timely if received on or before Monday, March 2, 2020.",
+      "type": "info",
+      "heading": "Announcement"
+    },
     "defaultPeriod": "2019",
     "defaultDocsPeriod": "2019",
-    "filingPeriods": ["2020-Q1","2019", "2018"],
+    "filingPeriods": ["2020-Q1", "2019", "2018"],
     "filingQuarters": { "Q1": "01/01 - 05/30", "Q2": "07/01 - 08/29", "Q3": "10/01 - 11/29", "ANNUAL": "01/01 - 03/02" },
     "filingQuartersLate": { "Q1": "05/31 - 06/30", "Q2": "08/30 - 09/30", "Q3": "11/30 - 12/31" },
     "showMaps": true,
@@ -53,7 +53,7 @@
       "defaultDocsPeriod": "2019",
       "maintenanceMode": false,
       "filingAnnouncement": null,
-      "filingPeriods": ["2020-Q1", "2019", "2018"],
+      "filingPeriods": ["2020-Q1", "2020", "2019", "2018"],
       "filingQuarters": { "Q1": "01/01 - 05/30", "Q2": "07/01 - 08/29", "Q3": "10/01 - 11/29", "ANNUAL": "01/01 - 03/02" },
       "filingQuartersLate": { "Q1": "05/31 - 06/30", "Q2": "08/30 - 09/30", "Q3": "11/30 - 12/31" },
       "showMaps": true


### PR DESCRIPTION
Closes #307 

Some small formatting changes.

Only material change is adding "2020" to the `dev-beta` config. 