### PR TITLE
Center narrow tables

### DIFF
--- a/src/data-publication/reports/Report.css
+++ b/src/data-publication/reports/Report.css
@@ -56,3 +56,8 @@
 .Report .table-large th {
   padding: 0.5rem 1rem;
 }
+
+.Report .narrowTable {
+  max-width: 980px;
+  margin: 3em auto 0;
+}

--- a/src/data-publication/reports/tables/A.jsx
+++ b/src/data-publication/reports/tables/A.jsx
@@ -51,7 +51,7 @@ const renderDisposition = (disposition, i) => {
 const A = React.forwardRef((props, ref) => {
   if (!props.report) return null
   return (
-    <table ref={ref} style={{ fontSize: '.75em' }}>
+    <table ref={ref} className="narrowTable">
       <thead>
         <tr>
           <th width="20%" rowSpan={2}>

--- a/src/data-publication/reports/tables/A4.jsx
+++ b/src/data-publication/reports/tables/A4.jsx
@@ -82,7 +82,7 @@ const A4 = React.forwardRef((props, ref) => {
   if (!props.report) return null
 
   return (
-    <table ref={ref} style={{ fontSize: '.75em' }}>
+    <table ref={ref} className="narrowTable">
       <thead>
         <tr>
           <th width="25%" rowSpan={2}>

--- a/src/data-publication/reports/tables/AggregateI.jsx
+++ b/src/data-publication/reports/tables/AggregateI.jsx
@@ -42,7 +42,7 @@ const getRows = institutions => {
 const AggregateI = React.forwardRef((props, ref) => {
   if (!props.report) return null
   return (
-    <table ref={ref} style={{ fontSize: '.75em' }}>
+    <table ref={ref} className="narrowTable">
       <thead>
         <tr>
           <th style={{ borderWidth: 0, textAlign: 'left' }} colSpan={3}>

--- a/src/data-publication/reports/tables/I.jsx
+++ b/src/data-publication/reports/tables/I.jsx
@@ -42,7 +42,7 @@ const getRows = institutions => {
 const I = React.forwardRef((props, ref) => {
   if (!props.report) return null
   return (
-    <table ref={ref} style={{ fontSize: '.75em' }}>
+    <table ref={ref} className="narrowTable">
       <thead>
         <tr>
           <th style={{ borderWidth: 0, textAlign: 'left' }} colSpan={3}>


### PR DESCRIPTION
Closes #345 

Besides 2017 Aggregate table i, also fixes 2018 Aggregate "Reporting Financial Institutions" and the set of A tables for 2017 for both aggregate and disclosure.