### PR TITLE
Add 2021 option to HMDA Help in Prod Beta

### DIFF
--- a/src/hmda-help/constants/dates.js
+++ b/src/hmda-help/constants/dates.js
@@ -9,7 +9,7 @@ const dates = [
 
 /* TODO: 
 *    Build HHelp environment config or integrate broader Frontend env config.
-*    For now, we want this behavior to persist in the Dev Beta environment without 
+*    For now, we want this behavior to persist in the Prod & Dev Beta environments without 
 *     having to constantly ensure the "correct" version of the application is deployed.
 */ 
 if (isBeta(window.location.host))

--- a/src/hmda-help/constants/dates.js
+++ b/src/hmda-help/constants/dates.js
@@ -1,4 +1,4 @@
-import { isProd, isBeta } from '../../common/configUtils'
+import { isBeta } from '../../common/configUtils'
 
 // YYYY will come from state as filingPeriod
 const dates = [
@@ -12,7 +12,7 @@ const dates = [
 *    For now, we want this behavior to persist in the Dev Beta environment without 
 *     having to constantly ensure the "correct" version of the application is deployed.
 */ 
-if (!isProd(window.location.host) && isBeta(window.location.host))
+if (isBeta(window.location.host))
   dates.unshift({ id: '2021', name:'2021' })
 
 export default dates


### PR DESCRIPTION
Closes #774 

Adds 2021 for HMDA Help in all Beta environments.

<img width="664" alt="Screen Shot 2020-12-02 at 3 34 27 PM" src="https://user-images.githubusercontent.com/2592907/100939664-e4f53e80-34b3-11eb-966a-bc10d5004958.png">
