### PR TITLE
Enable yarn install to resolve @cypress/skip-test

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,7 +1618,7 @@
     date-fns "^1.27.2"
     figures "^1.7.0"
 
-"@cypress/skip-test@^2.5.0":
+"@cypress/skip-test@2.5.0":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@cypress/skip-test/-/skip-test-2.5.0.tgz#ba3fc8c441a9dda5fa410e783006107ff3b9d050"
   integrity sha512-OqyToxRLUG/EAfZa0w8sAooOW6tr8pYCBpo3SLsKycrV2RTj9Sy7rB+5U0MvES87kWCHtO10qMIESuw8RiEYyQ==


### PR DESCRIPTION
Closes #319 

Re-added the dependency using `yarn add <package>@<version>`, like I was supposed to do from the beginning, and was able to complete the build.  Hopefully this eliminates the glitch for good. 