### PR TITLE
[Filing] More Informative Filing Summary page

### DIFF
--- a/src/common/ExternalLink.jsx
+++ b/src/common/ExternalLink.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const ExternalLink = ({ url, text, className }) => {
+  return <a
+    target='_blank'
+    rel='noopener noreferrer'
+    href={url}
+    className={'external link ' + className}
+  >
+    {text || url}
+  </a>
+}
+
+export default ExternalLink

--- a/src/common/OptionCarousel.css
+++ b/src/common/OptionCarousel.css
@@ -19,6 +19,12 @@
   width: 20px;
 }
 
+.oc-option.no-icon:before{
+  background: none;
+  border-radius: inherit;
+  content: '';
+}
+
 .oc-option:hover {
   cursor: pointer;
   background: #d8d2c3;

--- a/src/common/OptionCarousel.jsx
+++ b/src/common/OptionCarousel.jsx
@@ -10,7 +10,8 @@ export const OptionCarousel = ({ options, ...rest }) => {
     setIdx((idx + 1) % options.length)
   }
 
-  const classname = [rest.className, 'oc-option'].filter((x) => x).join(' ')
+  const noIcon = rest.noIcon ? 'no-icon' : ''
+  const classname = [rest.className, 'oc-option', noIcon].filter((x) => x).join(' ')
 
   return (
     <>

--- a/src/filing/submission/container.css
+++ b/src/filing/submission/container.css
@@ -12,6 +12,9 @@
   margin-bottom: 0;
 }
 
+/*
+* PRINT STYLES 
+*/
 @media print {
   #header .logo {
     width: auto;
@@ -34,6 +37,7 @@
   .RefileWarning .alert,
   #summary {
     margin-bottom: 0;
+    margin-top: 0;
     width: 100%;
   }
 

--- a/src/filing/submission/summary/Summary.css
+++ b/src/filing/submission/summary/Summary.css
@@ -1,5 +1,5 @@
 .Summary {
-  margin-top: 3em;
+  margin-top: 2em;
 }
 
 .Summary header {
@@ -9,11 +9,24 @@
 .Summary h2 {
   font-size: 3rem;
 }
-.Summary .font-lead {
+
+.Summary .info-section {
+  border-top: 1px solid #dadada;
+}
+
+.Summary .font-lead, 
+.Summary .info-section-lead {
   color: #323a45;
   margin-top: 0.5em;
   margin-bottom: 0;
 }
+
+.Summary .info-section-lead {
+  font-size: 1em;
+  color: #666;
+  margin: .75em 0 1.25em;
+}
+
 .Summary .info {
   margin: 2em 0;
 }

--- a/src/filing/submission/summary/Summary.css
+++ b/src/filing/submission/summary/Summary.css
@@ -2,16 +2,26 @@
   margin-top: 2em;
 }
 
+.Summary .flex {
+  display: flex;
+  align-items: flex-start;
+}
+
 .Summary header {
   max-width: 77rem;
-  margin-bottom: 2em;
+  margin-bottom: 0em;
 }
+
 .Summary h2 {
   font-size: 3rem;
 }
 
 .Summary .info-section {
   border-top: 1px solid #dadada;
+}
+
+.Summary .info-section h3 {
+  margin-top: .5em;
 }
 
 .Summary .font-lead, 
@@ -24,11 +34,19 @@
 .Summary .info-section-lead {
   font-size: 1em;
   color: #666;
-  margin: .75em 0 1.25em;
+  margin: .75em 0;
 }
 
-.Summary .info {
-  margin: 2em 0;
+.Summary .section-heading {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  background: #eee;
+  padding: 0 .5em;
+}
+
+.Summary .section-heading .info-section-lead {
+  margin-right: 1em;
 }
 
 .Summary dt {
@@ -37,4 +55,74 @@
 .Summary dd {
   margin-bottom: 1em;
   margin-left: 0;
+}
+
+.Summary .emphasize {
+  font-weight: bold;
+  margin: .75em 0 0;
+}
+
+.Summary .info .emphasize {
+  color: rgb(14, 136, 110);
+}
+
+.Summary .emphasize .point {
+  padding-right: .3em;
+  color: black;
+  font-style: normal;
+}
+
+.Summary .external.link {
+  text-decoration: none;
+}
+
+.Summary .external.link.dotted {
+  border-bottom: 2px dashed #777;
+  color: #666;
+  font-style: italic;
+}
+
+.Summary .external.link:hover,
+.Summary .external.link:focus {
+  color: rgb(22, 114, 175);
+  border-bottom-color: rgb(22, 114, 175);
+  border-bottom-width: 3px;
+}
+
+.Summary .note {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+
+.Summary .note .point {
+  width: 10px;
+  height: 10px;
+  margin: 0 10px 0 0;
+  font-size: 1.5em;
+}
+
+.Summary .info .note {
+  margin-bottom: 1em;
+}
+
+#summary header {
+  margin-bottom: 0em;
+}
+
+#summary dt,
+#summary dd {
+  padding-left: .5em;
+}
+
+/*
+* PRINT STYLES 
+*/
+@media print {
+  .Summary .section-heading {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+  }
 }

--- a/src/filing/submission/summary/Summary.css
+++ b/src/filing/submission/summary/Summary.css
@@ -63,7 +63,7 @@
 }
 
 .Summary .info .emphasize {
-  color: rgb(14, 136, 110);
+  color: #2e8540;
 }
 
 .Summary .emphasize .point {

--- a/src/filing/submission/summary/index.jsx
+++ b/src/filing/submission/summary/index.jsx
@@ -1,31 +1,53 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { splitYearQuarter } from '../../api/utils'
+import ExternalLink from '../../../common/ExternalLink'
 
 import './Summary.css'
 
+const tsSchemaLink = (year) => (
+  <ExternalLink
+    url={`/documentation/${year}/ts-data-fields/`}
+    text='Transmittal Sheet'
+    className='dotted'
+  />
+)
+
 const Summary = props => {
   if (!props.submission || !props.ts) return null
-  const quarter = splitYearQuarter(props.filingPeriod)[1]
+  const [year, quarter] = splitYearQuarter(props.filingPeriod)
 
   return (
-    <section className="Summary full-width" id="summary">
+    <section className='Summary full-width' id='summary'>
       <header>
         <h2>HMDA Filing Summary</h2>
-        <p className="font-lead">
+        <p className='font-lead'>
           You have completed the verification process for your HMDA data.
         </p>
-        <p className="font-lead">Please review your Respondent Information.</p>
+        <p className='font-lead'>
+          The values below come from your {tsSchemaLink(year)}, the first
+          row of your LAR file.
+        </p>
+        <p className='emphasize'>
+          Please review your Respondent Information and submit any necessary
+          corrections.
+        </p>
       </header>
-      <div className="info full-width">
-        <section className="usa-width-one-half info-section">
-          <h3>Respondent Information</h3>
-          <p className='info-section-lead'>
-            This information is pulled directly from the Transmittal Sheet
-            (first row) of your submitted LAR file. <b><em>If changes are needed, please
-            update your file's Transmittal Sheet and resubmit your data for{' '}
-            {props.filingPeriod}.</em></b>
+      <div className='info'>
+        <div className='note'>
+          <span className='point'>*</span>
+          <p className='emphasize'>
+            To make changes, update your Transmittal Sheet and resubmit
+            your data for {props.filingPeriod}.
           </p>
+        </div>        
+        <section className='info-section'>
+          <div className='section-heading'>
+            <h3>Respondent Information *</h3>
+            <p className='info-section-lead'>
+              Institution identifiers and contact details
+            </p>
+          </div>
           <dl>
             <dt>Name:</dt>
             <dd>{props.ts.institutionName}</dd>
@@ -34,35 +56,31 @@ const Summary = props => {
             <dt>Tax ID:</dt>
             <dd>{props.ts.taxId}</dd>
             <dt>Agency:</dt>
-            <dd className="text-uppercase">{props.ts.agency}</dd>
+            <dd className='text-uppercase'>{props.ts.agency}</dd>
             <dt>Contact Name:</dt>
             <dd>{props.ts.contact && props.ts.contact.name}</dd>
             <dt>Phone:</dt>
-            <dd>
-              {props.ts.contact && props.ts.contact.phone}
-            </dd>
+            <dd>{props.ts.contact && props.ts.contact.phone}</dd>
             <dt>Email</dt>
-            <dd>
-              {props.ts.contact && props.ts.contact.email}
-            </dd>
+            <dd>{props.ts.contact && props.ts.contact.email}</dd>
           </dl>
         </section>
-        <section className="usa-width-one-half info-section">
-          <h3>File Information</h3>
-          <p className='info-section-lead'>
-            This section provides a high-level summary of the data you've provided in your LAR file.
-          </p>
+        <section className='info-section'>
+          <div className='section-heading flex'>
+            <h3>File Information *</h3>
+            <p className='info-section-lead'>Filing Period details and LAR count</p>
+          </div>
           <dl>
             <dt>File Name:</dt>
             <dd>{props.submission.fileName}</dd>
             <dt>Year:</dt>
             <dd>{props.ts.year}</dd>
-            {quarter && 
+            {quarter && (
               <>
                 <dt>Quarter:</dt>
                 <dd>{quarter}</dd>
               </>
-            }
+            )}
             <dt>Total Loans/Applications:</dt>
             <dd>{props.ts.totalLines}</dd>
           </dl>

--- a/src/filing/submission/summary/index.jsx
+++ b/src/filing/submission/summary/index.jsx
@@ -13,13 +13,19 @@ const Summary = props => {
       <header>
         <h2>HMDA Filing Summary</h2>
         <p className="font-lead">
-          You have completed the verification process for your HMDA data. Please
-          review the respondent and file information below from your HMDA file.
+          You have completed the verification process for your HMDA data.
         </p>
+        <p className="font-lead">Please review your Respondent Information.</p>
       </header>
       <div className="info full-width">
-        <section className="usa-width-one-half">
+        <section className="usa-width-one-half info-section">
           <h3>Respondent Information</h3>
+          <p className='info-section-lead'>
+            This information is pulled directly from the Transmittal Sheet
+            (first row) of your submitted LAR file. <b><em>If changes are needed, please
+            update your file's Transmittal Sheet and resubmit your data for{' '}
+            {props.filingPeriod}.</em></b>
+          </p>
           <dl>
             <dt>Name:</dt>
             <dd>{props.ts.institutionName}</dd>
@@ -41,8 +47,11 @@ const Summary = props => {
             </dd>
           </dl>
         </section>
-        <section className="usa-width-one-half">
+        <section className="usa-width-one-half info-section">
           <h3>File Information</h3>
+          <p className='info-section-lead'>
+            This section provides a high-level summary of the data you've provided in your LAR file.
+          </p>
           <dl>
             <dt>File Name:</dt>
             <dd>{props.submission.fileName}</dd>


### PR DESCRIPTION
Closes #917 

### Changes
- Adds some separation between Respondent Info and File Info
- Adds section descriptions
- Respondent Info description indicates that users should update/resubmit LAR to apply RI changes.

<img width="842" alt="filing-summary" src="https://user-images.githubusercontent.com/2592907/116449633-9c9a3c80-a817-11eb-8445-93e5c7294775.png">
