### PR TITLE
Add 2020 to FFVT

### DIFF
--- a/src/tools/file-format-verification/components/FilingPeriodSelector.jsx
+++ b/src/tools/file-format-verification/components/FilingPeriodSelector.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import './FilingPeriodSelector.css'
 
-const filingPeriods = ['2019', '2018']
+const filingPeriods = ['2020', '2019', '2018']
 
 const FilingPeriodSelector = props => {
   return (


### PR DESCRIPTION
Closes #772 

Adds 2020 option.

<img width="761" alt="Screen Shot 2020-12-02 at 3 23 55 PM" src="https://user-images.githubusercontent.com/2592907/100938700-6946c200-34b2-11eb-8627-a7ba30e04ebf.png">

