### PR TITLE
Use correct deadlines when restricting new Q-Filing creation

### DIFF
--- a/src/common/constants/config.json
+++ b/src/common/constants/config.json
@@ -22,7 +22,8 @@
     "filingQuartersLate": {
       "Q1": "06/02 - 06/30",
       "Q2": "09/01 - 09/30",
-      "Q3": "12/01 - 12/31"
+      "Q3": "12/01 - 12/31",
+      "ANNUAL": "01/01 - 03/02"
     },
     "showMaps": false,
     "maintenanceMode": false,
@@ -65,7 +66,11 @@
       "filingQuartersLate": {
         "Q1": "06/02 - 06/30",
         "Q2": "09/01 - 09/30",
-        "Q3": "12/01 - 12/31"
+        "Q3": "12/01 - 12/31",
+        "ANNUAL": "01/01 - 03/02",
+        "PREVIEW": [
+          "2020"
+        ]
       },
       "showMaps": false,
       "maintenanceMode": false,
@@ -106,7 +111,8 @@
     "filingQuartersLate": {
       "Q1": "06/02 - 06/30",
       "Q2": "09/01 - 09/30",
-      "Q3": "12/01 - 12/31"
+      "Q3": "12/01 - 12/31",
+      "ANNUAL": "01/01 - 03/02"
     },
     "showMaps": true,
     "maintenanceMode": false,
@@ -151,7 +157,8 @@
       "filingQuartersLate": {
         "Q1": "06/02 - 06/30",
         "Q2": "09/01 - 09/30",
-        "Q3": "12/01 - 12/31"
+        "Q3": "12/01 - 12/31",
+        "ANNUAL": "01/01 - 03/02"
       },
       "showMaps": true,
       "dataBrowserYears": [

--- a/src/filing/institutions/container.jsx
+++ b/src/filing/institutions/container.jsx
@@ -27,7 +27,7 @@ export class InstitutionContainer extends Component {
 
       // create the expected objects from the array, institutions = [{lei: lei}]
       let instArr = leis.map(lei => ({ lei }))
-      dispatch(fetchEachInstitution(instArr, filingPeriod, filingQuarters))
+      dispatch(fetchEachInstitution(instArr, filingPeriod, filingQuartersLate))
       dispatch(getFilingPeriodOptions(instArr, filingPeriods, filingQuarters, filingQuartersLate))
     }
   }

--- a/src/filing/institutions/container.jsx
+++ b/src/filing/institutions/container.jsx
@@ -18,7 +18,7 @@ export class InstitutionContainer extends Component {
   }
 
   fetchIfNeeded() {
-    const { dispatch, filingPeriod, filingQuarters, institutions, filingPeriods, filingQuartersLate } = this.props
+    const { dispatch, filingPeriod, institutions, filingPeriods, filingQuartersLate } = this.props
 
     if(!institutions.fetched && !institutions.isFetching){
       dispatch(requestInstitutions())
@@ -28,7 +28,7 @@ export class InstitutionContainer extends Component {
       // create the expected objects from the array, institutions = [{lei: lei}]
       let instArr = leis.map(lei => ({ lei }))
       dispatch(fetchEachInstitution(instArr, filingPeriod, filingQuartersLate))
-      dispatch(getFilingPeriodOptions(instArr, filingPeriods, filingQuarters, filingQuartersLate))
+      dispatch(getFilingPeriodOptions(instArr, filingPeriods))
     }
   }
 


### PR DESCRIPTION
Closes #524 

- Use the "late" filing deadlines when determining blocked actions
- Minor code cleanup

## Testing
- Can use `MEISSADIATESTBANK001` in prod-default
- Update to be a quarterly filer via Help
- Update `fetchCurrentFiling.js > line 17+` 
    ```
    // Avoid creating Filings for passed Quarters
    if (isQuarterly && afterFilingPeriod(period, filingQuarters)){
      console.log('No new Q filing after deadline')
      return dispatch(receiveNonQFiling(institution))
    }

    // Test 'Create New Filing' scenario but avoid actually creating the new filing 
    // to enable this LEI to be reused for these scenarios in the future.
    console.log('Creating new filing')
    return dispatch(receiveNonQFiling(institution))

    ```
- Set local keycloak and proxy to `prod-default`
- Update `filingQuartersLate` in `config.json` for `dev-default` 
  - No change => 'Creating new filing'
  - Set `"Q1": "06/02 - 05/30"` => 'No new Q filing after deadline'
