### PR TITLE
[Filing] replace "new Set(iterator)" - not supported in IE

### DIFF
--- a/src/filing/actions/getFilingPeriodOptions.js
+++ b/src/filing/actions/getFilingPeriodOptions.js
@@ -5,11 +5,12 @@ import fetchAllInstitutions from './fetchAllInstitutions'
 
 export default function getFilingPeriodOptions(institutions, filingPeriods) {
   // Only need to check years with quarterly options
-  const yearFilterCandidates = new Set(
-    filingPeriods
-      .filter((po) => po.indexOf("-Q") > -1)
-      .map((po) => splitYearQuarter(po)[0])
-  )
+  const yearFilterCandidates = new Set()
+
+  filingPeriods
+    .filter((po) => po.indexOf("-Q") > -1)
+    .map((po) => splitYearQuarter(po)[0])
+    .forEach(po => yearFilterCandidates.add(po))
 
   return (dispatch) => {
     const optionDisplayMap = {}


### PR DESCRIPTION
Closes #459 

Explicitly adds element to the Set as opposed to attempting to create the Set from the Array.

## Testing
No way for me to test locally.

Filing in Dev is currently down, redirecting resources for other dev work, so can't deploy there.

Unable to test the Filing app via IE Tab (redirect from Keycloak doesn't work...).

@wpears If you can test locally against Prod, it would be appreciated.  Otherwise we can wait until Dev is free, deploy, and I can test via citrix. 


