### PR TITLE
Open 2021-Q2

### DIFF
--- a/src/common/constants/dev-config.json
+++ b/src/common/constants/dev-config.json
@@ -9,11 +9,12 @@
       "text": "HMDA Data Publications page."
     }
   },
-  "defaultPeriod": "2021-Q1",
+  "defaultPeriod": "2021-Q2",
   "defaultDocsPeriod": "2021",
   "publicationReleaseYear": "2020",
   "mlarReleaseYear": "2020",
   "filingPeriods": [
+    "2021-Q2",
     "2021-Q1",
     "2020",
     "2020-Q3",

--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -5,11 +5,11 @@
     "type": "info",
     "heading": "Announcement"
   },
-  "defaultPeriod": "2021-Q1",
+  "defaultPeriod": "2021-Q2",
   "defaultDocsPeriod": "2021",
   "publicationReleaseYear": "2020",
   "filingPeriods": [
-    "2021",
+    "2021-Q2",
     "2021-Q1",
     "2020",
     "2020-Q3",

--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -9,6 +9,7 @@
   "defaultDocsPeriod": "2021",
   "publicationReleaseYear": "2020",
   "filingPeriods": [
+    "2021",
     "2021-Q2",
     "2021-Q1",
     "2020",

--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -9,11 +9,12 @@
       "text": "HMDA Data Publications page."
     }
   },
-  "defaultPeriod": "2021-Q1",
+  "defaultPeriod": "2021-Q2",
   "defaultDocsPeriod": "2021",
   "publicationReleaseYear": "2020",
   "mlarReleaseYear": "2020",
   "filingPeriods": [
+    "2021-Q2",
     "2021-Q1",
     "2020",
     "2020-Q3",


### PR DESCRIPTION
Closes #1026 

- Adds 2021-Q2 as an option in the Filing app
- Defaults the Filing app to the 2021-Q2 Filing Period
