### PR TITLE
Reenable 2019 mlar with header

### DIFF
--- a/cypress/integration/data-publication/ModifiedLAR.spec.js
+++ b/cypress/integration/data-publication/ModifiedLAR.spec.js
@@ -2,6 +2,12 @@ import { onlyOn } from '@cypress/skip-test'
 import { isBeta } from "../../support/helpers"
 const { HOST } = Cypress.env()
 
+const testCases = [
+  { year: 2019, name: "cypress", institution: "549300I4IUWMEMGLST06"},
+  { year: 2018, name: "cypress", institution: "549300I4IUWMEMGLST06"},
+  { year: 2017, name: "cypress", institution: "729178"}
+]
+
 onlyOn(isBeta(HOST), () => {
   describe("Modified LAR", function() {
     it("Does not run on Beta", () => {})
@@ -10,112 +16,46 @@ onlyOn(isBeta(HOST), () => {
 
 onlyOn(!isBeta(HOST), () => {
   describe("Modified LAR", function() {
-    it("Searches and finds correct link for 2019", function() {
-      cy.viewport(1680, 867)
-      cy.visit(`${HOST}/data-publication/modified-lar/2019`)
+    testCases.forEach(({ year, name, institution }) => {
+      it(`Searches and finds correct links for ${year}`, () => {
+        cy.visit(`${HOST}/data-publication/modified-lar/${year}`)
   
-      cy.get("#institution-name").click()
-      cy.get("#institution-name").type("cypress")
-
-      cy.get("#main-content > .SearchList > h4").contains("1 results found")
-      cy.get("#main-content > .SearchList > .Results > li > p").contains("549300I4IUWMEMGLST06")
-      cy.get("#main-content > .SearchList > .Results > li > .font-small").then(
-        $el => {
-          expect($el).to.have.text("Download Modified LAR ")
-          expect($el).to.have.attr(
-            "href",
-            "https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/2019/549300I4IUWMEMGLST06.txt"
-          )          
-        }
-      )
+        // Search finds the expected Institution
+        cy.get("#institution-name").click()
+        cy.get("#institution-name").type(name)
   
-      // TODO: Uncomment once "with Header" is available for 2019
-      // cy.get("#inclHeader").click()
-      // cy.get("#inclHeader").check("true")
-
-      // cy.get("#main-content > .SearchList > .Results > li > .font-small").should(
-      //   $el => {
-      //     expect($el).to.have.text("Download Modified LAR with Header")
-      //     expect($el).to.have.attr(
-      //       "href",
-      //       "https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/2019/header/549300I4IUWMEMGLST06_header.txt"
-      //     )
-      //   }
-      // )
-    })
-
-    it("Searches and finds correct link for 2018", function() {
-      cy.viewport(1680, 867)
-      cy.visit(`${HOST}/data-publication/modified-lar/2018`)
+        cy.get("#main-content > .SearchList > h4").contains("1 results found")
+        cy.get("#main-content > .SearchList > .Results > li > p").contains(institution)
+        cy.get("#main-content > .SearchList > .Results > li > .font-small").then(
+          $el => {
+            expect($el).to.have.text("Download Modified LAR ")
+            expect($el).to.have.attr(
+              "href",
+              `https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/${year}/${institution}.txt`
+            )          
+          }
+        )
+    
+        // Ticking the "Include Header" option updates download link appropriately
+        cy.get("#inclHeader").click()
+        cy.get("#inclHeader").check("true")
   
-      cy.get("#institution-name").click()
-      cy.get("#institution-name").type("cypress")
+        cy.get("#main-content > .SearchList > .Results > li > .font-small").should(
+          $el => {
+            expect($el).to.have.text("Download Modified LAR with Header")
+            expect($el).to.have.attr(
+              "href",
+              `https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/${year}/header/${institution}_header.txt`
+            )
+          }
+        )
 
-      cy.get("#main-content > .SearchList > h4").contains("1 results found")
-      cy.get("#main-content > .SearchList > .Results > li > p").contains("549300I4IUWMEMGLST06")
-      cy.get("#main-content > .SearchList > .Results > li > .font-small").then(
-        $el => {
-          expect($el).to.have.text("Download Modified LAR ")
-          expect($el).to.have.attr(
-            "href",
-            "https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/2018/549300I4IUWMEMGLST06.txt"
-          )          
-        }
-      )
-  
-      cy.get("#inclHeader").click()
-      cy.get("#inclHeader").check("true")
-
-      cy.get("#main-content > .SearchList > .Results > li > .font-small").should(
-        $el => {
-          expect($el).to.have.text("Download Modified LAR with Header")
-          expect($el).to.have.attr(
-            "href",
-            "https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/2018/header/549300I4IUWMEMGLST06_header.txt"
-          )
-        }
-      )
-    })
-  
-    it("Searches and finds correct link for 2017", function() {
-      cy.viewport(1680, 867)
-      cy.visit(`${HOST}/data-publication/modified-lar/2017`)
-
-      cy.get("#institution-name").click()
-      cy.get("#institution-name").type("cypress")
-
-      cy.get("#main-content > .SearchList > .Results > li > p").contains("729178")
-      cy.get("#main-content > .SearchList > .Results > li > .font-small").then(
-        $el => {
-          expect($el).to.have.text("Download Modified LAR ")
-          expect($el).to.have.attr(
-            "href",
-            "https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/2017/729178.txt"
-          )          
-        }
-      )
-
-      cy.get("#inclHeader").click()
-      cy.get("#inclHeader").check("true")
-
-      cy.get("#main-content > .SearchList > .Results > li > .font-small").then(
-        $el => {
-          expect($el).to.have.text("Download Modified LAR with Header")
-          expect($el).to.have.attr(
-            "href",
-            "https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/2017/header/729178_header.txt"
-          )             
-        }
-      )
-    })
-  
-   it("Has the right documentation link", function() {
-     cy.viewport(1680, 867)
-     cy.visit(`${HOST}/data-publication/modified-lar/2018`)
-     cy.get(".App > #main-content > .heading > p > a").click()
-     cy.get("#root > .App > #main-content > .DocSection > h2").contains(
-       "Modified LAR"
-     )
-   })  
+        // Documentation link points to correct place
+        const docLink = `/data-publication/documents#modified-lar`
+        cy.get(".App > #main-content > .heading > p > a").should($link => {
+          expect($link).to.have.attr("href", docLink)
+        })
+      })
+    }) 
   })
 })

--- a/src/data-publication/reports/Results.jsx
+++ b/src/data-publication/reports/Results.jsx
@@ -133,10 +133,6 @@ class Results extends React.Component {
     return this.props.year === '2017'
   }
 
-  is2019(){
-    return this.props.year === '2019'
-  }
-
   renderIncludeFileHeader() {
     return (
       <p>
@@ -169,7 +165,7 @@ class Results extends React.Component {
 
     return (
       <React.Fragment>
-        {this.props.isModLar && !this.is2019() && this.renderIncludeFileHeader()}
+        {this.props.isModLar && this.renderIncludeFileHeader()}
         {this.renderHeading(
           this.props.institutions.length,
           this.props.inputValue


### PR DESCRIPTION
Closes #550 

![with-header](https://user-images.githubusercontent.com/2592907/86954494-4dadda00-c113-11ea-9e5e-579ef7770332.gif)

- Enable "Include Header" for 2019
- Refactor mLAR tests to remove duplicated code.