### PR TITLE
Data Browser 2018 Cypress tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,5 +3,6 @@
   "pluginsFile": false,
   "env": {
     "HOST": "https://ffiec.cfpb.gov"
-  }
+  },
+  "defaultCommandTimeout": 10000
 }

--- a/cypress/integration/data-browser/2018.spec.js
+++ b/cypress/integration/data-browser/2018.spec.js
@@ -1,0 +1,157 @@
+import { openSelector, MAX_WAIT_SUMMARY, dbURL, isBeta, isProd } from '../../support/helpers'
+
+const { HOST } = Cypress.env()
+const dbUrl = dbURL.bind(null, HOST)
+
+describe('Data Browser 2018', function () {
+  it('State/Institution/PropertyType', function () {
+    cy.viewport(1000, 940)
+    cy.visit(dbUrl('2018?category=states'))
+
+    // Select Geography
+    openSelector('#ItemSelector')
+    cy.get('#react-select-3-option-0').click()
+    openSelector('#ItemSelector')
+    cy.get('#react-select-3-option-0').click()
+    cy.url().should('include', '?category=states&items=AL,AK')
+
+    // Select Institutions
+    openSelector('#lei-item-select')
+    cy.contains('1ST ALLIANCE LENDING, LLC' ).click()
+    openSelector('#lei-item-select')
+    cy.contains('21ST MORTGAGE CORPORATION' ).click()
+    cy.url().should('include', 'leis=549300X973YPKT8V0H73,549300XQVJ1XBNFA5536')
+
+    // Variables
+    openSelector('#VariableSelector')
+    cy.get('.SelectWrapper #react-select-5-option-10').click()
+    cy.get('.border > :nth-child(2) :checkbox').check('on')
+    cy.url().should('include', '&dwelling_categories=Single%20Family%20(1-4%20Units)%3ASite-Built')
+
+    // View Summary Table
+    cy.get('body > #root > .DataBrowser > .Geography > .secondary').click()
+    cy.get('.Aggregations', { timeout: MAX_WAIT_SUMMARY }).should('exist')
+    cy.get('.Aggregations :nth-child(1) > .sublist > li').should('have.text', 'ALABAMA, ALASKA')
+    cy.get('.Aggregations :nth-child(2) > .sublist > li').should('have.text', '1ST ALLIANCE LENDING, LLC, 21st Mortgage Corporation')
+    cy.get('.Aggregations :nth-child(3) > .sublist > li').should('have.text', 'Single Family (1-4 Units):Site-Built')
+    cy.get('.Error').should('not.exist')
+
+    // Test validity of download link
+    if(isProd(HOST) || isBeta(HOST)){
+      cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
+        assert.isTrue(status, 'Has valid download link.')
+      })
+    }
+  })
+
+  it('Nationwide/Institution/LienStatus', function () {
+    cy.viewport(1000, 940)
+    cy.visit(dbUrl('2018?category=nationwide'))
+
+    // Select Institutions
+    openSelector('#lei-item-select')
+    cy.contains('1ST ALLIANCE LENDING, LLC' ).click()
+    openSelector('#lei-item-select')
+    cy.contains('121 FINANCIAL' ).click()
+    cy.url().should('include', 'leis=549300X973YPKT8V0H73,549300XCP8KCUTKGF379')
+
+    // Variables
+    openSelector('#VariableSelector')
+    cy.get('.SelectWrapper #react-select-5-option-6').click()
+    cy.get('#lien_statuses1').check('on')
+    cy.url().should('include', '&lien_statuses=1')
+
+    // View Summary Table
+    cy.get('body > #root > .DataBrowser > .Geography > .secondary').click()
+    cy.get('.Aggregations', { timeout: MAX_WAIT_SUMMARY }).should('exist')
+    cy.get('.Aggregations :nth-child(1) > .sublist > li').should('have.text', '1ST ALLIANCE LENDING, LLC, 121 FINANCIAL')
+    cy.get('.Aggregations :nth-child(2) > .sublist > li').should('have.text', '1 - Secured By First Lien')
+    cy.get('.Error').should('not.exist')
+
+    // Test validity of download link
+    if(isProd(HOST) || isBeta(HOST)){
+      cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
+        assert.isTrue(status, 'Has valid download link.')
+      })
+    }
+  })
+
+  it('County/Institution/Action&Purpose', function () {
+    cy.viewport(1000, 940)
+    cy.visit(dbUrl('2018?category=counties'))
+
+    // Select Geography
+    openSelector('#ItemSelector')
+    cy.get('#react-select-3-option-0').click()
+    openSelector('#ItemSelector')
+    cy.get('#react-select-3-option-0').click()
+    cy.url().should('include', '?category=counties&items=01001,01003')
+
+    // Select Institutions
+    openSelector('#lei-item-select')
+    cy.contains('1ST ALLIANCE LENDING, LLC' ).click()
+    openSelector('#lei-item-select')
+    cy.contains('1ST FRANKLIN FINANCIAL CORPORATION' ).click()
+    cy.url().should('include', 'leis=549300X973YPKT8V0H73,25490092DWDTDJ002J62')
+
+    // Variables
+    openSelector('#VariableSelector')
+    cy.get('.SelectWrapper #react-select-5-option-8').click()
+    cy.get('#total_units25-49').check('on')
+    cy.url().should('include', '&total_units=25-49')
+
+    // View Summary Table
+    cy.get('body > #root > .DataBrowser > .Geography > .secondary').click()
+    cy.get('.Aggregations', { timeout: MAX_WAIT_SUMMARY }).should('exist')
+    cy.get('.Aggregations :nth-child(1) > .sublist > li').should('have.text', 'AUTAUGA COUNTY, BALDWIN COUNTY')
+    cy.get('.Aggregations :nth-child(2) > .sublist > li').should('have.text', '1ST ALLIANCE LENDING, LLC, 1st Franklin Financial Corporation')
+    cy.get('.Aggregations :nth-child(3) > .sublist > li').should('have.text', '25-49')
+    cy.get('.Error').should('not.exist')
+
+    // Test validity of download link
+    if(isProd(HOST) || isBeta(HOST)){
+      cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
+        assert.isTrue(status, 'Has valid download link.')
+      })
+    }
+  })
+
+  it('MSA/Institution/PropertyType', function () {
+    cy.viewport(1000, 940)
+    cy.visit(dbUrl('2018?category=msamds'))
+
+    // Select Geography
+    openSelector('#ItemSelector')
+    cy.get('#react-select-3-option-0').click()
+    openSelector('#ItemSelector')
+    cy.get('#react-select-3-option-0').click()
+    cy.url().should('include', '?category=msamds&items=11500,12220')
+
+    // Select Institutions
+    openSelector('#lei-item-select')
+    cy.contains('1ST ALLIANCE LENDING, LLC' ).click()
+    openSelector('#lei-item-select')
+    cy.contains('21ST MORTGAGE CORPORATION' ).click()
+    cy.url().should('include', 'leis=549300X973YPKT8V0H73,549300XQVJ1XBNFA5536')
+
+    // Variables
+    openSelector('#VariableSelector')
+    cy.get('.SelectWrapper #react-select-5-option-1').click()
+    cy.get('#loan_types1').check('on')
+    cy.url().should('include', '&loan_types=1')
+
+    // View Summary Table
+    cy.get('body > #root > .DataBrowser > .Geography > .secondary').click()
+    cy.get('.Aggregations', { timeout: MAX_WAIT_SUMMARY }).should('exist')
+    cy.get('.Aggregations :nth-child(1) > .sublist > li').should('have.text',"11500\u00A0-\u00A0ANNISTON-OXFORD-JACKSONVILLE, 12220\u00A0-\u00A0AUBURN-OPELIKA")
+    cy.get('.Aggregations :nth-child(3) > .sublist > li').should('have.text', '1 - Conventional')
+    cy.get('.Error').should('not.exist')
+
+    // Test validity of download link
+    if(isProd(HOST) || isBeta(HOST)){
+      cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
+        assert.isTrue(status, 'Has valid download link.')
+      })
+    }
+  })
+})

