### PR TITLE
Use defaultDocsPeriod instead of defaultPeriod to set period for Tools

### DIFF
--- a/src/tools/file-format-verification/reducers/index.js
+++ b/src/tools/file-format-verification/reducers/index.js
@@ -40,7 +40,7 @@ const defaultPagination = {
   fade: 0
 }
 
-const defaultFilingPeriod = config && config.defaultPeriod
+const defaultFilingPeriod = config && config.defaultDocsPeriod
 
 //empty action logger, temporary / for debugging
 export const empty = (state = {}, action) => {

--- a/src/tools/lar-formatting/AppIntro.jsx
+++ b/src/tools/lar-formatting/AppIntro.jsx
@@ -4,7 +4,7 @@ import { withAppContext } from '../../common/appContextHOC.jsx'
 import Heading from '../../common/Heading.jsx'
 
 const AppIntro = ({ config = {} }) => {
-  const {defaultPeriod} = config
+  const { defaultDocsPeriod } = config
 
   return [
     <Heading
@@ -20,7 +20,7 @@ const AppIntro = ({ config = {} }) => {
           The HMDA LAR formatting tool is a Microsoft® Excel® workbook created by the Bureau for HMDA filers, who do not have another means of doing so, to enter and format data into a pipe delimited text file. A pipe delimited text file is the required format beginning for data collected in 2017 for financial institutions to file their loan/application register (LAR) using the HMDA Platform.
         </p>
         <p>
-          Follow the <Link to={`/documentation/${defaultPeriod}/tools/lar-formatting/`}>LAR Formatting Tool instructions</Link> to format your data into a pipe delimited text file.
+          Follow the <Link to={`/documentation/${defaultDocsPeriod}/tools/lar-formatting/`}>LAR Formatting Tool instructions</Link> to format your data into a pipe delimited text file.
         </p>
       </React.Fragment>
     </Heading>,


### PR DESCRIPTION
Closes #788 again.

Uses `defaultDocsPeriod` instead of `defaultPeriod` so that the original intent is met: to allow Docs/Tools to point to the upcoming Filing season separately from the Filing app options.