### PR TITLE
Update broken 2017 Modified LAR Cypress test

### DIFF
--- a/cypress/integration/data-publication/ModifiedLAR.spec.js
+++ b/cypress/integration/data-publication/ModifiedLAR.spec.js
@@ -66,18 +66,8 @@ onlyOn(!isBeta(HOST), () => {
       cy.visit(`${HOST}/data-publication/modified-lar/2017`)
 
       cy.get(
-        "#root > .App > #main-content > .YearSelector > a:nth-child(3)"
-      ).click()
-
-      cy.wait(ACTION_DELAY)
-
-      cy.get(
         "#main-content > .SearchList > form > div > #institution-name"
       ).click()
-
-      // cy.get(
-      //   "#main-content > .SearchList > form > div > #institution-name"
-      // ).click()
 
       cy.get(
         "#main-content > .SearchList > form > div > #institution-name"


### PR DESCRIPTION
Closes #344 

Test was performing an unnecessary click that changed the target year from 2017 to 2018, resulting in the expected Institution ID not being found.