--- a/cypress/integration/data-browser/2018.spec.js
+++ b/cypress/integration/data-browser/2018.spec.js
@@ -1,4 +1,4 @@
-import { openSelector, MAX_WAIT_SUMMARY, dbURL, isBeta, isProd } from '../../support/helpers'
+import { openSelector, dbURL, isBeta, isProd } from '../../support/helpers'
 
 const { HOST } = Cypress.env()
 const dbUrl = dbURL.bind(null, HOST)
@@ -30,7 +30,7 @@ describe('Data Browser 2018', function () {
 
     // View Summary Table
     cy.get('body > #root > .DataBrowser > .Geography > .secondary').click()
-    cy.get('.Aggregations', { timeout: MAX_WAIT_SUMMARY }).should('exist')
+    cy.get('.Aggregations').should('exist')
     cy.get('.Aggregations :nth-child(1) > .sublist > li').should('have.text', 'ALABAMA, ALASKA')
     cy.get('.Aggregations :nth-child(2) > .sublist > li').should('have.text', '1ST ALLIANCE LENDING, LLC, 21st Mortgage Corporation')
     cy.get('.Aggregations :nth-child(3) > .sublist > li').should('have.text', 'Single Family (1-4 Units):Site-Built')
@@ -63,7 +63,7 @@ describe('Data Browser 2018', function () {
 
     // View Summary Table
     cy.get('body > #root > .DataBrowser > .Geography > .secondary').click()
-    cy.get('.Aggregations', { timeout: MAX_WAIT_SUMMARY }).should('exist')
+    cy.get('.Aggregations').should('exist')
     cy.get('.Aggregations :nth-child(1) > .sublist > li').should('have.text', '1ST ALLIANCE LENDING, LLC, 121 FINANCIAL')
     cy.get('.Aggregations :nth-child(2) > .sublist > li').should('have.text', '1 - Secured By First Lien')
     cy.get('.Error').should('not.exist')
@@ -102,7 +102,7 @@ describe('Data Browser 2018', function () {
 
     // View Summary Table
     cy.get('body > #root > .DataBrowser > .Geography > .secondary').click()
-    cy.get('.Aggregations', { timeout: MAX_WAIT_SUMMARY }).should('exist')
+    cy.get('.Aggregations').should('exist')
     cy.get('.Aggregations :nth-child(1) > .sublist > li').should('have.text', 'AUTAUGA COUNTY, BALDWIN COUNTY')
     cy.get('.Aggregations :nth-child(2) > .sublist > li').should('have.text', '1ST ALLIANCE LENDING, LLC, 1st Franklin Financial Corporation')
     cy.get('.Aggregations :nth-child(3) > .sublist > li').should('have.text', '25-49')
@@ -142,7 +142,7 @@ describe('Data Browser 2018', function () {
 
     // View Summary Table
     cy.get('body > #root > .DataBrowser > .Geography > .secondary').click()
-    cy.get('.Aggregations', { timeout: MAX_WAIT_SUMMARY }).should('exist')
+    cy.get('.Aggregations').should('exist')
     cy.get('.Aggregations :nth-child(1) > .sublist > li').should('have.text',"11500\u00A0-\u00A0ANNISTON-OXFORD-JACKSONVILLE, 12220\u00A0-\u00A0AUBURN-OPELIKA")
     cy.get('.Aggregations :nth-child(3) > .sublist > li').should('have.text', '1 - Conventional')
     cy.get('.Error').should('not.exist')

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -28,16 +28,9 @@ export function urlExists(url) {
 }
 
 /* Data Browser Helpers */
-export const MAX_WAIT_INSTITUTIONS = 10000 //10s
-export const MAX_WAIT_SUMMARY = 10000 //10s
-export const DEFAULT_WAIT = 4000 //4s
-
-/* Open react-select drop-down if it's not loading */
-export const openSelector = (id, timeout = MAX_WAIT_INSTITUTIONS) =>
-  cy.get(`${id} > div > div`, { timeout }).first().should('not.contain', 'Loading').click()
-
-/* Delay by {time} milliseconds */
-export const waitFor = (time = DEFAULT_WAIT) => cy.wait(time)
+// Open react-select drop-down if it's not loading
+export const openSelector = (id) =>
+  cy.get(`${id} > div > div`).first().should('not.contain', 'Loading').click()
 
 export const dbClick2018 = () => cy.get('#root > .DataBrowser > .Geography > .YearSelector > a:nth-child(2)').click()
 export const dbClick2017 = () => cy.get('#root > .DataBrowser > .Geography > .YearSelector > a:nth-child(3)').click()

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -26,3 +26,19 @@ export function urlExists(url) {
     xhr.send()
   })
 }
+
+/* Data Browser Helpers */
+export const MAX_WAIT_INSTITUTIONS = 10000 //10s
+export const MAX_WAIT_SUMMARY = 10000 //10s
+export const DEFAULT_WAIT = 4000 //4s
+
+/* Open react-select drop-down if it's not loading */
+export const openSelector = (id, timeout = MAX_WAIT_INSTITUTIONS) =>
+  cy.get(`${id} > div > div:first`, { timeout }).should('not.contain', 'Loading').click()
+
+/* Delay by {time} milliseconds */
+export const waitFor = (time = DEFAULT_WAIT) => cy.wait(time)
+
+export const dbClick2018 = () => cy.get('#root > .DataBrowser > .Geography > .YearSelector > a:nth-child(2)').click()
+export const dbClick2017 = () => cy.get('#root > .DataBrowser > .Geography > .YearSelector > a:nth-child(3)').click()
+export const dbURL = (host, queryStr) => `${host}/data-browser/data/${queryStr}` 

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -34,7 +34,7 @@ export const DEFAULT_WAIT = 4000 //4s
 
 /* Open react-select drop-down if it's not loading */
 export const openSelector = (id, timeout = MAX_WAIT_INSTITUTIONS) =>
-  cy.get(`${id} > div > div:first`, { timeout }).should('not.contain', 'Loading').click()
+  cy.get(`${id} > div > div`, { timeout }).first().should('not.contain', 'Loading').click()
 
 /* Delay by {time} milliseconds */
 export const waitFor = (time = DEFAULT_WAIT) => cy.wait(time)

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,3 +21,7 @@ import { urlExists } from "./helpers"
 Cypress.Commands.add("hasValidHref", { prevSubject: true }, anchor => {
   return urlExists(anchor.attr("href"))
 })
+
+Cypress.Commands.add("dataUrl", { prevSubject: true }, target => {
+  return urlExists(target.attr('data-url'))
+})

--- a/src/data-browser/geo/ActionsWarningsErrors.jsx
+++ b/src/data-browser/geo/ActionsWarningsErrors.jsx
@@ -5,6 +5,7 @@ import LoadingButton from './LoadingButton.jsx'
 export const ActionsWarningsErrors = ({
   downloadCallback,
   downloadEnabled,
+  downloadUrl,
   showSummaryButton,
   summaryEnabled,
   loadingDetails,
@@ -14,7 +15,7 @@ export const ActionsWarningsErrors = ({
 }) => {
   return (
     <>
-      <LoadingButton onClick={downloadCallback} disabled={!downloadEnabled}>
+      <LoadingButton onClick={downloadCallback} disabled={!downloadEnabled} dataUrl={downloadUrl}>
         Download Dataset
       </LoadingButton>
       {showSummaryButton && (

--- a/src/data-browser/geo/Geography.jsx
+++ b/src/data-browser/geo/Geography.jsx
@@ -7,7 +7,7 @@ import ItemSelect from './ItemSelect.jsx'
 import { fetchLeis, filterLeis } from './leiUtils'
 import VariableSelect from './VariableSelect.jsx'
 import Aggregations from './Aggregations.jsx'
-import { getItemCSV, getSubsetDetails, getSubsetCSV, isRetryable, RETRY_DELAY } from '../api.js'
+import { getItemCSV, getSubsetDetails, getSubsetCSV, isRetryable, makeUrl, RETRY_DELAY } from '../api.js'
 import { makeSearchFromState, makeStateFromSearch } from '../query.js'
 import { ActionsWarningsErrors } from './ActionsWarningsErrors'
 import MSAMD_COUNTS from '../constants/msamdCounts.js'
@@ -276,6 +276,11 @@ class Geography extends Component {
       loadingDetails, orderedVariables, variables } = this.state
     const enabled = category === 'nationwide' || items.length
     const checksExist = someChecksExist(variables)
+    const fileDownloadUrl =
+      window.location.origin +
+      (checksExist
+        ? makeUrl(this.state, true)
+        : makeUrl(this.state, true, false))    
 
     return (
       <div className='Geography'>
@@ -334,6 +339,7 @@ class Geography extends Component {
         <ActionsWarningsErrors
           downloadEnabled={enabled}
           downloadCallback={checksExist ? this.requestSubsetCSV : this.requestItemCSV}
+          downloadUrl={fileDownloadUrl}          
           showSummaryButton={!details.aggregations}
           summaryEnabled={enabled && checksExist}
           loadingDetails={loadingDetails}

--- a/src/data-browser/geo/ItemSelect.jsx
+++ b/src/data-browser/geo/ItemSelect.jsx
@@ -39,6 +39,7 @@ const ItemSelect = ({
       </p>
       <CategorySelect category={category} onChange={onCategoryChange} />
       <Select
+        id='ItemSelector'      
         components={{ MenuList }}
         filterOption={createFilter({ ignoreAccents: false })}
         controlShouldRenderValue={false}

--- a/src/data-browser/geo/LoadingButton.jsx
+++ b/src/data-browser/geo/LoadingButton.jsx
@@ -9,10 +9,15 @@ function makeClassname(opts={}){
   return cname
 }
 
-const LoadingButton = ({loading, disabled, onClick, children, secondary}) => {
+const LoadingButton = ({loading, disabled, onClick, children, secondary, dataUrl}) => {
   return (
     <>
-      <button onClick={onClick} disabled={disabled} className={makeClassname({disabled, secondary})}>
+      <button
+        onClick={onClick}
+        disabled={disabled}
+        className={makeClassname({ disabled, secondary })}
+        data-url={dataUrl}
+      >
         {children}
       </button>
       {loading ? <LoadingIcon className="LoadingInline" /> : null}

--- a/src/data-browser/geo/VariableSelect.jsx
+++ b/src/data-browser/geo/VariableSelect.jsx
@@ -24,7 +24,7 @@ const VariableSelect = ({ options, variables, orderedVariables, year, checkFacto
           popular variables
         </a>
       </p>
-      <Select
+      <Select id='VariableSelector'
         controlShouldRenderValue={false}
         onChange={onChange}
         placeholder={


### PR DESCRIPTION
Closes #416 

- Copies over helper functions, HTML element IDs, and `data-url` tags from 2017
- Implements 2018 Data Browser tests
- Extends `defaultCommandTimout` in an attempt to address flakiness.

## About flakiness
I'm not positive that [this change](https://github.com/cfpb/hmda-frontend/pull/486/commits/2c7cbf3681f22d49fa844641355ddb25b35cf703) actually fixes the problem, though the `Object{3}` error does seem to be resolved. 

I switched back to the old code to try to verify the fix but all tests continued to pass. 🤷  
