### PR TITLE
[Filing] Stop auto-redirect to Keycloak login page

### DIFF
--- a/cypress/integration/filing/Keycloak.spec.js
+++ b/cypress/integration/filing/Keycloak.spec.js
@@ -1,14 +1,17 @@
 import { isCI } from '../../support/helpers'
 
-const { HOST, USERNAME, PASSWORD, ENVIRONMENT } = Cypress.env()
+const { HOST, USERNAME, PASSWORD, ENVIRONMENT, AUTH_REALM, AUTH_BASE_URL } = Cypress.env()
 
 describe('Keycloak', () => {
+  const authUrl = HOST.indexOf('localhost') > -1 ? AUTH_BASE_URL : HOST
+
   if(isCI(ENVIRONMENT)) 
     it('Does not run on CI')
   else {
     beforeEach(() => {
       cy.visit(`${HOST}/filing`)
       cy.get({ HOST, USERNAME, PASSWORD, ENVIRONMENT }).logEnv()
+      cy.logout({ root: authUrl, realm: AUTH_REALM })
     })
   
     describe('Sign In', () => {
@@ -19,7 +22,7 @@ describe('Keycloak', () => {
         cy.findByText('Sign In').click()
         
         // Successful sign in lands on Instutituions page
-        cy.url().should('match', /\/filing\/\d{4}\/institutions$/)
+        cy.url().should('match', /\/filing\/\d{4}(-Q\d)?\/institutions$/)
 
         // Logout
         cy.findByText('Logout').click()

--- a/src/filing/App.jsx
+++ b/src/filing/App.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
+import { Redirect } from 'react-router'
 import ConfirmationModal from './modals/confirmationModal/container.jsx'
 import Beta, { isBeta } from '../common/Beta'
 import Header from './common/Header.jsx'
@@ -13,7 +14,6 @@ import isRedirecting from './actions/isRedirecting.js'
 import updateFilingPeriod from './actions/updateFilingPeriod.js'
 import { detect } from 'detect-browser'
 import { FilingAnnouncement } from './common/FilingAnnouncement'
-
 import 'normalize.css'
 import './app.css'
 
@@ -106,6 +106,8 @@ export class AppContainer extends Component {
   render() {
     const { match: { params }, location, config: { filingAnnouncement } } = this.props
     const validFilingPeriod = this.isValidPeriod(params.filingPeriod)
+    if (!validFilingPeriod && params.filingPeriod !== '2017') 
+      return <Redirect to={`/filing/${this.props.config.filingPeriods[0]}/`} />
 
     return (
       <div className="AppContainer">
@@ -116,12 +118,16 @@ export class AppContainer extends Component {
         <ConfirmationModal />
         {isBeta() ? <Beta/> : null}
         {filingAnnouncement ? <FilingAnnouncement data={filingAnnouncement} /> : null}
-        {validFilingPeriod
-          ? this._renderAppContents(this.props)
-          : params.filingPeriod === '2017'
-            ? <p className="full-width">Files are no longer being accepted for the 2017 filing period. For further assistance, please contact <a href="mailto:hmdahelp@cfpb.gov">HMDA Help</a>.</p>
-            : <p className="full-width">The {params.filingPeriod} filing period does not exist. If this seems wrong please contact <a href="mailto:hmdahelp@cfpb.gov">HMDA Help</a>.</p>
-        }
+        {params.filingPeriod === '2017' ? (
+          <p className='full-width'>
+            Files are no longer being accepted for the 2017 filing period. For
+            further assistance, please contact{' '}
+            <a href='mailto:hmdahelp@cfpb.gov'>HMDA Help</a>.
+          </p>
+        ) : (
+          this._renderAppContents(this.props)
+        )}
+
         <Footer filingPeriod={params.filingPeriod} config={this.props.config} />
       </div>
     )

--- a/src/filing/App.jsx
+++ b/src/filing/App.jsx
@@ -82,7 +82,7 @@ export class AppContainer extends Component {
   }
 
   _isHome(props) {
-    return !!props.location.pathname.match(/^\/filing\/\d{4}\/$/)
+    return !!props.location.pathname.match(/^\/filing\/\d{4}(-Q\d)?\/$/)
   }
 
   checkForValidQuarters(period){


### PR DESCRIPTION
Closes #901 

- Fix: Filing app was automatically redirecting to the Keycloak login page when visiting a Quarterly filing (i.e. /filing/2021-Q1/) page, preventing users from being given the option to Login or Signup. Was also breaking Keycloak specs.
- Updated Cypress specs to ensure the test user is logged out before each Keycloak test.

This is deployed to Production under v1.2.14e and the testing Pod has been updated with the latest specs, with all tests passing. 

---
Part 1 of #809   
Late addition (not in v1.2.14.e)
Redirect to latest filing period when visiting an invalid filing period i.e. /filing/3000 in [App.jsx](https://github.com/cfpb/hmda-frontend/pull/902/files#diff-0aea4518a35821b77199ef545c45a26241242ad9753c54e4f66c2293ba571955)