### PR TITLE
task(changelog): Agg Report 9 regeneration

### DIFF
--- a/src/data-publication/ChangeLog/change-log-data.json
+++ b/src/data-publication/ChangeLog/change-log-data.json
@@ -11,6 +11,16 @@
       "type": "correction",
       "product": "datasets",
       "description": "The LEI column header was incorrectly named 'upper' in the Reporter Panel file. We have corrected this so the column header displays the correct header name 'lei'."
+
+    },
+    {
+      "date": "06/29/21",
+      "type": "correction",
+      "product": "reports",
+      "description": "Aggregate Report \"Applications by Median Age of Homes\" has been regenerated for 2020 and 2019 in order to address an error in the data format, which was causing the UI to crash.",
+      "links": [
+        {"text": "HMDA Aggregate Reports", "url": "https://ffiec.cfpb.gov/data-publication/aggregate-reports/"}
+      ]
     },
     {
       "date": "06/17/21",


### PR DESCRIPTION
Closes #1021 

Adds a `Correction` to the Change Log, noting the regeneration of the Report 9 for 2019 & 2020.

<img width="1007" alt="Screen Shot 2021-06-29 at 10 04 16 AM" src="https://user-images.githubusercontent.com/2592907/123831495-a09f1500-d8c1-11eb-80b7-63136c362647.png">

