### PR TITLE
Update popup styling to be more clear

### DIFF
--- a/src/data-browser/maps/MapsGraphs.css
+++ b/src/data-browser/maps/MapsGraphs.css
@@ -14,6 +14,10 @@
   margin: 0;
 }
 
+.mapboxgl-ctrl-logo {
+  display: none !important;
+}
+
 .legend {
   position: absolute;
   bottom: 20px;

--- a/src/data-browser/maps/popupUtils.jsx
+++ b/src/data-browser/maps/popupUtils.jsx
@@ -14,7 +14,7 @@ const popup = new mapbox.Popup({
 })
 
 function buildPopupHTML(geography, feature, origPer1000){
-  return '<h4>' + feature + ' - ' + getFeatureName(geography, feature) + (origPer1000 !== undefined ? ` - ${origPer1000}` : '') + '</h4>'
+  return '<h4>' + getFeatureName(geography, feature) + (origPer1000 !== undefined ? ` - ${origPer1000} per 1000 people` : '') + '</h4>'
 }
 
 function getFeatureName(geography, feature){


### PR DESCRIPTION
The FIPS isn't really helpful in the popup and (especially for states) could be confusing. The `per 1000 people` bit I think makes it less of a floating number with no context