### PR TITLE
Filing: Only show relevant period options 

### DIFF
--- a/src/filing/App.jsx
+++ b/src/filing/App.jsx
@@ -99,10 +99,6 @@ export class AppContainer extends Component {
   }
 
   isValidPeriod(period) {
-    // TODO: Account for past periods/use derived period options here
-    // Consider: Once 2020-Q1 closes, will it be removed from the config.filingPeriods array?
-    // if (this.props.filingPeriodOptions.options.length === 0) return true
-    // return this.props.filingPeriodOptions.options.indexOf(period) > -1
     return this.props.config.filingPeriods.indexOf(period) > -1
   }
 

--- a/src/filing/App.jsx
+++ b/src/filing/App.jsx
@@ -99,6 +99,10 @@ export class AppContainer extends Component {
   }
 
   isValidPeriod(period) {
+    // TODO: Account for past periods/use derived period options here
+    // Consider: Once 2020-Q1 closes, will it be removed from the config.filingPeriods array?
+    // if (this.props.filingPeriodOptions.options.length === 0) return true
+    // return this.props.filingPeriodOptions.options.indexOf(period) > -1
     return this.props.config.filingPeriods.indexOf(period) > -1
   }
 
@@ -128,7 +132,7 @@ export class AppContainer extends Component {
 }
 
 export function mapStateToProps(state, ownProps) {
-  const { filingPeriod, redirecting, statePathname } = state.app
+  const { filingPeriod, redirecting, statePathname, filingPeriodOptions } = state.app
   const { maintenanceMode, filingAnnouncement } = ownProps.config
 
   return {
@@ -136,7 +140,8 @@ export function mapStateToProps(state, ownProps) {
     statePathname,
     maintenanceMode, 
     filingAnnouncement,
-    filingPeriod
+    filingPeriod,
+    filingPeriodOptions
   }
 }
 

--- a/src/filing/actions/fetchAllInstitutions.js
+++ b/src/filing/actions/fetchAllInstitutions.js
@@ -1,0 +1,12 @@
+import { getInstitution } from "../api/api";
+
+export default function fetchAllInstitutions(years, institutions) {
+  const promises = [];
+  // Fetch Institution details for each year
+  years.forEach((year) => {
+    institutions.forEach((i) => {
+      promises.push(getInstitution(i.lei, year));
+    });
+  });
+  return Promise.all(promises);
+}

--- a/src/filing/actions/getFilingPeriodOptions.js
+++ b/src/filing/actions/getFilingPeriodOptions.js
@@ -1,26 +1,12 @@
 import { splitYearQuarter } from "../api/utils"
-import { afterFilingPeriod, withinFilingPeriod } from "../utils/date"
 import receivePeriodOptions from "./receivePeriodOptions"
 import requestPeriodOptions from "./requestPeriodOptions"
 import fetchAllInstitutions from './fetchAllInstitutions'
 
-const QUARTERS = ["Q1", "Q2", "Q3"]
-
-export default function getFilingPeriodOptions(
-  institutions,
-  filingPeriods,
-  filingQuarters,
-  filingQuartersLate
-) {
-  let periodOptions = generatePeriodOptions(
-    filingPeriods,
-    filingQuarters,
-    filingQuartersLate
-  )
-
+export default function getFilingPeriodOptions(institutions, filingPeriods) {
   // Only need to check years with quarterly options
   const yearFilterCandidates = new Set(
-    periodOptions
+    filingPeriods
       .filter((po) => po.indexOf("-Q") > -1)
       .map((po) => splitYearQuarter(po)[0])
   )
@@ -37,66 +23,17 @@ export default function getFilingPeriodOptions(
           ? +json.url.split("/").slice(-1)
           : json.institution.activityYear
 
-        // Any quarterly filer = should display year
+        // Any quarterly filer = should display year's quarters
         if (!json.status)
           optionDisplayMap[year] =
             json.institution.quarterlyFiler || optionDisplayMap[year]
       })
 
       dispatch(
-        receivePeriodOptions(filterOptions(periodOptions, optionDisplayMap))
+        receivePeriodOptions(filterOptions(filingPeriods, optionDisplayMap))
       )
     })
   }
