### PR TITLE
[Filing] Show simple message when there is no submission history

### DIFF
--- a/src/filing/institutions/SubmissionHistory.jsx
+++ b/src/filing/institutions/SubmissionHistory.jsx
@@ -46,6 +46,7 @@ class InstitutionPreviousSubmissions extends Component {
     if (!Object.keys(this.props.submissionPages).length) return null
 
     const pageSubmissions = this.props.submissionPages[this.state.page] || []
+    const hasSubmissions = this.props.links.last !== '0'
 
     return (
       <section className="SubmissionHistory" id={`history-${this.props.lei}`}>
@@ -67,18 +68,23 @@ class InstitutionPreviousSubmissions extends Component {
               className="accordion-content"
               aria-hidden="true"
             >
-              <p>
-                The edit report for previous submissions that completed the
-                validation process can be downloaded in csv format below.
-              </p>
+              {hasSubmissions ? (
+                <p>
+                  The edit report for previous submissions that completed the
+                  validation process can be downloaded in csv format below.
+                </p>
+              ) : (
+                'There are no previous submissions.'
+              )}
               <SubmissionHistoryNav 
                 clickHandler={this.handlePaginationClick} 
                 links={this.props.links}
                 page={this.state.page}
                 top={true}
+                hidden={!hasSubmissions}
               />
               <ol>
-                {!pageSubmissions.length && <LoadingIcon />}
+                {!pageSubmissions.length && hasSubmissions && <LoadingIcon />}
                 {pageSubmissions.map((submission, i) => {
                   const startDate = ordinal(new Date(submission.start))
                   const endDate = ordinal(new Date(submission.end))


### PR DESCRIPTION
Closes #533 

<img width="736" alt="Screen Shot 2020-06-30 at 1 15 14 PM" src="https://user-images.githubusercontent.com/2592907/86168279-38aec680-bad5-11ea-8f00-7216ef39e844.png">

Testing against dev-default
- Use FRONTENDTESTBANK9999
- For Q2, observe the simple message shown in the screenshot above.
- For Q1, observe paginated display of history.