### PR TITLE
feat(help): autosearch for valid leis

### DIFF
--- a/src/hmda-help/search/FilersSelectBox.jsx
+++ b/src/hmda-help/search/FilersSelectBox.jsx
@@ -89,8 +89,10 @@ export const FilersSearchBox = ({ endpoint, onChange, year, ...rest }) => {
     const lengthCheck = cleanNoSpace.length
     if (lengthCheck < 20 && cleanNoSpace.match(/[0-9]$/)) // Could be an LEI but it's too short
       setValidationMsgs([{ type: 'error', text: 'LEI must be 20 characters' }])
-    else if (lengthCheck === 20) // If you're trying to enter an LEI, this is a correctly formatted LEI
+    else if (lengthCheck === 20) { // If you're trying to enter an LEI, this is a correctly formatted LEI
       setValidationMsgs([{ type: 'success', text: 'LEI (20 characters)' }])
+      handleSelection({ value: text, label: text }) // Automatically perform an Institution search
+    }
     else if (lengthCheck > 20)  // You're probably searching for an Institution name, but if you were trying to enter an LEI...
       setValidationMsgs([{ type: 'status', text: `Not an LEI: ${lengthCheck} characters` }])
     else

--- a/src/hmda-help/search/FilersSelectBox.jsx
+++ b/src/hmda-help/search/FilersSelectBox.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useState, useRef } from 'react'
+import React, { useLayoutEffect, useState } from 'react'
 import { createFilter } from 'react-select'
 import CreatableSelect from 'react-select/creatable'
 import { MenuList } from '../../data-browser/datasets/MenuList'
@@ -48,7 +48,6 @@ export const FilersSearchBox = ({ endpoint, onChange, year, ...rest }) => {
   const [selectedValue, setSelectedValue] = useState(null)
   const [isInitial, setIsInitial] = useState(true)
   const [validationMsgs, setValidationMsgs] = useState([])
-  const selectRef = useRef()
 
   const [data, isFetching, error] = useRemoteJSON(
     endpoint || `https://ffiec.cfpb.gov/v2/reporting/filers/${year}`,
@@ -93,7 +92,6 @@ export const FilersSearchBox = ({ endpoint, onChange, year, ...rest }) => {
     else if (lengthCheck === 20) { // If you're trying to enter an LEI, this is a correctly formatted LEI
       setValidationMsgs([{ type: 'success', text: 'LEI (20 characters)' }])
       handleSelection({ value: text, label: text }) // Automatically perform an Institution search
-      if(selectRef && selectRef.current) selectRef.current.blur()
     }
     else if (lengthCheck > 20)  // You're probably searching for an Institution name, but if you were trying to enter an LEI...
       setValidationMsgs([{ type: 'status', text: `Not an LEI: ${lengthCheck} characters` }])
@@ -107,7 +105,6 @@ export const FilersSearchBox = ({ endpoint, onChange, year, ...rest }) => {
     <>
       <ValidationStatus items={validationMsgs} />
       <CreatableSelect
-        ref={ref => selectRef.current = ref }
         id='lei-select'
         autoFocus
         openOnFocus

--- a/src/hmda-help/search/FilersSelectBox.jsx
+++ b/src/hmda-help/search/FilersSelectBox.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useState } from 'react'
+import React, { useLayoutEffect, useState, useRef } from 'react'
 import { createFilter } from 'react-select'
 import CreatableSelect from 'react-select/creatable'
 import { MenuList } from '../../data-browser/datasets/MenuList'
@@ -48,6 +48,7 @@ export const FilersSearchBox = ({ endpoint, onChange, year, ...rest }) => {
   const [selectedValue, setSelectedValue] = useState(null)
   const [isInitial, setIsInitial] = useState(true)
   const [validationMsgs, setValidationMsgs] = useState([])
+  const selectRef = useRef()
 
   const [data, isFetching, error] = useRemoteJSON(
     endpoint || `https://ffiec.cfpb.gov/v2/reporting/filers/${year}`,
@@ -92,6 +93,7 @@ export const FilersSearchBox = ({ endpoint, onChange, year, ...rest }) => {
     else if (lengthCheck === 20) { // If you're trying to enter an LEI, this is a correctly formatted LEI
       setValidationMsgs([{ type: 'success', text: 'LEI (20 characters)' }])
       handleSelection({ value: text, label: text }) // Automatically perform an Institution search
+      if(selectRef && selectRef.current) selectRef.current.blur()
     }
     else if (lengthCheck > 20)  // You're probably searching for an Institution name, but if you were trying to enter an LEI...
       setValidationMsgs([{ type: 'status', text: `Not an LEI: ${lengthCheck} characters` }])
@@ -105,6 +107,7 @@ export const FilersSearchBox = ({ endpoint, onChange, year, ...rest }) => {
     <>
       <ValidationStatus items={validationMsgs} />
       <CreatableSelect
+        ref={ref => selectRef.current = ref }
         id='lei-select'
         autoFocus
         openOnFocus


### PR DESCRIPTION
Closes #1018 

The HMDA Help search box will now automatically perform an Institution search when a correctly formatted LEI is entered. This addresses a gap in the pre-populated list of Institutions.

![hmda-help-autosearch](https://user-images.githubusercontent.com/2592907/124002206-b16b8b80-d992-11eb-9f70-a9e3a13d0420.gif)
