### PR TITLE
[Homepage] Indicate that users are access the HMDA Beta Filing Platform

### DIFF
--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -36,7 +36,7 @@ const Home = ({ config }) => {
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Access the HMDA Filing Platform
+                  Access the HMDA {isBeta() && 'Beta '} Filing Platform
                 </a>
               </h3>
               <p>


### PR DESCRIPTION
Closes #910 

- Adds the word `Beta` in Beta environments

<img width="445" alt="Screen Shot 2021-04-16 at 4 23 33 PM" src="https://user-images.githubusercontent.com/2592907/115089848-75b34080-9ed0-11eb-90c7-8afc4d62cc73.png">
