### PR TITLE
 Suppressing redundant ULI fields for V608-1 and V608-2

### DIFF
--- a/src/filing/submission/edits/Table.jsx
+++ b/src/filing/submission/edits/Table.jsx
@@ -6,7 +6,7 @@ import EditsTableRow from './TableRow.jsx'
 
 import './Table.css'
 
-export const supressULI = edit => ["S303", "V609"].indexOf(edit) > -1
+export const supressULI = edit => ["S303", "V609","V608-1","V608-2"].indexOf(edit) > -1
 
 export const formatHeader = (text, isTransmittal) => {
   if (text === 'value' || text === 'fields') return null


### PR DESCRIPTION
closes #795

## Changes

- adds `V608-1` and `V608-2`  to ULI suppression list

## Testing

1. Sample Test Files
[Abhinayaa.Bank_V608-2.txt](https://github.com/cfpb/hmda-frontend/files/5713617/Abhinayaa.Bank_V608-2.txt)

[Abhinayaa.Bank_V608-1-uli.48.character (1).txt](https://github.com/cfpb/hmda-frontend/files/5713615/Abhinayaa.Bank_V608-1-uli.48.character.1.txt)




## Notes

-
