### PR TITLE
Display HTTP Status Code in Filing errors

### DIFF
--- a/src/filing/common/ErrorWarning.css
+++ b/src/filing/common/ErrorWarning.css
@@ -1,3 +1,9 @@
 .ErrorWarning {
   margin: 2em 0;
 }
+
+.ErrorWarning .error-code{
+  display: block;
+  margin-top: .5rem;
+  font-weight: bold;
+}

--- a/src/filing/common/ErrorWarning.jsx
+++ b/src/filing/common/ErrorWarning.jsx
@@ -27,24 +27,25 @@ export function getText(props) {
 
   switch (status) {
     case 400:
-      return 'Your request could not be completed. Please try again.'
+      return `Your request could not be completed. Please try again.`
+
     case 401:
-      return 'Please log in to complete this request.'
+      return `Please log in to complete this request.`
 
     case 403:
-      return "You don't have access to the requested resources. Please ensure you are filing for the correct institution."
+      return `You don't have access to the requested resources. Please ensure you are filing for the correct institution.`
 
     case 500:
-      return "We're quickly working on resolving the issue, please refresh the page."
+      return `We're quickly working on resolving the issue, please refresh the page.`
 
     case 502:
-      return "We're having trouble routing your request, please refresh the page or try again later."
+      return `We're having trouble routing your request, please refresh the page or try again later.`
 
     case 503:
-      return "We're experiencing some issues on our end, please refresh the page or try again later."
+      return `We're experiencing some issues on our end, please refresh the page or try again later.`
 
     default:
-      return 'Please refresh the page.'
+      return `Please refresh the page.`
   }
 }
 
@@ -55,6 +56,8 @@ export function getContact(props) {
   return 'If the problem persists, contact '
 }
 
+const showErrorStatus = ({ status }) => status ? <span className='error-code'>Error code: {status}</span> : ''
+
 const ErrorWarning = props => {
   if (props.error)
     return (
@@ -63,6 +66,7 @@ const ErrorWarning = props => {
           <p>
             {getText(props)} {getContact(props)}
             <a href="mailto:hmdahelp@cfpb.gov">HMDA Help</a>.
+            {showErrorStatus(props.error)}
           </p>
         </Alert>
       </div>

--- a/src/filing/common/ErrorWarning.jsx
+++ b/src/filing/common/ErrorWarning.jsx
@@ -56,7 +56,12 @@ export function getContact(props) {
   return 'If the problem persists, contact '
 }
 
-const showErrorStatus = ({ status }) => status ? <span className='error-code'>Error code: {status}</span> : ''
+const showErrorStatus = ({ status, statusText }) => {
+  if (!status) return ''
+  let text = statusText ? `Error: ${status}` : `Error code: ${status}`
+  if (statusText) text += `  - ${statusText}`
+  return <span className='error-code'>{text}</span>
+}
 
 const ErrorWarning = props => {
   if (props.error)

--- a/src/filing/reducers/error.js
+++ b/src/filing/reducers/error.js
@@ -10,7 +10,8 @@ export default (state = defaultError, action) => {
   switch (action.type) {
     case RECEIVE_ERROR:
     case RECEIVE_UPLOAD_ERROR:
-      return action.error
+      const { status, statusText } = action.error
+      return { status, statusText }
 
     case REFRESH_STATE:
       return defaultError

--- a/src/filing/reducers/error.js
+++ b/src/filing/reducers/error.js
@@ -9,8 +9,12 @@ const defaultError = null
 export default (state = defaultError, action) => {
   switch (action.type) {
     case RECEIVE_ERROR:
+      const { status, statusText } = action.error
+      return { status, statusText }
+
     case RECEIVE_UPLOAD_ERROR:
       const { status, statusText } = action.error
+      if (status === 504) return state // Ignore 504 errors for file upload
       return { status, statusText }
 
     case REFRESH_STATE:

--- a/src/filing/reducers/error.js
+++ b/src/filing/reducers/error.js
@@ -5,15 +5,16 @@ import {
 } from '../constants'
 
 const defaultError = null
+const unknownError = { status: 999, statusText: 'Unknown error'}
 
 export default (state = defaultError, action) => {
+  const { status, statusText } = action.error || unknownError
+
   switch (action.type) {
     case RECEIVE_ERROR:
-      const { status, statusText } = action.error
       return { status, statusText }
 
     case RECEIVE_UPLOAD_ERROR:
-      const { status, statusText } = action.error
       if (status === 504) return state // Ignore 504 errors for file upload
       return { status, statusText }
 

--- a/src/filing/reducers/error.js
+++ b/src/filing/reducers/error.js
@@ -15,7 +15,6 @@ export default (state = defaultError, action) => {
       return { status, statusText }
 
     case RECEIVE_UPLOAD_ERROR:
-      if (status === 504) return state // Ignore 504 errors for file upload
       return { status, statusText }
 
     case REFRESH_STATE:


### PR DESCRIPTION
Close #776 

- ~Suppresses 504 errors that occur during file upload.~
- Displays status code and status text when available
  <img width="745" alt="Screen Shot 2021-01-29 at 2 57 43 PM" src="https://user-images.githubusercontent.com/2592907/106331604-737f0580-6242-11eb-981c-2f6ea776adf6.png">
