### PR TITLE
TS vs LAR headers + S303 Highlighting

### DIFF
--- a/src/filing/submission/edits/Table.css
+++ b/src/filing/submission/edits/Table.css
@@ -53,7 +53,13 @@
   margin-bottom: 0;
 }
 
-// hightlight Q666 for PII
+.EditsTable span.mismatch {
+  font-weight: bold;
+  font-size: 1.75rem;
+  color: #e31c3d;
+}
+
+/* hightlight Q666 for PII */
 #Q666 caption,
 #Q666 .caption {
   background-color: #fff1d2;

--- a/src/filing/submission/edits/Table.jsx
+++ b/src/filing/submission/edits/Table.jsx
@@ -6,8 +6,9 @@ import EditsTableRow from './TableRow.jsx'
 
 import './Table.css'
 
-export const formatHeader = text => {
+export const formatHeader = (text, isTransmittal) => {
   if (text === 'value' || text === 'fields') return null
+  if (text === 'id' && isTransmittal) return 'Legal Entity Identifier (LEI)'
   if (text === 'id') return 'Universal Loan Identifier (ULI)'
   if (text === 'edit') return 'Edit ID'
   if (text === 'editId') return 'Edit ID'
@@ -15,7 +16,7 @@ export const formatHeader = text => {
   return text
 }
 
-export const renderHeader = (edits, rows, type) => {
+export const renderHeader = (edit, rows, type) => {
   let cellCount = 0
   const cells = []
 
@@ -24,9 +25,10 @@ export const renderHeader = (edits, rows, type) => {
   const numOfCells = fieldCells + 1
   const cellWidth = `${100 / numOfCells}%`
 
-  Object.keys(keyCells).forEach(field => {
-    const text = formatHeader(field)
+  Object.keys(keyCells).forEach((field, index) => {
+    if(edit.edit === 'S303' && index === 0) return
 
+    const text = formatHeader(field, edit.transmittalSheet)
     if (text) {
       cells.push(
         <th key={++cellCount} width={cellWidth}>
@@ -49,7 +51,7 @@ export const renderHeader = (edits, rows, type) => {
 
 export const renderBody = (edits, rows, type) => {
   return rows.map((row, i) => {
-    return <EditsTableRow row={row} key={i} />
+    return <EditsTableRow row={row} key={i} edit={edits} />
   })
 }
 

--- a/src/filing/submission/edits/TableRow.jsx
+++ b/src/filing/submission/edits/TableRow.jsx
@@ -3,17 +3,50 @@ import PropTypes from 'prop-types'
 
 import EditsTableCell from './TableCell.jsx'
 
+/* Clearly differentiate erroneous "Provided" values */
+export function highlightMismatch(value){
+  if(!value || value.indexOf("Provided") < 0) return value
+
+  let [provided, expected] = value.split(",").map(v => {
+    const [label, val] = v.split(":")
+    return { label, value: val }
+  })
+
+  if(provided.value !== expected.value)
+    return (
+      <>
+        <span className="mismatch">
+          {provided.label}: {provided.value}
+        </span>
+        , {expected.label}: {expected.value}
+      </>
+    )
+  
+  return value
+}
+
 const EditsTableRow = props => {
   if (!props.row) return null
 
   const cells = []
   let cellCount = 0
+  const isS303 = props.edit.edit === 'S303'
 
-  if(props.edit.edit !== 'S303') 
+  if(!isS303) 
     cells.push(<EditsTableCell key={++cellCount} cell={props.row.id} />)
 
   props.row.fields.forEach(field => {
-    cells.push(<EditsTableCell key={++cellCount} cell={field.value} cellName={field.name} />)
+    let cellValue = isS303
+      ? highlightMismatch(field && field.value)
+      : field.value
+      
+    cells.push(
+      <EditsTableCell
+        key={++cellCount}
+        cell={cellValue}
+        cellName={field.name}
+      />
+    )
   })
 
   return <tr>{cells}</tr>

--- a/src/filing/submission/edits/TableRow.jsx
+++ b/src/filing/submission/edits/TableRow.jsx
@@ -9,7 +9,8 @@ const EditsTableRow = props => {
   const cells = []
   let cellCount = 0
 
-  cells.push(<EditsTableCell key={++cellCount} cell={props.row.id} />)
+  if(props.edit.edit !== 'S303') 
+    cells.push(<EditsTableCell key={++cellCount} cell={props.row.id} />)
 
   props.row.fields.forEach(field => {
     cells.push(<EditsTableCell key={++cellCount} cell={field.value} cellName={field.name} />)


### PR DESCRIPTION
Closes #262
Closes #291

# Changes
- Displays appropriate column label for Edit row identifiers (LEI for TS, ULI for LAR)
- Highlights the "Provided" value when it does not match the expected value (S303 only)
- Removes the row identifier column for S303 (previously ULI, but should be LEI since it is a TS edit) because there is another column labeled LEI, used to show the Provided/Expected values.

# Screenshots

## Before Shot
<img width="987" alt="Screen Shot 2020-03-20 at 2 01 06 PM" src="https://user-images.githubusercontent.com/2592907/77202599-45725600-6ab4-11ea-9210-19e0050f4270.png">

## After Shot
**S303**: Special case that suppresses the row identifier, highlights Prov./Exp. mismatch
**V602**: TS Edit with row identifier "Legal Entity Identifier"
**V619-3**: LAR Edit with row identifier "Universal Loan Identifier"
<br>
<img width="991" alt="Screen Shot 2020-03-20 at 2 00 41 PM" src="https://user-images.githubusercontent.com/2592907/77202616-4c996400-6ab4-11ea-84a6-33e396e1d0a4.png">

