### PR TITLE
Data Browser - Select All button

### DIFF
--- a/src/data-browser/constants/variables.js
+++ b/src/data-browser/constants/variables.js
@@ -204,7 +204,8 @@ function makeObj(label, definition) {
 
 function buildWithId(label, definition, list) {
   const obj = makeObj(label, definition)
-
+  obj.options.push({ id: 'all', name: 'Select All' })
+  
   list.forEach(o => {
     const nameWithId = `${o.id} - ${o.name}`
     obj.options.push({id: o.id, name: o.name})
@@ -216,7 +217,8 @@ function buildWithId(label, definition, list) {
 
 function buildEncoded(label, definition, list) {
   const obj = makeObj(label, definition)
-
+  obj.options.push({ id: 'all', name: 'Select All' })
+  
   list.forEach(name => {
     const id = encodeURIComponent(name)
     obj.options.push({ id, name })

--- a/src/data-browser/constants/variables.js
+++ b/src/data-browser/constants/variables.js
@@ -204,7 +204,6 @@ function makeObj(label, definition) {
 
 function buildWithId(label, definition, list) {
   const obj = makeObj(label, definition)
-  obj.options.push({ id: 'all', name: 'Select All' })
   
   list.forEach(o => {
     const nameWithId = `${o.id} - ${o.name}`
@@ -217,7 +216,6 @@ function buildWithId(label, definition, list) {
 
 function buildEncoded(label, definition, list) {
   const obj = makeObj(label, definition)
-  obj.options.push({ id: 'all', name: 'Select All' })
   
   list.forEach(name => {
     const id = encodeURIComponent(name)

--- a/src/data-browser/datasets/CheckboxContainer.jsx
+++ b/src/data-browser/datasets/CheckboxContainer.jsx
@@ -5,25 +5,7 @@ import DocLink from './DocLink.jsx'
 function renderCheckboxes(variable, vars, makeCb, year) {
   const variables = getVariables(year)
 
-  return variables[variable].options.map((v) => {
-    // Add a "Select/Unselect all" box that behaves a bit differently
-    if(v.id === 'all') { 
-      const allChecked =
-        Object.keys(vars[variable]).length &&
-        Object.keys(vars[variable]).every((x) => vars[variable][x])
-
-        return (
-          <button
-            className='CheckboxToggleBtn'
-            key={v.id}
-            onClick={makeCb(variable, v)}
-            id={variable + v.id}
-          >
-            {allChecked ? 'Clear Selected' : 'Select All'}
-          </button>
-        )
-    }
-
+  const boxes = variables[variable].options.map((v) => {
     return (
       <div className='CheckboxWrapper' key={v.id}>
         <input
@@ -36,6 +18,24 @@ function renderCheckboxes(variable, vars, makeCb, year) {
       </div>
     )
   })
+
+  const allChecked =
+    Object.keys(vars[variable]).length &&
+    Object.keys(vars[variable]).every((x) => vars[variable][x])
+
+  boxes.unshift(
+    // Add a button to Select/Clear all options for this variable
+    <button
+      className='CheckboxToggleBtn'
+      key={'all'}
+      onClick={makeCb(variable, {id: 'all'})}
+      id={variable + "-all"}
+    >
+      {allChecked ? 'Clear Selected' : 'Select All'}
+    </button>
+  )
+
+  return boxes
 }
 
 const CheckboxContainer = props => {

--- a/src/data-browser/datasets/CheckboxContainer.jsx
+++ b/src/data-browser/datasets/CheckboxContainer.jsx
@@ -4,7 +4,26 @@ import DocLink from './DocLink.jsx'
 
 function renderCheckboxes(variable, vars, makeCb, year) {
   const variables = getVariables(year)
+
   return variables[variable].options.map((v) => {
+    // Add a "Select/Unselect all" box that behaves a bit differently
+    if(v.id === 'all') { 
+      const allChecked =
+        Object.keys(vars[variable]).length &&
+        Object.keys(vars[variable]).every((x) => vars[variable][x])
+
+        return (
+          <button
+            className='CheckboxToggleBtn'
+            key={v.id}
+            onClick={makeCb(variable, v)}
+            id={variable + v.id}
+          >
+            {allChecked ? 'Clear Selected' : 'Select All'}
+          </button>
+        )
+    }
+
     return (
       <div className='CheckboxWrapper' key={v.id}>
         <input

--- a/src/data-browser/datasets/Geography.css
+++ b/src/data-browser/datasets/Geography.css
@@ -77,6 +77,10 @@ svg {
   margin-bottom: 5px;
 }
 
+.SelectWrapper .CheckboxToggleBtn:hover {
+  box-shadow: none;
+}
+
 .QueryButton {
   background-color: #0071bc;
   color: #fff;

--- a/src/data-browser/datasets/Geography.css
+++ b/src/data-browser/datasets/Geography.css
@@ -70,6 +70,13 @@ svg {
   cursor: pointer;
 }
 
+.CheckboxToggleBtn {
+  max-width: 50%;
+  padding: 5px;
+  margin-top: 0px;
+  margin-bottom: 5px;
+}
+
 .QueryButton {
   background-color: #0071bc;
   color: #fff;

--- a/src/data-browser/datasets/Geography.jsx
+++ b/src/data-browser/datasets/Geography.jsx
@@ -318,6 +318,7 @@ class Geography extends Component {
         const nextVal = !allChecked
         newState.variables[variable] = variables[variable].options.reduce(
           (acc, opt) => {
+            // Only create entries for options that are selected
             nextVal && opt.id !== 'all' && (acc[opt.id] = nextVal)
             return acc
           },

--- a/src/data-browser/datasets/Geography.jsx
+++ b/src/data-browser/datasets/Geography.jsx
@@ -307,7 +307,26 @@ class Geography extends Component {
         }
       }
 
-      if(!newState.variables[variable][subvar.id]) delete newState.variables[variable][subvar.id]
+      // Check/Uncheck all options for a variable
+      if (subvar.id === 'all') {
+        const allChecked =
+          Object.keys(this.state.variables[variable]).length &&
+          Object.keys(this.state.variables[variable]).every(
+            (key) => this.state.variables[variable][key]
+          )
+        const variables = getVariables(this.state.year)
+        const nextVal = !allChecked
+        newState.variables[variable] = variables[variable].options.reduce(
+          (acc, opt) => {
+            nextVal && opt.id !== 'all' && (acc[opt.id] = nextVal)
+            return acc
+          },
+          {}
+        )
+      } else if (!newState.variables[variable][subvar.id]){
+        // Clear a single option's checkbox
+        delete newState.variables[variable][subvar.id]
+      }
 
       const largeFile = this.checkIfLargeFile(this.state.category, this.state.items)
 


### PR DESCRIPTION
Closes #114 

Adds a button to each Filter option selector in the Data Browser to either "Select All" or 
Clear Selected".

![db-select-all-proto-3](https://user-images.githubusercontent.com/2592907/125521125-a8ba3099-ee2c-46a9-95f5-9d86cd58cc29.gif)
