### PR TITLE
[Filing] Fix Filing Period dropdown in IE

### DIFF
--- a/src/filing/institutions/InstitutionPeriodSelector.jsx
+++ b/src/filing/institutions/InstitutionPeriodSelector.jsx
@@ -77,7 +77,10 @@ function yearOptions(filingPeriods, hasQFilers) {
     if (quarter && !hasQFilers) return
     yearSet.add(year)
   })
-  return Array.from(yearSet).sort((a,b) => b - a).map(periodOption)
+  
+  const yearArray = []
+  yearSet.forEach(el => yearArray.push(el))
+  return yearArray.sort((a,b) => b - a).map(periodOption)
 }
 
 


### PR DESCRIPTION
Closes #313 

Replaces `Array.from` when generating Filing Period options.

Strange that there was no error throw in IE to indicate that this unsupported method was the issue.  I see two other instances of `Array.from` in Data Publication but will open a separate ticket to address their replacement. 