### PR TITLE
If announcement isn't present, prevent access errors

### DIFF
--- a/src/MaintenanceMessage.jsx
+++ b/src/MaintenanceMessage.jsx
@@ -6,7 +6,7 @@ let maintenanceClosed = false
 const MaintenanceMessage = ({ config, closeCallback }) => {
   const { announcement, maintenanceMode } = config
 
-  if(!maintenanceMode) return null
+  if(!maintenanceMode || !announcement) return null
 
   const isOpen = maintenanceMode && !maintenanceClosed
   const cname = announcement.type + (!isOpen ? ' closed' : '')

--- a/src/filing/home/index.jsx
+++ b/src/filing/home/index.jsx
@@ -7,13 +7,13 @@ import './Home.css'
 const Home = props => {
   const buttonTitle = props.maintenanceMode ? 'Unavailable during maintenance' : undefined
   const buttonsDisabled = !!props.maintenanceMode
-  const cname = "FilingHome" + (props.maintenanceMode ? " maintenance" : "")
+  const cname = 'FilingHome' + (props.maintenanceMode ? ' maintenance' : '')
 
   return (
     <main className={cname} id="main-content">
       <section className="hero">
         <div className="full-width">
-          {!!props.maintenanceMode && (
+          {!!props.maintenanceMode && !!props.announcement && (
             <Alert type='error' heading='System Temporarily Unavailable'>
               <p>{props.announcement.message}</p>
             </Alert>


### PR DESCRIPTION
Closes #501 
Allows us to remove the announcement message if we desire