### PR TITLE
Replace ol.reversed with li.value

### DIFF
--- a/src/filing/institutions/SubmissionHistory.jsx
+++ b/src/filing/institutions/SubmissionHistory.jsx
@@ -78,7 +78,7 @@ class InstitutionPreviousSubmissions extends Component {
                 page={this.state.page}
                 top={true}
               />
-              <ol reversed start={listStartingNumber} >
+              <ol>
                 {!pageSubmissions.length && <LoadingIcon />}
                 {pageSubmissions.map((submission, i) => {
                   const startDate = ordinal(new Date(submission.start))
@@ -93,7 +93,7 @@ class InstitutionPreviousSubmissions extends Component {
                   // because quality and macro are verified
                   if (submission.status.code > VALIDATING) {
                     return (
-                      <li key={i}>
+                      <li key={i} value={listStartingNumber - i}>
                         Filing progress on {startDate}:{' '}
                         <strong>{message}</strong>
                         {signedOn},{' '}


### PR DESCRIPTION
Closes #362 

## Changes
- Remove usage of "reversed" attribute on order list
- Add "value" attribute to line items instead

## Testing
I don't have ability to test IE locally but via DOM Explorer on Citrix it looks like IE respects the "value" attribute for line items.  Looks good on Chrome, Safari locally.  