### PR TITLE
Extend wait time for platform/frontend to load in CI builds

### DIFF
--- a/cypress/wait-for-server.sh
+++ b/cypress/wait-for-server.sh
@@ -1,14 +1,16 @@
+MAX_ITERATIONS=60
+WAIT_TIME=10s
 i=0
 
 # Wait for the Filing app to be reachable
 while ! curl -s "localhost:8080" >/dev/null; do
     ((i = i + 1))
-    if [[ "$i" -gt 30 ]]; then
+    if [[ "$i" -gt $MAX_ITERATIONS ]]; then
         echo "Error: Timed out waiting for the HMDA Platform to load! "
         exit 1
     fi
     echo "Waiting for the HMDA Platform to load on localhost:8080..."
-    sleep 10s
+    sleep $WAIT_TIME
 done
 
 i=0
@@ -16,10 +18,10 @@ i=0
 # Wait for the Frontend app to be reachable
 while ! curl -s "localhost:3000" >/dev/null; do
     ((i = i + 1))
-    if [[ "$i" -gt 30 ]]; then
+    if [[ "$i" -gt $MAX_ITERATIONS ]]; then
         echo "Error: Timed out waiting for the HMDA Frontend to load! "
         exit 1
     fi
     echo "Waiting for the HMDA Frontend to load on localhost:3000..."
-    sleep 10s
+    sleep $WAIT_TIME
 done


### PR DESCRIPTION
Closes #652 

Doubling the wait time from 5 mins to 10 mins.