### PR TITLE
Cypress fixes for Rate Spread and Check Digit

### DIFF
--- a/cypress/integration/tools/CheckDigitTool.spec.js
+++ b/cypress/integration/tools/CheckDigitTool.spec.js
@@ -78,14 +78,14 @@ onlyOn(isProd(HOST) && !isBeta(HOST), () => {
       // Get file from fixtures as binary
       cy.fixture(fileName, "binary").then(excelBin => {
         // File in binary format gets converted to blob so it can be sent as Form data
-        Cypress.Blob.binaryStringToBlob(excelBin, fileType).then(blob => {
-          // Build up the form
-          const formData = new FormData()
-          formData.set("file", blob, fileName) //adding a file to the form
-          // Perform the request
-          withFormData(method, url, formData, function(res) {
-            response = res
-          })
+        const blob = Cypress.Blob.binaryStringToBlob(excelBin, fileType)
+      
+        // Build up the form
+        const formData = new FormData()
+        formData.set("file", blob, fileName) //adding a file to the form
+        // Perform the request
+        withFormData(method, url, formData, function(res) {
+          response = res
         })
 
         cy.wrap(null).should(() => {
@@ -117,14 +117,14 @@ onlyOn(isProd(HOST) && !isBeta(HOST), () => {
       // Get file from fixtures as binary
       cy.fixture(fileName, "binary").then(excelBin => {
         // File in binary format gets converted to blob so it can be sent as Form data
-        Cypress.Blob.binaryStringToBlob(excelBin, fileType).then(blob => {
-          // Build up the form
-          const formData = new FormData()
-          formData.set("file", blob, fileName) //adding a file to the form
-          // Perform the request
-          withFormData(method, url, formData, function(res) {
-            response = res
-          })
+        const blob = Cypress.Blob.binaryStringToBlob(excelBin, fileType)
+      
+        // Build up the form
+        const formData = new FormData()
+        formData.set("file", blob, fileName) //adding a file to the form
+        // Perform the request
+        withFormData(method, url, formData, function(res) {
+          response = res
         })
 
         cy.wrap(null).should(() => {

--- a/cypress/integration/tools/RateSpread.spec.js
+++ b/cypress/integration/tools/RateSpread.spec.js
@@ -1,6 +1,6 @@
 import { withFormData, isProd } from "../../support/helpers"
 
-const { HOST, TEST_DELAY, ENVIRONMENT } = Cypress.env()
+const { HOST, TEST_DELAY } = Cypress.env()
 
 describe("Rate Spread Tool", function() {
   beforeEach(() => {
@@ -45,7 +45,8 @@ describe("Rate Spread Tool", function() {
 })
 
 describe("Rate Spread API", () => {
-  if(!isProd(ENVIRONMENT)) it("Only runs in Production")
+  
+  if(!isProd(HOST)) it("Only runs in Production", () => cy.log(`Is Prod: ${isProd(HOST)}`))
   else {
     it("Generates rates from file", () => {
       let response
@@ -61,14 +62,15 @@ describe("Rate Spread API", () => {
       // Get file from fixtures as binary
       cy.fixture(fileName, "binary").then(excelBin => {
         // File in binary format gets converted to blob so it can be sent as Form data
-        Cypress.Blob.binaryStringToBlob(excelBin, fileType).then(blob => {
-          // Build up the form
-          const formData = new FormData()
-          formData.set("file", blob, fileName) //adding a file to the form
-          // Perform the request
-          withFormData(method, url, formData, function(res) {
-            response = res
-          })
+        const blob = Cypress.Blob.binaryStringToBlob(excelBin, fileType)
+
+        // Build up the form
+        const formData = new FormData()
+        formData.set("file", blob, fileName) //adding a file to the form
+        
+        // Perform the request
+        withFormData(method, url, formData, function(res) {
+          response = res
         })
 
         cy.wrap(null).should(() => {

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -1,6 +1,6 @@
 export const cleanHost = host => host.replace(/^https?:\/\//, '')
 export const isCI = env => env === 'CI'
-export const isProd = (host) => !!cleanHost(host).match('/^ffiec/')
+export const isProd = (host) => !!cleanHost(host).match(/^ffiec/)
 export const isBeta = (host) => cleanHost(host).indexOf('beta') > -1
 export const isDev = (host) => !isProd(cleanHost(host))
 export const isDevBeta = (host) => isDev(host) && isBeta(host)


### PR DESCRIPTION
Closes #785

- Fixes pattern matching (was a string instead of regex) in `isProd` , which was causing some tests to incorrectly get skipped based on their environment.
- Updates use of Cypress.Blob API to reflect new return type for `#binaryStringToBlob`