### PR TITLE
Enable 2021 for HMDA Help in dev-beta

### DIFF
--- a/src/hmda-help/constants/dates.js
+++ b/src/hmda-help/constants/dates.js
@@ -1,7 +1,18 @@
-// Month in bizarre JS 0-11 format
+import { isProd, isBeta } from '../../common/configUtils'
+
 // YYYY will come from state as filingPeriod
-export default [
+const dates = [
   { id: '2020', name:'2020', isBeta: '0' },
   { id: '2019', name:'2019', isBeta: '0' },
   { id: '2018', name:'2018', isBeta: '0' }
 ]
+
+/* TODO: 
+*    Build HHelp environment config or integrate broader Frontend env config.
+*    For now, we want this behavior to persist in the Dev Beta environment without 
+*     having to constantly ensure the "correct" version of the application is deployed.
+*/ 
+if (!isProd(window.location.host) && isBeta(window.location.host))
+  dates.unshift({ id: '2021', name:'2021' })
+
+export default dates


### PR DESCRIPTION
Closes #741 

Short term fix to enable 2021 for HMDA Help in dev-beta.

The long-term solution for HMDA Help environment configuration which will probably involve expanding the shared, GH hosted environment config files. 