### PR TITLE
Restore running of all Cypress tests by removing .only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   # Trick to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs -r rm
   # Workaround for broken sbt-launch download
-  - "[ ! -f $HOME/.sbt/launchers/1.3.10/sbt-launch.jar ] && curl -L --create-dirs -o $HOME/.sbt/launchers/1.3.10/sbt-launch.jar https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.3.10/sbt-launch.jar"
+  - "[ -f $HOME/.sbt/launchers/1.3.10/sbt-launch.jar ] || curl -L --create-dirs -o $HOME/.sbt/launchers/1.3.10/sbt-launch.jar https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.3.10/sbt-launch.jar"
   - sbt ++$TRAVIS_SCALA_VERSION  "project hmda-platform" "run" &
   - cd ..
 

--- a/cypress/integration/filing/Keycloak.spec.js
+++ b/cypress/integration/filing/Keycloak.spec.js
@@ -19,7 +19,7 @@ describe('Keycloak', () => {
     })
   
     describe('Account creation', () => {
-      it.only('Performs form validation', () => {
+      it('Performs form validation', () => {
         const registerText = "Register"
         const formPassword = "1234567890Ab!"
         const passwordMismatch = "Passwords do not match"

--- a/src/data-browser/Select.jsx
+++ b/src/data-browser/Select.jsx
@@ -9,6 +9,7 @@ const WrappedSelect = props => {
   function ieBlurHack() {
     if(!isIE || document.activeElement.tagName !== 'DIV') return
     selRef.current.focus()
+    // eslint-disable-next-line
     throw null
   }
 


### PR DESCRIPTION
Closes #619 

- Removes command preventing execution of full Cypress test suite
- Updates poorly written Travis config command that was causing build to fail
- Clears eslint warning about an IE workaround