### PR TITLE
Maps Updates

### DIFF
--- a/src/common/constants/dev-beta-config.json
+++ b/src/common/constants/dev-beta-config.json
@@ -43,8 +43,8 @@
   },
   "showMaps": true,
   "dataBrowserYears": [
-    "2018",
-    "2019"
+    "2019",
+    "2018"
   ],
   "dataPublicationYears": {
     "shared": [

--- a/src/data-browser/index.js
+++ b/src/data-browser/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import { Switch, Route } from 'react-router-dom'
-
+import { Switch, Route, Redirect } from 'react-router-dom'
 import Home from './Home'
 import Geography from './datasets/Geography.jsx'
 import MapsGraphs from './maps/MapsGraphs.jsx'
@@ -8,6 +7,8 @@ import NotFound from '../common/NotFound'
 import { withAppContext } from '../common/appContextHOC'
 
 const DataBrowser = props => {
+  const { publicationReleaseYear } = props.config
+
   return (
     <div className="DataBrowser App">
       <Switch>
@@ -16,14 +17,24 @@ const DataBrowser = props => {
           path="/data-browser/data/:year?"
           render={(r_props) => <Geography {...r_props} {...props} /> }
         />
-        {
-          props.config.showMaps
-          ? <Route
-              path="/data-browser/maps-graphs/:year?"
-              render={(r_props) => <MapsGraphs {...r_props} {...props} /> }
-            />
-          : null
-        }
+        {props.config.showMaps ? (
+          <Route
+            path='/data-browser/maps-graphs/:year?'
+            render={(r_props) => {
+              const year = r_props.match.params.year
+              const { pathname, search } = r_props.location
+
+              if (!year)
+                return (
+                  <Redirect
+                    to={`${pathname}${publicationReleaseYear}${search}`}
+                  />
+                )
+                
+              return <MapsGraphs {...r_props} {...props} />
+            }}
+          />
+        ) : null}
         <Route component={NotFound} />
       </Switch>
     </div>

--- a/src/data-browser/maps/MapContainer.jsx
+++ b/src/data-browser/maps/MapContainer.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef }  from 'react'
-import { Redirect } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import Select from '../Select.jsx'
 import DBYearSelector from '../datasets/DBYearSelector'
 import LoadingButton from '../datasets/LoadingButton.jsx'
@@ -395,11 +395,6 @@ const MapContainer = props => {
   }
 
   const resolved = resolveData()
-
-  if (!year)
-    return (
-      <Redirect to={props.location.pathname + `${props.config.publicationReleaseYear}` + props.location.search} />
-    )
 
   return (
     <div className="SelectWrapper">


### PR DESCRIPTION
The previous Redirect method can lead to a `WebGl not supported` message.  This corrects that moving the redirect outside of the affected component.

Previously:
<img width="1012" alt="Screen Shot 2020-12-02 at 2 47 00 PM" src="https://user-images.githubusercontent.com/2592907/100937546-61861e00-34b0-11eb-98b9-f6f5dbfe89a9.png">


Also fixes the order of DB years.

|Before|After|
|---|---|
|<img width="162" alt="Screen Shot 2020-12-02 at 3 10 12 PM" src="https://user-images.githubusercontent.com/2592907/100937742-b6299900-34b0-11eb-97d7-a9c955d2e681.png">|<img width="160" alt="Screen Shot 2020-12-02 at 3 10 51 PM" src="https://user-images.githubusercontent.com/2592907/100937682-98f4ca80-34b0-11eb-9ae9-5d5259a742b7.png">|
