### PR TITLE
Publish Modified LAR 2019

### DIFF
--- a/src/data-publication/constants/years.js
+++ b/src/data-publication/constants/years.js
@@ -1,1 +1,1 @@
-export default ['2018', '2017']
+export default ['2019', '2018', '2017']

--- a/src/data-publication/reports/SearchList.jsx
+++ b/src/data-publication/reports/SearchList.jsx
@@ -4,7 +4,7 @@ import LoadingIcon from '../../common/LoadingIcon.jsx'
 
 import './SearchList.css'
 
-let INSTITUTIONS = { 2017: null, 2018: null }
+let INSTITUTIONS = { 2017: null, 2018: null, 2019: null }
 
 class SearchList extends React.Component {
   constructor(props) {


### PR DESCRIPTION
Closes #293 

- Adds 2019 to Year selection
- Adds 2019 to list of years to fetch data for

![mlar2019](https://user-images.githubusercontent.com/2592907/77569757-4c241300-6e90-11ea-9707-716e353f2e33.gif)

## Testing
There's no indication of the year in the file name or in the content as far as I can tell.  So you can just inspect the 'Download Modified LAR' link to validate that it's pulling from the `/modified-lar/2019` bucket when `2019` is selected. 
