### PR TITLE
[DynamicDatasets] Remove Panel documentation links

### DIFF
--- a/src/data-publication/reports/DynamicDataset.jsx
+++ b/src/data-publication/reports/DynamicDataset.jsx
@@ -17,8 +17,8 @@ function makeListLink(href, val) {
 function linkToDocs(year = '2018'){
   return [
     <li key="0"><a href={`/documentation/${year}/public-lar-schema/`}>Public LAR Schema</a></li>,
-    <li key="1"><a href={`/documentation/${year}/public-ts-schema/`}>Public Transmittal Sheet Schema</a></li>,
-    <li key="2"><a href={`/documentation/${year}/lar-data-fields/`}>Public HMDA Data Fields with Values and Definitions</a></li>,
+    <li key="1"><a href={`/documentation/${year}/lar-data-fields/`}>Public LAR Field Definitions and Values</a></li>,
+    <li key="2"><a href={`/documentation/${year}/public-ts-schema/`}>Public Transmittal Sheet Schema</a></li>,
   ]
 }
 

--- a/src/data-publication/reports/DynamicDataset.jsx
+++ b/src/data-publication/reports/DynamicDataset.jsx
@@ -18,11 +18,10 @@ function linkToDocs(year = '2018'){
   return [
     <li key="0"><a href={`/documentation/${year}/public-lar-schema/`}>Public LAR Schema</a></li>,
     <li key="1"><a href={`/documentation/${year}/public-ts-schema/`}>Public Transmittal Sheet Schema</a></li>,
-    <li key="2"><a href={`/documentation/${year}/public-panel-schema/`}>Public Panel Schema</a></li>,
-    <li key="3"><a href={`/documentation/${year}/lar-data-fields/`}>Public HMDA Data Fields with Values and Definitions</a></li>,
-    <li key="4"><a href={`/documentation/${year}/panel-data-fields/`}>Public Panel Values and Definitions</a></li>
+    <li key="2"><a href={`/documentation/${year}/lar-data-fields/`}>Public HMDA Data Fields with Values and Definitions</a></li>,
   ]
 }
+
 
 const DynamicDataset = props => {
   const { params, url } = props.match


### PR DESCRIPTION
Closes #916

- Removes extraneous file spec links for Panel
- Rewords and reorders file spec links for LAR files to better connect the two documents
<img width="848" alt="Screen Shot 2021-04-19 at 4 51 32 PM" src="https://user-images.githubusercontent.com/2592907/115313331-4bf85480-a130-11eb-9458-7348ba715821.png">
