### PR TITLE
Maps fixes

### DIFF
--- a/src/data-browser/maps/MapsGraphs.css
+++ b/src/data-browser/maps/MapsGraphs.css
@@ -157,6 +157,7 @@
   display: flex;
   flex-flow: column wrap;
   justify-content: space-evenly;
+  line-height: 1.25em;
   font-size: 1.1em;
 }
 
@@ -172,8 +173,9 @@
 }
 
 .maps-control-wrapper .filter-clause {
-  color: #777;
+  color: #555;
   font-weight: bold;
+  font-size: 16px;
 }
 
 

--- a/src/data-browser/maps/TextSelector.css
+++ b/src/data-browser/maps/TextSelector.css
@@ -5,7 +5,7 @@
   padding: 0em 1em;
   align-items: center;
   line-height: 1.25em;
-  font-size: 1.25em;
+  font-size: 16px;
   width: 100%;
   justify-content: flex-start;
 }

--- a/src/documentation/markdown/2018/data-browser-maps-faq.md
+++ b/src/documentation/markdown/2018/data-browser-maps-faq.md
@@ -26,7 +26,7 @@ The various color palettes (orange, red, purple, green, blue) are used to highli
 The data tables show the aggregated data for the selected filter variables.  
 
 - When only one filter is selected, you will be presented with a single table that includes a row for each option of the filter.  
-- When two filters are selected, another table will be displayed for the secon filter's data.  Additionally, a new set of columns will be included in each table to highlight the intersection between the selected filters.
+- When two filters are selected, another table will be displayed for the second filter's data.  Additionally, a new set of columns will be included in each table to highlight the intersection between the selected filters.
   
 |One Filter|Two Filters|
 |---|---|

--- a/src/documentation/markdown/2019/data-browser-maps-faq.md
+++ b/src/documentation/markdown/2019/data-browser-maps-faq.md
@@ -26,7 +26,7 @@ The various color palettes (orange, red, purple, green, blue) are used to highli
 The data tables show the aggregated data for the selected filter variables.  
 
 - When only one filter is selected, you will be presented with a single table that includes a row for each option of the filter.  
-- When two filters are selected, another table will be displayed for the secon filter's data.  Additionally, a new set of columns will be included in each table to highlight the intersection between the selected filters.
+- When two filters are selected, another table will be displayed for the second filter's data.  Additionally, a new set of columns will be included in each table to highlight the intersection between the selected filters.
   
 |One Filter|Two Filters|
 |---|---|

--- a/src/documentation/markdown/2020/data-browser-maps-faq.md
+++ b/src/documentation/markdown/2020/data-browser-maps-faq.md
@@ -26,7 +26,7 @@ The various color palettes (orange, red, purple, green, blue) are used to highli
 The data tables show the aggregated data for the selected filter variables.  
 
 - When only one filter is selected, you will be presented with a single table that includes a row for each option of the filter.  
-- When two filters are selected, another table will be displayed for the secon filter's data.  Additionally, a new set of columns will be included in each table to highlight the intersection between the selected filters.
+- When two filters are selected, another table will be displayed for the second filter's data.  Additionally, a new set of columns will be included in each table to highlight the intersection between the selected filters.
   
 |One Filter|Two Filters|
 |---|---|


### PR DESCRIPTION
Closes #993 

- Typo in Maps FAQ (secon => second)
- Fixes app crash when clearing the only selected filter
- More consistent font size and color in Maps control box

  | Before | After |  
  |--|--|
  |<img width="415" alt="before" src="https://user-images.githubusercontent.com/2592907/120544593-d4fae080-c3aa-11eb-831c-f5d76c0bc0ed.png">|<img width="415" alt="Screen Shot 2021-06-02 at 12 36 29 PM" src="https://user-images.githubusercontent.com/2592907/120544270-746ba380-c3aa-11eb-9b69-8b0fa620a1a4.png">|

