### PR TITLE
Expand 2018 FIG links

### DIFF
--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -58,16 +58,43 @@ const Home = ({ config }) => {
             <ul>
               <li>Filing Instructions Guide</li>
               <ul>
-                {[2021, 2020, 2019, 2018, 2017].map(year => (
-                  <li>
-                    <a
-                      href={`https://s3.amazonaws.com/cfpb-hmda-public/prod/help/${year}-hmda-fig.pdf`}
-                      download={true}
-                    >
-                      For data collected in {year}
-                    </a>
-                  </li>
-                ))}                              
+                {[2021, 2020, 2019, 2018, 2017].map(year => {
+                  if (year === 2018) {
+                    return (
+                      <li>
+                        For data collected in {year}
+                        <ul>
+                          <li key={year + '-hmda-rule'}>
+                            <a
+                              href={`https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2018-hmda-fig-2018-hmda-rule.pdf`}
+                              download={true}
+                            >
+                              incorporating the 2018 HMDA rule
+                            </a>
+                          </li>
+                          <li key={year}>
+                            <a
+                              href={`https://s3.amazonaws.com/cfpb-hmda-public/prod/help/${year}-hmda-fig.pdf`}
+                              download={true}
+                            >
+                              prior to the 2018 HMDA rule
+                            </a>
+                          </li>
+                        </ul>
+                      </li>
+                    )
+                  }
+                  return (
+                    <li key={year}>
+                      <a
+                        href={`https://s3.amazonaws.com/cfpb-hmda-public/prod/help/${year}-hmda-fig.pdf`}
+                        download={true}
+                      >
+                        For data collected in {year}
+                      </a>
+                    </li>
+                  )
+                })}                             
                 <li>
                   For data collected in or before 2016, please visit the{' '}
                   <a

--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -69,7 +69,7 @@ const Home = ({ config }) => {
                               href={`https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2018-hmda-fig-2018-hmda-rule.pdf`}
                               download={true}
                             >
-                              incorporating the 2018 HMDA rule
+                              Incorporating the 2018 HMDA rule
                             </a>
                           </li>
                           <li key={year}>
@@ -77,7 +77,7 @@ const Home = ({ config }) => {
                               href={`https://s3.amazonaws.com/cfpb-hmda-public/prod/help/${year}-hmda-fig.pdf`}
                               download={true}
                             >
-                              prior to the 2018 HMDA rule
+                              Prior to the 2018 HMDA rule
                             </a>
                           </li>
                         </ul>


### PR DESCRIPTION
Closes #735 

Adds separate 2018 FIG links for data collected with/without the 2018 HMDA rule.

<img width="456" alt="Screen Shot 2020-11-12 at 9 37 12 AM" src="https://user-images.githubusercontent.com/2592907/98968492-fa85d280-24ca-11eb-9dc4-8e01d3756d79.png">

