### PR TITLE
Remove Edit description quotes

### DIFF
--- a/src/filing/submission/edits/Table.jsx
+++ b/src/filing/submission/edits/Table.jsx
@@ -76,7 +76,7 @@ export const renderTableCaption = props => {
     captionHeader = 'Review your loan/application IDs'
   }
 
-  const description = props.edit.description
+  const description = props.edit.description.replace(/"/g, "")
 
   if (shouldSuppressTable(props)) {
     return (


### PR DESCRIPTION
Closes #317 

As part of changes to fix CSV parsing on the Platform, quotes were added around the Edit description field.

<img width="343" alt="edit-quotes" src="https://user-images.githubusercontent.com/2592907/77466959-b70e1500-6dd0-11ea-9005-65df330cd6fa.png">

This removes them.  

Verified with the team that quotations marks are not part of the Edit description, other than those added during this parsing fix, so the global replace on that string should be safe. 