### PR TITLE
Remove deprecated Promise methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ cypress.env.json
 cypress/videos/
 cypress/screenshots/
 package-lock.json
+
+# Editor Configs #
+.vscode/

--- a/src/filing/home/index.jsx
+++ b/src/filing/home/index.jsx
@@ -59,7 +59,6 @@ const Home = props => {
           <iframe
             src="https://www.youtube.com/embed/C_73Swgyc4g?rel=0"
             frameBorder="0"
-            gesture="media"
             allow="encrypted-media"
             allowFullScreen
             title="HMDA Video"

--- a/src/filing/utils/keycloak.js
+++ b/src/filing/utils/keycloak.js
@@ -27,13 +27,13 @@ const refresh = () => {
     setTimeout(() => {
       keycloak
         .updateToken(20)
-        .success(refreshed => {
+        .then(refreshed => {
           if (refreshed) {
             AccessToken.set(keycloak.token)
           }
           updateKeycloak()
         })
-        .error(() => {
+        .catch(() => {
           return keycloak.login()
         })
     }, +(keycloak.tokenParsed.exp + '000') - Date.now() - 10000)

--- a/src/hmda-help/index.js
+++ b/src/hmda-help/index.js
@@ -30,7 +30,7 @@ const refreshToken = self => {
     setTimeout(() => {
       keycloak
         .updateToken(20)
-        .success(refreshed => {
+        .then(refreshed => {
           if (refreshed) {
             self.setState({
               token: keycloak.token,
@@ -39,7 +39,7 @@ const refreshToken = self => {
           }
           updateKeycloak()
         })
-        .error(() => {
+        .catch(() => {
           return keycloak.login()
         })
     }, +(keycloak.tokenParsed.exp + '000') - Date.now() - 10000)

--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -61,7 +61,7 @@ const Home = ({ config }) => {
                 {[2021, 2020, 2019, 2018, 2017].map(year => {
                   if (year === 2018) {
                     return (
-                      <li>
+                      <li key={`${year}`}>
                         For data collected in {year}
                         <ul>
                           <li key={year + '-hmda-rule'}>


### PR DESCRIPTION
Closes #812 
- remove `.error()`
- remove `.success()`