### PR TITLE
Add FIG update date

### DIFF
--- a/src/documentation/FigLinks.jsx
+++ b/src/documentation/FigLinks.jsx
@@ -20,7 +20,7 @@ const links = {
     <li key="8"><Link to="/documentation/2020/quarterly-filing-dates/">Quarterly HMDA Filing Period Dates</Link></li>
   ],
   2021: [
-    <li key="9"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2021-hmda-fig.pdf">For data collected in 2021</a></li>,
+    <li key="9"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2021-hmda-fig.pdf">For data collected in 2021 ( Last updated: 11/20/2020 )</a></li>,
     <li key="10"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/supplemental-guide-for-quarterly-filers-for-2021.pdf">Supplemental Guide for Quarterly Filers for 2021</a></li>,
     <li key="11"><Link to="/documentation/2021/annual-filing-dates/">Annual HMDA Filing Period Dates</Link></li>,
     <li key="12"><Link to="/documentation/2021/quarterly-filing-dates/">Quarterly HMDA Filing Period Dates</Link></li>

--- a/src/homepage/Home.css
+++ b/src/homepage/Home.css
@@ -1,3 +1,16 @@
 .App.home .card:nth-of-type(2){
   margin-right: 0;
 }
+
+.App.home .last-updated:hover {
+  color: inherit;
+}
+
+.App.home .last-updated {
+  display: inline-block;
+  text-decoration: inherit;
+  margin: 0 0 0 .5rem;
+  color: grey;
+  font-size: 1.25rem;
+  text-align: right;
+}

--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -84,6 +84,19 @@ const Home = ({ config }) => {
                       </li>
                     )
                   }
+
+                  { if (year === 2021) {
+                    return <li key={year}>
+                    <a
+                      href={`https://s3.amazonaws.com/cfpb-hmda-public/prod/help/${year}-hmda-fig.pdf`}
+                      download={true}
+                    >
+                      For data collected in {year}
+                      <span className='last-updated'>( Last updated: 11/20/2020 )</span>
+                    </a>
+                  </li>
+                  }}
+
                   return (
                     <li key={year}>
                       <a


### PR DESCRIPTION
We can go ahead and merge this, then do a deployment on Friday, once the S3 update is complete.

Checks a box in #745 

# Homepage link
<img width="435" alt="Screen Shot 2020-11-17 at 10 35 01 AM" src="https://user-images.githubusercontent.com/2592907/99426037-e07c3380-28c0-11eb-9bda-3807e7731447.png">

# Documentation link
<img width="445" alt="Screen Shot 2020-11-17 at 10 34 35 AM" src="https://user-images.githubusercontent.com/2592907/99426059-e6721480-28c0-11eb-8d1e-4ff689f1f15b.png">
