### PR TITLE
Update service.yaml

### DIFF
--- a/kubernetes/beta/hmda-frontend/templates/service.yaml
+++ b/kubernetes/beta/hmda-frontend/templates/service.yaml
@@ -8,7 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http


### PR DESCRIPTION
Error while using helm 3
helm.go:81: [debug] failed to replace object: Service "hmda-frontend-beta" is invalid: spec.clusterIP: Invalid value: "": field is immutable

## Changes

-

## Testing

1.


## Notes

-
