### PR TITLE
Automate "Filing closed" banner

### DIFF
--- a/src/common/OptionCarousel.css
+++ b/src/common/OptionCarousel.css
@@ -1,3 +1,62 @@
+.oc {
+  position: relative;
+  user-select: all;
+}
+
+.oc .progress {
+  display: flex;
+  flex-flow: row nowrap;
+  position: absolute;
+  user-select: none;
+  top: 5px;
+  right: 5px;
+  z-index: 1;
+  border-radius: 5px;
+  background: rgba(153, 153, 153, .8); 
+}
+
+.oc .progress button {
+  cursor: default;
+  position:relative;
+  user-select: none;
+  margin: 0;
+  padding: 3px 6px;
+  background: none;
+  color: white;
+  border: 1px solid rgba(0,0,0,0)
+}
+
+.oc .progress button.clickable {
+  cursor: pointer;
+}
+
+.oc .progress button.clickable:hover,
+.oc .progress button.clickable:focus-visible { 
+  background: #DDD;
+  border: 1px solid darkgrey;
+  color: black;
+}
+
+.oc .progress button.pause svg {
+  width: 10px;
+  height: 10px;
+}
+
+.oc .progress button.pause svg * {
+  fill: white;
+  stroke: white;
+}
+
+.oc .progress button.pause:hover svg *,
+.oc .progress button.pause:focus-visible svg * {
+  fill: #000; 
+  stroke: black;
+}
+
+.oc .progress button.clickable:active {
+  background: #fff;
+}
+
 .oc-option {
   position: relative;
   user-select: none;
@@ -25,9 +84,9 @@
   content: '';
 }
 
