### PR TITLE
[Cypress] Pull correct env config file

### DIFF
--- a/src/common/configUtils.js
+++ b/src/common/configUtils.js
@@ -11,7 +11,8 @@ export function fetchEnvConfig(setFn, host) {
     .then(config => setFn(config))
 }
 
-export function getDefaultConfig(host) {
+export function getDefaultConfig(str) {
+  const host = str.replace(/https?:\/\//, "")
   return isProd(host)
     ? isBeta(host)
       ? prodBeta


### PR DESCRIPTION
Closes #717 

Strips http:// and https:// from host name when determining environment configuration file. 