### PR TITLE
fix(docs): Remove year selector from Rate Spread docs

### DIFF
--- a/src/documentation/Product.jsx
+++ b/src/documentation/Product.jsx
@@ -4,10 +4,13 @@ import Heading from '../common/Heading.jsx'
 import YearSelector from '../common/YearSelector.jsx'
 import { DOCS_YEARS } from '../common/constants/years.js'
 
+export const excludeYearSelector = (slug) => ['check-digit', 'rate-spread'].indexOf(slug) > -1
+
 const Product = props => {
   let { list } = props
   const { heading, lead, inList, url, year, collection, slug } = props
   let header
+  
 
   if(!list || !list.length) {
     if(inList) return null
@@ -29,7 +32,7 @@ const Product = props => {
       <div className="intro">
         { header }
         { inList ? <p>{lead}</p> : null}
-        { inList || slug === 'check-digit' ? null : <YearSelector year={year} url={url} years={DOCS_YEARS} /> }
+        { inList || excludeYearSelector(slug) ? null : <YearSelector year={year} url={url} years={DOCS_YEARS} /> }
         { inList || slug === 'check-digit' ? null : <h4>Documentation</h4> }
         <ul>
           {list}


### PR DESCRIPTION
Closes #960 

Rate Spread documentation is not split by year, so no need to present year selection.

|Before|After|
|--|--|
|![Screen Shot 2021-06-02 at 3 06 06 PM](https://user-images.githubusercontent.com/2592907/120552993-2f993a00-c3b5-11eb-8a94-0ccd47d37cba.png)|![Screen Shot 2021-06-02 at 3 06 22 PM](https://user-images.githubusercontent.com/2592907/120552998-3162fd80-c3b5-11eb-8de2-434e5927ebde.png)|