-.oc-option:hover {
+.oc .clickable .oc-option:hover {
   cursor: pointer;
-  background: #d8d2c3;
+  background: #ccc;
 }
 
 .oc-option-custom {

--- a/src/common/OptionCarousel.jsx
+++ b/src/common/OptionCarousel.jsx
@@ -1,34 +1,84 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
+import { ReactComponent as IconPlay } from '../common/images/play.svg'
+import { ReactComponent as IconPause } from '../common/images/pause.svg'
 import './OptionCarousel.css'
 
-export const OptionCarousel = ({ options, ...rest }) => {
+/**
+ * A component to enable testing of potential changes in a live site by clicking to cycle through available options
+ * @param {Array} options Components/Elements to display as options
+ * @param {Boolean} showControls Display the navigation controls
+ * @param {Boolean} hideIcon Hide the icon marking these elements as part of the carousel
+ * @param {String} className Optional classname to add to carousel elements
+ * @param {Integer} cycleTime Number of seconds to wait before displaying the next option, if multiple options are passed. Setting this to 0 will turn off the auto advance behavior.
+ * @returns 
+ */
+export const OptionCarousel = ({
+  options = [],
+  showControls = true,
+  cycleTime = 2,
+  hideIcon = false,
+  className = '',
+  fixedHeight = 'auto'
+}) => {
   const [idx, setIdx] = useState(0)
-  const [custom, setCustom] = useState(false)
+  const [paused, setPaused] = useState(false)  // Auto-advance?
   if (!options || !options.length) return null
 
-  const next = () => {
-    setIdx((idx + 1) % options.length)
-  }
+  const hasMultiple = options.length > 1
+  const next = () => setIdx((idx + 1) % options.length)
+  const prev = () =>
+    setIdx(idx - 1 < 0 ? options.length - 1 : (idx - 1) % options.length)
 
-  const noIcon = rest.noIcon ? 'no-icon' : ''
-  const classname = [rest.className, 'oc-option', noIcon].filter((x) => x).join(' ')
+  let autoAdvance
+  useEffect(() => {
+    if (paused) {
+      autoAdvance && clearTimeout(autoAdvance)
+    } else {
+      if (!options.length) return null
+      const secs = parseInt(cycleTime)
+      if (hasMultiple && secs) {
+        autoAdvance = setTimeout(next, secs * 1000)
+        return () => clearTimeout(autoAdvance)
+      }
+    }
+  }, [idx, paused])
+
+  const hideIconClass = hideIcon ? 'no-icon' : ''
+  const classname = [className, 'oc-option', hideIconClass].filter((x) => x).join(' ')
+  const styles = { height: fixedHeight }
 
   return (
-    <>
-      {custom ? (
-        <CustomText />
-      ) : (
-        <span {...rest} className={classname} onClick={next}>
-          {options[idx]}
-        </span>
+    <div className='oc' style={styles}>
+      {showControls && hasMultiple && (
+        <div className='progress-wrapper'>
+          <div className={'progress'}>
+            <button
+              className='previous clickable'
+              onClick={prev}
+              title='Previous'
+            >
+              &lt;
+            </button>
+            <button className='count' tabIndex='-1'>
+              {idx + 1}/{options.length}
+            </button>
+            <button className='next clickable' onClick={next} title='Next'>
+              &gt;
+            </button>
+            <button
+              className='pause clickable'
+              title={paused ? 'Resume auto-advance' : 'Pause auto-advance'}
+              onClick={() => setPaused(!paused)}
+            >
+              <span className='svg icon'>
+                {paused ? <IconPlay /> : <IconPause />}
+              </span>
+            </button>
+          </div>
+        </div>
       )}
-    </>
+
+      <span className={classname}>{options[idx]}</span>
+    </div>
   )
-}
-
-
-const CustomText = () => {
-  const [value, setValue] = useState('')
-  const handleChange = e => setValue(e.target.value)
-  return <input type='text' className='oc-option-custom' value={value} onChange={handleChange} placeholder='Enter text of a custom option' />
 }

--- a/src/common/images/pause.svg
+++ b/src/common/images/pause.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.8 134.3" width="128" height="134"><style type="text/css">  
+	.st0{fill:#FFFFFF;stroke:#231F20;stroke-width:10;stroke-miterlimit:10;}
+	.st1{fill:#231F20;stroke:#231F20;stroke-width:5;stroke-miterlimit:10;}
+</style><switch transform="translate(-78.800003 -75.5)"><foreignObject requiredExtensions="http://ns.adobe.com/AdobeIllustrator/10.0/" width="1" height="1"/><g><g><g><rect x="81.3" y="78" class="st1" width="47.4" height="129.3"/><rect x="156.7" y="78" class="st1" width="47.4" height="129.3"/></g></g></g></switch></svg>

--- a/src/common/images/play.svg
+++ b/src/common/images/play.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 305.3 305.7" width="305" height="306"><style type="text/css">  
+	.st0{fill:none;stroke:#231F20;stroke-width:12;stroke-miterlimit:10;}
+	.st1{fill:#231F20;stroke:#231F20;stroke-width:10;stroke-linejoin:round;stroke-miterlimit:10;}
+</style><switch transform="translate(-4.8163139 -4.4752959)"><foreignObject requiredExtensions="http://ns.adobe.com/AdobeIllustrator/10.0/" width="1" height="1"/><polygon class="st1" points="248.7 157.3 108 238.6 108 76.1 " transform="matrix(2.0255613 0 0 1.7724679 -203.8165 -121.54782)"/></switch></svg>

--- a/src/filing/utils/date.js
+++ b/src/filing/utils/date.js
@@ -108,3 +108,9 @@ const openForPreview = (period, filingQuarters) => {
   if(!previewPeriods) return false
   return previewPeriods.indexOf(period) > -1
 }
+
+export const numDaysBetween = function(d1, d2) {
+  var diff = Math.abs(d1.getTime() - d2.getTime());
+  const daysDiff = diff / (1000 * 60 * 60 * 24)
+  return daysDiff
+};

--- a/src/homepage/AnnouncementBanner.jsx
+++ b/src/homepage/AnnouncementBanner.jsx
@@ -1,0 +1,171 @@
+import React from 'react'
+import ConfiguredAlert from '../common/ConfiguredAlert'
+import {
+  formattedQtrBoundaryDate,
+  numDaysBetween,
+  qtrBoundaryDate,
+} from '../filing/utils/date.js'
+import { splitYearQuarter } from '../filing/api/utils.js'
+import { OptionCarousel } from '../common/OptionCarousel'
+
+const TIMEZONE_OFFSET_HOURS = new Date().getTimezoneOffset() / 60
+
+/* Length of time, in days, to display the announcement after the event has occurred. */
+const SCHEDULED_EVENT_DURATIONS = {
+  annualOpen: 45,    // Annual Filing period is open.
+  annualClose: 30,   // Annual Filing Timely deadline is passed.  Resubmissions still accepted.
+  quarterlyOpen: 30, // Quarterly Filing period is open.
+  quarterlyClose: 0, // Quarterly Filing period is closed (no message)
+}
+
+/**
+ * Create a UTC timestamp for the given day/month/year at 11:59:59pm
+ * @param {Object} dayMonthObj
+ * @param {Number} dayMonthObj.day // Day of month (1-31)
+ * @param {Number} dayMonthObj.month // JS Month (0-11)
+ * @returns Number
+ */
+const getDeadline = (dayMonthObj) => {
+  return Date.UTC(
+    new Date().getFullYear(),
+    dayMonthObj.month,
+    dayMonthObj.day,
+    23 + TIMEZONE_OFFSET_HOURS,
+    59,
+    59
+  )
+}
+
+/**
+ * Check if an event's occurrence was within SCHEDULED_EVENT_DURATIONS[evt] number of days
+ * @param {String} eventId
+ * @param {Object} dayMonth
+ * @param {Number} dayMonth.day Day of month (1-31)
+ * @param {Number} dayMonth.month Javascript Month (0-11)
+ * @returns Boolean
+ */
+const isEventWithinRange = (eventId, dayMonth) => {
+  const deadline = getDeadline(dayMonth)
+  const diff = numDaysBetween(new Date(), new Date(deadline))
+  return diff < SCHEDULED_EVENT_DURATIONS[eventId]
+}
+
+/**
+ * Formatted String of currently available Annual filing periods
+ * ex. "2018 - 2020"
+ * @param {Array} filingPeriods
+ * @returns String
+ */
+const availableAnnualRange = (filingPeriods) => {
+  const annualPeriods = filingPeriods
+    .filter((x) => x.indexOf('Q') === -1)
+    .sort()
+  return annualPeriods[0] + ' - ' + annualPeriods[annualPeriods.length - 1]
+}
+
+/**
+ * Create Alerts for all current Filing period events
+ * @param {String} defaultPeriod Current Filing period
+ * @param {Object} filingQuarters Date ranges for which Filing periods are accessible
+ * @returns Array[ConfiguredAlert]
+ */
+const scheduledFilingAnnouncements = (
+  defaultPeriod,
+  filingQuarters,
+  filingPeriods
+) => {
+  const [year, quarter] = splitYearQuarter(defaultPeriod)
+  const annualFilingYear = parseInt(year) - 1
+  const announcements = []
+  let startDate, endDate
+
+  /*** Quarterly Filing Announcements ***/
+  
+  // Only display Quarterly announcements during Quarterly Filing periods
+  if (quarter) {
+    startDate = qtrBoundaryDate(quarter, filingQuarters, 0)
+    endDate = qtrBoundaryDate(quarter, filingQuarters, 1)
+
+    // Quarterly Filing Open
+    if (isEventWithinRange('quarterlyOpen', startDate)) {
+      const quarterlyDeadline = formattedQtrBoundaryDate(quarter, filingQuarters, 1) + `, ${year}`
+
+      announcements.push(
+        <ConfiguredAlert
+          heading={`${defaultPeriod} Quarterly filing period is open`}
+          message={`Submissions of ${defaultPeriod} HMDA data will be accepted through ${quarterlyDeadline}.`}
+          type='success'
+        />
+      )
+    }
+  }
+
+  /*** Annual Filing Announcements ***/
+  
+  // Annual announcements may overlap with Quarterly announcements, so we will always check for these.
+  startDate = qtrBoundaryDate('ANNUAL', filingQuarters, 0)
+  endDate = qtrBoundaryDate('ANNUAL', filingQuarters, 1)
+
+  // Annual Filing Open
+  if (isEventWithinRange('annualOpen', startDate)) {
+    const annualDeadline = formattedQtrBoundaryDate('ANNUAL', filingQuarters, 1) + `, ${year}`
+    announcements.push(
+      <ConfiguredAlert
+        heading={`${annualFilingYear} Annual filing period is open`}
+        message={`Submissions of ${annualFilingYear} HMDA data will be considered timely if received on or before ${annualDeadline}. `}
+        type='success'
+      />
+    )
+  }
+
+  // Annual Filing Resubmission period
+  if (isEventWithinRange('annualClose', endDate)) {
+    announcements.push(
+      <ConfiguredAlert
+        heading={`${annualFilingYear} Annual filing period is closed`}
+        message={`The HMDA Platform remains available outside of the filing period for late submissions and resubmissions of ${availableAnnualRange(
+          filingPeriods
+        )} HMDA data.`}
+        type='info'
+      />
+    )
+  }
+
+  return announcements
+}
+
+/**
+ * Display scheduled and configured Announcements on the HMDA Homepage.
+ * Scheduled announcements are defined in this file.
+ * Configured announcements are injected from the external environment config.
+ * @param {Object} announcement
+ * @param {String} defaultPeriod
+ * @param {Object} filingQuarters
+ * @returns
+ */
+export const AnnouncementBanner = ({
+  announcement,
+  defaultPeriod,
+  filingQuarters,
+  filingPeriods,
+}) => {
+  // Collect all scheduled announcements
+  const announcements = scheduledFilingAnnouncements(defaultPeriod, filingQuarters, filingPeriods)
+
+  // Prioritize the message set in the external configuration
+  if (announcement) announcements.unshift(<ConfiguredAlert {...announcement} />)
+
+  // Display an auto-advancing, navigable carousel of announcements
+  return (
+    <OptionCarousel
+      id='oc-homepage-banner'
+      options={announcements}
+      cycleTime={5}
+      hideIcon
+      showControls
+      fixedHeight='100px'
+    />
+  )
+}
+
+export default AnnouncementBanner

--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { isBeta } from '../common/Beta.jsx'
 import { withAppContext } from '../common/appContextHOC'
-import ConfiguredAlert from '../common/ConfiguredAlert'
-
+import { AnnouncementBanner } from './AnnouncementBanner'
 import './Home.css'
 
 export function isProd() {
@@ -12,7 +11,7 @@ export function isProd() {
 
 const Home = ({ config }) => {
   const isProdBeta = isProd() && isBeta()
-  const { announcement, defaultPeriod, publicationReleaseYear, mlarReleaseYear } = config
+  const { defaultPeriod, publicationReleaseYear, mlarReleaseYear } = config
 
   return (
     <main className="App home" id="main-content">
@@ -24,7 +23,7 @@ const Home = ({ config }) => {
             publicly disclose information about mortgages.
           </p>
         </header>
-        {announcement && <ConfiguredAlert {...announcement} />}
+        <AnnouncementBanner {...config} />
       </div>
       <div style={{marginTop: '3em'}} className="usa-grid-full">
         <div className="card-container">


### PR DESCRIPTION
Closes #869 

## Changes
This PR adds a banner carousel that enables us to display multiple announcements on the HMDA homepage, in a compact space.  The carousel includes auto and manual-advance functionality, as well as the ability to pause the auto-advance. 

Additionally, we've added the ability to configure scheduled announcements.  This is designed to address the pain point of having to manually change the homepage banner to notify users about the the open/close of both Annual and Quarterly filing periods.  This will operate by displaying the following message types for the corresponding number of days:

```
const SCHEDULED_EVENT_DURATIONS = {
  annualOpen: 45,    // Annual Filing period is open.
  annualClose: 30,   // Annual Filing Timely deadline is passed.  Resubmissions still accepted.
  quarterlyOpen: 30, // Quarterly Filing period is open.
  quarterlyClose: 0, // Quarterly Filing period is closed (no message)
}
```
 
Finally, we will continue to incorporate the announcement from the external [environment config file](https://github.com/cfpb/hmda-frontend/blob/master/src/common/constants/prod-config.json).  This PR assumes the dynamic message that we set in the environment config file is the most pertinent to our users and so it will always be displayed first in the carousel, ahead of any scheduled announcements. i.e. A data release announcement will take precedence over a 'Filing period is closed' message.
 
## Demo
https://user-images.githubusercontent.com/2592907/127040723-b5bb762a-2f2d-4c6a-a319-2d2561831fee.mov

