### PR TITLE
Reduce flakiness of Cypress link validition

### DIFF
--- a/cypress/integration/data-browser/2017.spec.js
+++ b/cypress/integration/data-browser/2017.spec.js
@@ -43,8 +43,8 @@ describe('Data Browser 2017', function () {
 
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })
@@ -77,8 +77,8 @@ describe('Data Browser 2017', function () {
 
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })
@@ -118,8 +118,8 @@ describe('Data Browser 2017', function () {
 
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })
@@ -160,8 +160,8 @@ describe('Data Browser 2017', function () {
 
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })

--- a/cypress/integration/data-browser/2018.spec.js
+++ b/cypress/integration/data-browser/2018.spec.js
@@ -43,8 +43,8 @@ describe('Data Browser 2018', function () {
 
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })
@@ -77,8 +77,8 @@ describe('Data Browser 2018', function () {
 
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })
@@ -121,8 +121,8 @@ describe('Data Browser 2018', function () {
 
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })
@@ -165,8 +165,8 @@ describe('Data Browser 2018', function () {
 
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })

--- a/cypress/integration/data-browser/2019.spec.js
+++ b/cypress/integration/data-browser/2019.spec.js
@@ -43,8 +43,8 @@ describe('Data Browser 2019', function () {
   
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })
@@ -77,8 +77,8 @@ describe('Data Browser 2019', function () {
   
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })
@@ -120,8 +120,8 @@ describe('Data Browser 2019', function () {
   
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })
@@ -163,8 +163,8 @@ describe('Data Browser 2019', function () {
   
       // Test validity of download link
       if(isProd(HOST) || isBeta(HOST)){
-        cy.get('.QueryButton:first').dataUrl().then(({ status }) => {
-          assert.isTrue(status, 'Has valid download link.')
+        cy.get('.QueryButton:first').dataUrl().then(({ status, statusCode, url }) => {
+          assert.isTrue(status, `\nURL: ${url}\nStatus Code: ${statusCode}\nHas valid download link`)
         })
       }
     })

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -25,7 +25,8 @@ export function urlExists(url) {
     const xhr = new XMLHttpRequest()
 
     xhr.onreadystatechange = function () {
-      if (xhr.readyState === 4) resolve({ url, status: xhr.status === 200 })
+      if (xhr.readyState === 4)
+        resolve({ url, status: xhr.status < 400, statusCode: xhr.status })
     }
 
     xhr.open('HEAD', url)


### PR DESCRIPTION
Closes #732 

- More lenient checking of the HTTP status code when validating Data Browser download links.  Instead of checking exclusively for a `200`, we'll now check for any non-error code `< 400`.
- More detailed error message in the event of failure

Example of new error output.
<img width="1148" alt="Screen Shot 2020-10-29 at 1 46 48 PM" src="https://user-images.githubusercontent.com/2592907/97816935-6c9e2200-1c56-11eb-9f3a-eb3ad6690139.png">
