### PR TITLE
[Documentation] Expound upon HMDA API section

### DIFF
--- a/src/documentation/Home.jsx
+++ b/src/documentation/Home.jsx
@@ -7,6 +7,7 @@ import FigLinks from './FigLinks.jsx'
 import Publications from './publications'
 import Tools from './tools'
 import { DOCS_YEARS } from '../common/constants/years.js'
+import Product from './Product.jsx'
 
 const Home = props => {
   const { year, url } = props
@@ -35,9 +36,14 @@ const Home = props => {
         <Tools year={year}/>
       </div>
       <div>
-        <h2>Other HMDA Documentation</h2>
+        <h2>HMDA APIs</h2>
+          <p>Endpoints, schemas, and examples to help you access HMDA Data via the HMDA APIs.</p>
           <ul>
-            <li><a target="_blank" rel="noopener noreferrer" href="https://cfpb.github.io/hmda-platform/">API Documentation</a></li>
+            <li><a target="_blank" rel="noopener noreferrer" href="https://cfpb.github.io/hmda-platform/">HMDA APIs - Overview</a></li>
+            <li><a target="_blank" rel="noopener noreferrer" href="https://cfpb.github.io/hmda-platform/#data-browser-api">HMDA Data Browser API</a></li>
+            <li><a target="_blank" rel="noopener noreferrer" href="https://cfpb.github.io/hmda-platform/#hmda-filing-api">HMDA Filing API</a></li>
+            <li><a target="_blank" rel="noopener noreferrer" href="https://cfpb.github.io/hmda-platform/#hmda-public-api">HMDA Public API</a></li>
+            <li><a target="_blank" rel="noopener noreferrer" href="https://cfpb.github.io/hmda-platform/#rate-spread">HMDA Rate Spread API</a></li>
           </ul>
       </div>
     </div>


### PR DESCRIPTION
Closes #914 

- Rebrands the `Other Documentation` section for the `HMDA APIs`
- Adds a short purpose description of the `HMDA APIs` section 
- Add more fine-grained links to to each API's section in the API Documentation site
<img width="642" alt="Screen Shot 2021-04-16 at 4 10 59 PM" src="https://user-images.githubusercontent.com/2592907/115088952-819e0300-9ece-11eb-9d30-fb410956a429.png">
