### PR TITLE
842 site updates

### DIFF
--- a/src/documentation/Product.jsx
+++ b/src/documentation/Product.jsx
@@ -10,12 +10,7 @@ const Product = props => {
   let header
 
   if(!list || !list.length) {
-    if(inList) return (
-      <li>
-        <h4>{heading}</h4>
-        <ul><li>No documentation for {year}.</li></ul>
-      </li>
-    )
+    if(inList) return null
     list = <li>No documentation for {year}.</li>
   }
 

--- a/src/documentation/tools/DataBrowser.jsx
+++ b/src/documentation/tools/DataBrowser.jsx
@@ -5,7 +5,7 @@ import Product from '../Product.jsx'
 const links = {
   2017: [
     <li key="0">The HMDA Data Browser currently allows users to filter and download HMDA datasets for 2018 and beyond. Historic data from 2007-2017 is <a target="_blank" rel="noopener noreferrer" href="https://www.consumerfinance.gov/data-research/hmda/historic-data/">available for download here</a>.</li>,
-    <li key="1"><Link to="/documentation/2017/data-browser-filters/">Available Filters</Link></li>,
+    // <li key="1"><Link to="/documentation/2017/data-browser-filters/">Available Filters</Link></li>, // TODO: Uncomment when 2017 DB is released.
   ],
   2018: [
     <li key="1"><Link to="/documentation/2018/data-browser-faq/">Frequently Asked Questions</Link></li>,


### PR DESCRIPTION
Closes #842

- Hides Documentation sections that don't have articles.
- Removes pre-release 2017 DB documentation

## Before
<img width="1005" alt="Screen Shot 2021-02-08 at 9 54 41 PM" src="https://user-images.githubusercontent.com/2592907/107318354-d13cfa00-6a59-11eb-9d05-1b9a87db4f85.png">

## After
<img width="1010" alt="Screen Shot 2021-02-08 at 10 06 28 PM" src="https://user-images.githubusercontent.com/2592907/107318397-ed409b80-6a59-11eb-80f7-f7c211ef5993.png">

