### PR TITLE
Deny scripts, Limit connections

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -46,6 +46,9 @@ http {
     ~image/                    max;
   }
 
+  # Limit connections per IP address
+  limit_conn_zone $binary_remote_addr zone=addr:10m;
+
   server {
     listen 8080;
     root /usr/share/nginx/html/;
@@ -57,6 +60,7 @@ http {
     tcp_nopush on;
     tcp_nodelay on;
     expires $expires;
+    limit_conn addr 8;
 
     # Prevent access from nasty user agents
     if ($badagent) {
@@ -77,6 +81,12 @@ http {
       }
       try_files '' /index.html;
     }
+
+    # deny running scripts inside core system folders
+    location ~* /(system|vendor)/.*\.(txt|xml|md|html|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ { return 418; }
+    
+    # deny running scripts inside user folder
+    location ~* /user/.*\.(txt|md|yaml|yml|php|pl|py|cgi|twig|sh|bat)$ { return 418; }
   }
 
 }


### PR DESCRIPTION
Helps with Devops issue #2135
- Adds a limit of 8 simultaneous connections per IP address
- Blocks script execution in user and system folders 