### PR TITLE
Update Redux store's filingPeriod if different from URL's

### DIFF
--- a/src/filing/App.jsx
+++ b/src/filing/App.jsx
@@ -50,7 +50,11 @@ export class AppContainer extends Component {
       return this.props.history.push('/filing') 
       
     const filingPeriod = this.props.match.params.filingPeriod
-    if(!this.isValidPeriod(filingPeriod)) this.checkForValidQuarters(filingPeriod)
+    if (!this.isValidPeriod(filingPeriod)) {
+      this.checkForValidQuarters(filingPeriod)
+    } else if (filingPeriod !== this.props.filingPeriod) {
+      this.props.dispatch(updateFilingPeriod(filingPeriod))
+    }
 
     const keycloak = getKeycloak()
     if (!keycloak.authenticated && !this._isHome(this.props)){
@@ -124,15 +128,15 @@ export class AppContainer extends Component {
 }
 
 export function mapStateToProps(state, ownProps) {
-  const { redirecting } = state.app
-  const { statePathname } = state.app
+  const { filingPeriod, redirecting, statePathname } = state.app
   const { maintenanceMode, filingAnnouncement } = ownProps.config
 
   return {
     redirecting,
     statePathname,
     maintenanceMode, 
-    filingAnnouncement
+    filingAnnouncement,
+    filingPeriod
   }
 }
 


### PR DESCRIPTION
Closes #342 

## Testing Locally
- Edit `userEnvironmentConfig.jsx` to always fetch from git hosted config
- Edit `config.json` to remove 2020-Q1 from `dev.filingPeriods`
- Navigate to 2020-Q1 filing
- Hit refresh a few a times
- Observe that the UI does not display error or hang with loading icons
