### PR TITLE
Pre-v1.2.15 cleanup

### DIFF
--- a/cypress/integration/data-browser/2018.spec.js
+++ b/cypress/integration/data-browser/2018.spec.js
@@ -4,8 +4,8 @@ const { HOST, ENVIRONMENT } = Cypress.env()
 const dbUrl = dbURL.bind(null, HOST)
 
 describe('Data Browser 2018', function () {
-  if(isCI(ENVIRONMENT)) it("Does not run on CI")
-  else if((!isBeta(HOST) || (isBeta(HOST) && !isProd(HOST)))){
+  if(!isProd(HOST)) it("Only runs in Production")
+  else {
     it('State/Institution/PropertyType', function () {
       cy.get({ HOST, ENVIRONMENT }).logEnv()
       cy.viewport(1000, 940)
@@ -171,7 +171,5 @@ describe('Data Browser 2018', function () {
         })
       }
     })
-  } else {
-    it(`does not run on host: ${HOST}`)
   }
 })

--- a/cypress/integration/data-browser/2019.spec.js
+++ b/cypress/integration/data-browser/2019.spec.js
@@ -4,8 +4,8 @@ const { HOST, ENVIRONMENT } = Cypress.env()
 const dbUrl = dbURL.bind(null, HOST)
 
 describe('Data Browser 2019', function () {
-  if(isCI(ENVIRONMENT)) it("Does not run on CI")
-  else if(!isBeta(HOST)){
+  if(!isProd(HOST)) it("Only runs in Production")
+  else {
     it('State/Institution/PropertyType', function () {
       cy.get({ HOST, ENVIRONMENT }).logEnv()
       cy.viewport(1000, 940)
@@ -172,7 +172,5 @@ describe('Data Browser 2019', function () {
         })
       }
     })
-  } else {
-    it(`does not run on host: ${HOST}`)
   }
 })

--- a/src/common/environmentChecks.js
+++ b/src/common/environmentChecks.js
@@ -1,0 +1,1 @@
+export const isCI = () => process.env.REACT_APP_ENVIRONMENT === 'CI'

--- a/src/common/useRemoteJSON.jsx
+++ b/src/common/useRemoteJSON.jsx
@@ -27,8 +27,10 @@ export function useRemoteJSON(sourceUrl, options = {}) {
 
     fetch(sourceUrl)
       .then((response) => {
-        if (hasHttpError(response)) return Promise.reject(response)
-        return response.json()
+        return hasHttpError(response).then(res => {
+          if(res) return Promise.reject(response)
+          return response.json()
+        })
       })
       .then((json) => {
         if (options.transformReceive) setData(options.transformReceive(json))

--- a/src/tools/rate-spread/CSVUpload.jsx
+++ b/src/tools/rate-spread/CSVUpload.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import fileSaver from 'file-saver'
 import LoadingIcon from '../../common/LoadingIcon.jsx'
 import Alert from '../../common/Alert.jsx'
+import { isCI } from '../../common/environmentChecks'
 import Heading from '../../common/Heading.jsx'
 import runFetch from './runFetch.js'
 
@@ -64,7 +65,7 @@ class CSVUpload extends Component {
     event.target.value = null
 
     this.onCSVFetch()
-    const CSV_URL = '/public/rateSpread/csv'
+    const CSV_URL = (isCI() ? '' : 'https://ffiec.cfpb.gov') + '/public/rateSpread/csv'
     runFetch(CSV_URL, this.prepareCSVBody(file), true).then(res => {
       this.onCSVCalculated(res, file)
     })

--- a/src/tools/rate-spread/Form.jsx
+++ b/src/tools/rate-spread/Form.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import LoadingIcon from '../../common/LoadingIcon.jsx'
 import Alert from '../../common/Alert.jsx'
+import { isCI } from '../../common/environmentChecks'
 import Heading from '../../common/Heading.jsx'
 import runFetch from './runFetch.js'
 
@@ -175,7 +176,7 @@ class Form extends Component {
       if (errs.rateSetDate || errs.APR || errs.loanTerm) return
 
       this.onFetch()
-      const API_URL = '/public/rateSpread'
+      const API_URL = (isCI() ? '' : 'https://ffiec.cfpb.gov') + '/public/rateSpread'
       runFetch(API_URL, this.prepareBodyFromState()).then(res => {
         this.onCalculated(res)
       })


### PR DESCRIPTION
Closes #829
Closes #905

## Changes
- [Cypress] Only run Data Browser 2018/2019 against Production
- [Rate Spread] Only use local API in CI
- [External Config] Fix bug that prevented remotely hosted config files from updating the UI.
 
This is currently deployed to `Dev` as `v1.2.15-pre2`, testing looks good 👍🏽 
![Screen Shot 2021-04-09 at 1 14 06 PM](https://user-images.githubusercontent.com/2592907/114229775-86464280-9935-11eb-9633-3d0f98ef5376.png)
