### PR TITLE
Open 2021 Annual and Q1 in Dev-Beta

### DIFF
--- a/src/common/constants/dev-beta-config.json
+++ b/src/common/constants/dev-beta-config.json
@@ -11,6 +11,8 @@
   "maintenanceMode": false,
   "filingAnnouncement": null,
   "filingPeriods": [
+    "2021-Q1",
+    "2021",
     "2020-Q3",
     "2020-Q2",
     "2020-Q1",
@@ -24,6 +26,8 @@
     "Q3": "10/01 - 11/30",
     "ANNUAL": "01/01 - 03/02",
     "PREVIEW": [
+      "2021-Q1",
+      "2021",
       "2020"
     ]
   },


### PR DESCRIPTION
Part of #738 

## Before
<img width="240" alt="Screen Shot 2020-11-09 at 9 26 10 AM" src="https://user-images.githubusercontent.com/2592907/98569427-87cceb00-226f-11eb-9711-ac89181afe02.png">

## After
<img width="232" alt="Screen Shot 2020-11-09 at 9 36 36 AM" src="https://user-images.githubusercontent.com/2592907/98569448-8c919f00-226f-11eb-819d-14c85b09db6e.png">
<img width="244" alt="Screen Shot 2020-11-09 at 9 36 41 AM" src="https://user-images.githubusercontent.com/2592907/98569454-8dc2cc00-226f-11eb-9ce6-253e71f92b0f.png">