-}
-
-/*********************************************************
-********************* Service Methods ********************
-**********************************************************/
-
-/**
- * Determine if a filingPeriod is currently open or has passed
- * @param {String} period filingPeriod
- * @param {Object} dates start/end dates for filing
- * @param {Object} datesLate start/end dates for late filing
- */
-function shouldAddPeriod(period, dates, datesLate) {
-  return (
-    withinFilingPeriod(period, dates) ||
-    withinFilingPeriod(period, datesLate) ||
-    afterFilingPeriod(period, dates) ||
-    afterFilingPeriod(period, datesLate)
-  )
-}
-
-/**
- * Generate a list of viable filingPeriods
- * @param {Array} periods List of open filingPeriods
- * @param {Object} dates start/end dates for filing
- * @param {Object} datesLate start/end dates for late filing
- */
-function generatePeriodOptions(periods, dates, datesLate) {
-  let options = new Set()
-
-  periods.forEach((fp) => {
-    const [year, quarter] = splitYearQuarter(fp)
-
-    // Add all Annual
-    if (!quarter) options.add(fp)
-
-    // Add all current/past quarters of year if >= 2020
-    if (+year >= 2020) {
-      QUARTERS.forEach((qtr) => {
-        let candidatePeriod = `${year}-${qtr}`
-        if (shouldAddPeriod(candidatePeriod, dates, datesLate))
-          options.add(candidatePeriod)
-      })
-    }
-  })
-
-  const result = []
-  options.forEach(el => result.push(el))
-  return result
 }
 
 /**
@@ -105,21 +42,13 @@ function generatePeriodOptions(periods, dates, datesLate) {
  * @param {Object} optionDisplayMap Maps filingYear => shouldDisplay flag
  */
 function filterOptions(periodOptions, optionDisplayMap) {
-  let filteredOptions = [...periodOptions]
+  let keepers = []
 
-  // TODO: this more efficiently
-  Object.keys(optionDisplayMap).forEach((yearKey) => {
-    if (!optionDisplayMap[yearKey]) {
-      filteredOptions = filteredOptions.filter((po) => {
-        // Keep if unrelated to year currently being filtered out
-        if (po.indexOf(yearKey) < 0) return true
-        // Keep if Annual entry for filtering year
-        if (po.indexOf("-Q") < 0) return true
-        // Remove Quarterly option
-        return false
-      })
-    }
+  periodOptions.forEach(po => {
+    const [yr, hasQtr] = splitYearQuarter(po)
+    if(!optionDisplayMap[yr] && hasQtr) return 
+    keepers.push(po)
   })
 
-  return filteredOptions
+  return keepers
 }

--- a/src/filing/actions/getFilingPeriodOptions.js
+++ b/src/filing/actions/getFilingPeriodOptions.js
@@ -1,0 +1,125 @@
+import { splitYearQuarter } from "../api/utils"
+import { afterFilingPeriod, withinFilingPeriod } from "../utils/date"
+import receivePeriodOptions from "./receivePeriodOptions"
+import requestPeriodOptions from "./requestPeriodOptions"
+import fetchAllInstitutions from './fetchAllInstitutions'
+
+const QUARTERS = ["Q1", "Q2", "Q3"]
+
+export default function getFilingPeriodOptions(
+  institutions,
+  filingPeriods,
+  filingQuarters,
+  filingQuartersLate
+) {
+  let periodOptions = generatePeriodOptions(
+    filingPeriods,
+    filingQuarters,
+    filingQuartersLate
+  )
+
+  // Only need to check years with quarterly options
+  const yearFilterCandidates = new Set(
+    periodOptions
+      .filter((po) => po.indexOf("-Q") > -1)
+      .map((po) => splitYearQuarter(po)[0])
+  )
+
+  return (dispatch) => {
+    const optionDisplayMap = {}
+
+    dispatch(requestPeriodOptions)
+
+    fetchAllInstitutions(yearFilterCandidates, institutions).then((jsons) => {
+      jsons.forEach((json) => {
+        // Response object (has URL) vs Institution details object
+        let year = json.url
+          ? +json.url.split("/").slice(-1)
+          : json.institution.activityYear
+
+        // Any quarterly filer = should display year
+        if (!json.status)
+          optionDisplayMap[year] =
+            json.institution.quarterlyFiler || optionDisplayMap[year]
+      })
+
+      dispatch(
+        receivePeriodOptions(filterOptions(periodOptions, optionDisplayMap))
+      )
+    })
+  }
+}
+
+/*********************************************************
+********************* Service Methods ********************
+**********************************************************/
+
+/**
+ * Determine if a filingPeriod is currently open or has passed
+ * @param {String} period filingPeriod
+ * @param {Object} dates start/end dates for filing
+ * @param {Object} datesLate start/end dates for late filing
+ */
+function shouldAddPeriod(period, dates, datesLate) {
+  return (
+    withinFilingPeriod(period, dates) ||
+    withinFilingPeriod(period, datesLate) ||
+    afterFilingPeriod(period, dates) ||
+    afterFilingPeriod(period, datesLate)
+  )
+}
+
+/**
+ * Generate a list of viable filingPeriods
+ * @param {Array} periods List of open filingPeriods
+ * @param {Object} dates start/end dates for filing
+ * @param {Object} datesLate start/end dates for late filing
+ */
+function generatePeriodOptions(periods, dates, datesLate) {
+  let options = new Set()
+
+  periods.forEach((fp) => {
+    const [year, quarter] = splitYearQuarter(fp)
+
+    // Add all Annual
+    if (!quarter) options.add(fp)
+
+    // Add all current/past quarters of year if >= 2020
+    if (+year >= 2020) {
+      QUARTERS.forEach((qtr) => {
+        let candidatePeriod = `${year}-${qtr}`
+        if (shouldAddPeriod(candidatePeriod, dates, datesLate))
+          options.add(candidatePeriod)
+      })
+    }
+  })
+
+  const result = []
+  options.forEach(el => result.push(el))
+  return result
+}
+
+/**
+ * Remove periodOptions that should not be displayed
+ * @param {Array} periodOptions List of filingPeriod Strings
+ * @param {Object} optionDisplayMap Maps filingYear => shouldDisplay flag
+ */
+function filterOptions(periodOptions, optionDisplayMap) {
+  let filteredOptions = [...periodOptions]
+
+  // TODO: this more efficiently
+  Object.keys(optionDisplayMap).forEach((yearKey) => {
+    if (!optionDisplayMap[yearKey]) {
+      filteredOptions = filteredOptions.filter((po) => {
+        // Keep if unrelated to year currently being filtered out
+        if (po.indexOf(yearKey) < 0) return true
+        // Keep if Annual entry for filtering year
+        if (po.indexOf("-Q") < 0) return true
+        // Remove Quarterly option
+        return false
+      })
+    }
+  })
+
+  return filteredOptions
+}

--- a/src/filing/actions/receivePeriodOptions.js
+++ b/src/filing/actions/receivePeriodOptions.js
@@ -1,0 +1,6 @@
+export default function receivePeriodOptions(array) {
+  return {
+    type: "RECEIVE_PERIOD_OPTIONS",
+    options: array,
+  }
+}

--- a/src/filing/actions/requestPeriodOptions.js
+++ b/src/filing/actions/requestPeriodOptions.js
@@ -1,0 +1,5 @@
+export default function requestPeriodOptions() {
+  return {
+    type: "REQUEST_PERIOD_OPTIONS"
+  };
+}

--- a/src/filing/institutions/InstitutionPeriodSelector.jsx
+++ b/src/filing/institutions/InstitutionPeriodSelector.jsx
@@ -7,20 +7,21 @@ import '../../common/YearSelector.css'
 
 const ANNUAL = 'annual'
 
-const InstitutionPeriodSelector = ({ filingPeriod, filingPeriods, hasQuarterlyFilers, history, pathname, dispatch }) => {
+const InstitutionPeriodSelector = ({ filingPeriod, history, pathname, dispatch, filingPeriodOptions }) => {
   const [filingYear, filingQuarter] = splitYearQuarter(filingPeriod)
   const yearOpt = periodOption(filingYear)
   const quarterOpt = periodOption(filingQuarter)
-  const quarterOpts = quarterOptions(filingYear, filingPeriods)
-  const showQuarterMenu = +filingYear >= 2020 && hasQuarterlyFilers
+  const quarterOpts = quarterOptions(filingYear, filingPeriodOptions.options)
+  const showQuarterMenu =
+    +filingYear >= 2020 &&
+    filingPeriodOptions.options.some((x) => x.indexOf("-Q") > -1)
 
   return (
     <div className='YearSelector'>
       <h4>Select a filing period</h4>
       <Select
         value={yearOpt}
-        // options={yearOptions(filingPeriods, hasQuarterlyFilers)}
-        options={yearOptions(filingPeriods, true)}
+        options={yearOptions(filingPeriodOptions.options, true)}
         styles={styleFn()}
         onChange={opt => {
           dispatch(refreshState())
@@ -70,13 +71,9 @@ function formQPath(opt, year) {
 }
 
 
-function yearOptions(filingPeriods, hasQFilers) {
+function yearOptions(filingPeriods) {
   const yearSet = new Set()
-  filingPeriods.forEach(v => {
-    const [year, quarter] = splitYearQuarter(v)
-    if (quarter && !hasQFilers) return
-    yearSet.add(year)
-  })
+  filingPeriods.forEach((v) => yearSet.add(splitYearQuarter(v)[0]))
   
   const yearArray = []
   yearSet.forEach(el => yearArray.push(el))

--- a/src/filing/institutions/InstitutionPeriodSelector.jsx
+++ b/src/filing/institutions/InstitutionPeriodSelector.jsx
@@ -12,16 +12,13 @@ const InstitutionPeriodSelector = ({ filingPeriod, history, pathname, dispatch, 
   const yearOpt = periodOption(filingYear)
   const quarterOpt = periodOption(filingQuarter)
   const quarterOpts = quarterOptions(filingYear, filingPeriodOptions.options)
-  const showQuarterMenu =
-    +filingYear >= 2020 &&
-    filingPeriodOptions.options.some((x) => x.indexOf("-Q") > -1)
 
   return (
     <div className='YearSelector'>
       <h4>Select a filing period</h4>
       <Select
         value={yearOpt}
-        options={yearOptions(filingPeriodOptions.options, true)}
+        options={yearOptions(filingPeriodOptions.options)}
         styles={styleFn()}
         onChange={opt => {
           dispatch(refreshState())
@@ -29,7 +26,7 @@ const InstitutionPeriodSelector = ({ filingPeriod, history, pathname, dispatch, 
           history.replace(pathname.replace(filingPeriod, opt.value))
         }}
       />
-      { showQuarterMenu &&
+      { showQuarterMenu(filingYear, filingPeriodOptions) &&
         <Select
           value={quarterOpt || quarterOpts[0]}
           options={quarterOpts}
@@ -95,5 +92,12 @@ function quarterOptions(filingYear, filingPeriods) {
 
   return quarters
 }
+
+function showQuarterMenu(filingYear, periodOptions){
+  return periodOptions.options.filter(x => {
+    const [year, qtr] = splitYearQuarter(x)
+    return year === filingYear && qtr
+  }).length > 0
+} 
 
 export default InstitutionPeriodSelector

--- a/src/filing/institutions/container.jsx
+++ b/src/filing/institutions/container.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import requestInstitutions from '../actions/requestInstitutions.js'
 import fetchEachInstitution from '../actions/fetchEachInstitution.js'
+import getFilingPeriodOptions from '../actions/getFilingPeriodOptions'
 import Institutions from './index.jsx'
 import { getKeycloak } from '../utils/keycloak.js'
 import { afterFilingPeriod, beforeFilingPeriod } from "../utils/date"
@@ -17,7 +18,7 @@ export class InstitutionContainer extends Component {
   }
 
   fetchIfNeeded() {
-    const { dispatch, filingPeriod, filingQuarters, institutions } = this.props
+    const { dispatch, filingPeriod, filingQuarters, institutions, filingPeriods, filingQuartersLate } = this.props
 
     if(!institutions.fetched && !institutions.isFetching){
       dispatch(requestInstitutions())
@@ -27,6 +28,7 @@ export class InstitutionContainer extends Component {
       // create the expected objects from the array, institutions = [{lei: lei}]
       let instArr = leis.map(lei => ({ lei }))
       dispatch(fetchEachInstitution(instArr, filingPeriod, filingQuarters))
+      dispatch(getFilingPeriodOptions(instArr, filingPeriods, filingQuarters, filingQuartersLate))
     }
   }
 
@@ -36,7 +38,7 @@ export class InstitutionContainer extends Component {
 }
 
 export function mapStateToProps(state, ownProps) {
-  const { institutions, filingPeriod, filings, submission, latestSubmissions, error, redirecting } = state.app
+  const { institutions, filingPeriod, filings, submission, latestSubmissions, error, redirecting, filingPeriodOptions } = state.app
   const { filingPeriods, filingQuarters, filingQuartersLate } = ownProps.config
   const isQuarterly = Boolean(splitYearQuarter(filingPeriod)[1])
   const isPassedQuarter = isQuarterly && afterFilingPeriod(filingPeriod, filingQuartersLate)
@@ -57,6 +59,7 @@ export function mapStateToProps(state, ownProps) {
     isPassedQuarter,
     isClosedQuarter,
     hasQuarterlyFilers: hasQuarterlyFilers(institutions),
+    filingPeriodOptions
   }
 }
 

--- a/src/filing/institutions/index.jsx
+++ b/src/filing/institutions/index.jsx
@@ -188,7 +188,8 @@ export default class Institutions extends Component {
       hasQuarterlyFilers,
       history,
       location,
-      dispatch
+      dispatch,
+      filingPeriodOptions
     } = this.props
     
     const institutions = this.props.institutions.institutions
@@ -220,6 +221,7 @@ export default class Institutions extends Component {
             pathname={location.pathname}
             dispatch={dispatch}
             hasQuarterlyFilers={hasQuarterlyFilers}
+            filingPeriodOptions={filingPeriodOptions}
           />
 
           {_whatToRender(this.props)}

--- a/src/filing/institutions/index.jsx
+++ b/src/filing/institutions/index.jsx
@@ -182,7 +182,6 @@ export default class Institutions extends Component {
     const {
       error,
       filingPeriod,
-      filingPeriods,
       filingQuarters,
       filingQuartersLate,
       hasQuarterlyFilers,
@@ -215,7 +214,6 @@ export default class Institutions extends Component {
           ) : null}
 
           <InstitutionPeriodSelector
-            filingPeriods={filingPeriods}
             filingPeriod={filingPeriod}
             history={history}
             pathname={location.pathname}

--- a/src/filing/reducers/filingPeriodOptions.js
+++ b/src/filing/reducers/filingPeriodOptions.js
@@ -1,0 +1,20 @@
+const defaultState = { options: [] }
+
+export default (state = defaultState, action) => {
+  switch (action.type) {
+    case "RECEIVE_PERIOD_OPTIONS":
+      return {
+        isFetching: false,
+        fetched: true,
+        options: action.options,
+      }
+    case "REQUEST_PERIOD_OPTIONS":
+      return {
+        options: [],
+        isFetching: true,
+        fetched: false,
+      }
+    default:
+      return state
+  }
+}

--- a/src/filing/reducers/index.js
+++ b/src/filing/reducers/index.js
@@ -19,6 +19,7 @@ import user from './user.js'
 import redirecting from './redirecting.js'
 import latestSubmissions from './latestSubmissions'
 import refiling from './refiling'
+import filingPeriodOptions from './filingPeriodOptions'
 
 export default combineReducers({
   lei,
@@ -39,5 +40,6 @@ export default combineReducers({
   user,
   redirecting,
   latestSubmissions,
-  refiling
+  refiling,
+  filingPeriodOptions
 })

--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -32,7 +32,8 @@ const Home = ({ config }) => {
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Get started filing your HMDA data for {defaultPeriod}
+                  Access the HMDA Filing Platform
+                  {/* Access the HMDA Platform for Filing */}
                 </a>
               </h3>
               <p>
@@ -42,6 +43,24 @@ const Home = ({ config }) => {
                 accuracy and completeness of the data, and submit data for the
                 filing year.
               </p>
+              {/* Display a List */}
+              {/* <ul style={{ listStyle: "none", display: "inline-block", paddingLeft: "0", marginBottom: "0" }}>
+                <span style={{marginRight: "1rem"}}>File for: </span>
+                {config.filingPeriods.map(fp => {
+                  return (
+                    <li style={{ display: "inline-block", marginRight: "1rem" }}>
+                      {" "}
+                      <a
+                        href={`/filing/${fp}`}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        {fp}
+                      </a>
+                    </li>
+                  )
+                })}
+              </ul> */}
             </header>
 
             <header>

--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -33,7 +33,6 @@ const Home = ({ config }) => {
                   target="_blank"
                 >
                   Access the HMDA Filing Platform
-                  {/* Access the HMDA Platform for Filing */}
                 </a>
               </h3>
               <p>
@@ -43,24 +42,6 @@ const Home = ({ config }) => {
                 accuracy and completeness of the data, and submit data for the
                 filing year.
               </p>
-              {/* Display a List */}
-              {/* <ul style={{ listStyle: "none", display: "inline-block", paddingLeft: "0", marginBottom: "0" }}>
-                <span style={{marginRight: "1rem"}}>File for: </span>
-                {config.filingPeriods.map(fp => {
-                  return (
-                    <li style={{ display: "inline-block", marginRight: "1rem" }}>
-                      {" "}
-                      <a
-                        href={`/filing/${fp}`}
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        {fp}
-                      </a>
-                    </li>
-                  )
-                })}
-              </ul> */}
             </header>
 
             <header>


### PR DESCRIPTION
Closes #354 

Changes:
- Checks for quarterly institutions for 2020+
- Filters displayed filing period options on `/institutions` page accordingly

Considerations:
- Once 2020-Q1 closes, will it be removed from the config.filingPeriods array?
   - If no, then logic needs to update to use `config.filingPeriods` as source of truth
- Do we want to use the derived filing period options to determine re-routing at the `src/filing/App.jsx` level?

Testing (against Dev):
- 2020 and Q1 shown as option when QFiler associated (MEISSADIATESTBANK001)
- 2020 and Q1,Q2 shown as option when QFiler associated and config.filingQuarters has Q2 open
- 2020 not shown as option when no QFilers associated (MEISSADIATESTBANK002)

TODO:
- Cleanup `src/homepage/index.js`
- Cleanup `src/filing/App.jsx`
- More efficient filtering for `src/filing/actions/getFilingPeriodOptions.js` line 110