### PR TITLE
fix(databrowser): Remove option ID from all displayed instances

### DIFF
--- a/cypress/integration/data-browser/2018.spec.js
+++ b/cypress/integration/data-browser/2018.spec.js
@@ -62,7 +62,7 @@ describe('Data Browser 2018', function () {
 
       // Variables
       cy.get('#VariableSelector').type('lien{enter}')
-      cy.findByText('1 - Secured By First Lien').click()
+      cy.findByText('Secured By First Lien').click()
       cy.url().should('include', '&lien_statuses=1')
 
       // View Summary Table
@@ -73,7 +73,7 @@ describe('Data Browser 2018', function () {
         cy.wrap(text).should('contain', 'bank of america')
         cy.wrap(text).should('contain', 'chase bank')
       })
-      cy.get('.Aggregations :nth-child(2) > .sublist > li').should('have.text', '1 - Secured By First Lien')
+      cy.get('.Aggregations :nth-child(2) > .sublist > li').should('have.text', 'Secured By First Lien')
       cy.get('.Error').should('not.exist')
 
       // Test validity of download link
@@ -161,7 +161,7 @@ describe('Data Browser 2018', function () {
         cy.wrap(text).should('contain', 'bank of america')
         cy.wrap(text).should('contain', 'chase bank')
       })    
-      cy.get('.Aggregations :nth-child(3) > .sublist > li').should('have.text', '1 - Conventional')
+      cy.get('.Aggregations :nth-child(3) > .sublist > li').should('have.text', 'Conventional')
       cy.get('.Error').should('not.exist')
 
       // Test validity of download link

--- a/cypress/integration/data-browser/2019.spec.js
+++ b/cypress/integration/data-browser/2019.spec.js
@@ -63,7 +63,7 @@ describe('Data Browser 2019', function () {
   
       // Variables
       cy.get('#VariableSelector').type("lien status{enter}")
-      cy.findByText('1 - Secured By First Lien').click()
+      cy.findByText('Secured By First Lien').click()
       cy.url().should('include', '&lien_statuses=1')
   
       // View Summary Table
@@ -74,7 +74,7 @@ describe('Data Browser 2019', function () {
         cy.wrap(text).should('contain', 'bank of america')
         cy.wrap(text).should('contain', 'chase bank')
       })
-      cy.get('.Aggregations :nth-child(2) > .sublist > li').should('have.text', '1 - Secured By First Lien')
+      cy.get('.Aggregations :nth-child(2) > .sublist > li').should('have.text', 'Secured By First Lien')
       cy.get('.Error').should('not.exist')
   
       // Test validity of download link
@@ -150,7 +150,7 @@ describe('Data Browser 2019', function () {
   
       // Variables
       cy.get('#VariableSelector').type("loan type{enter}")
-      cy.findByText('1 - Conventional').click()
+      cy.findByText('Conventional').click()
       cy.url().should('include', '&loan_types=1')
   
       // View Summary Table
@@ -162,7 +162,7 @@ describe('Data Browser 2019', function () {
         cy.wrap(text).should('contain', 'bank of america')
         cy.wrap(text).should('contain', 'chase bank')
       })
-      cy.get('.Aggregations :nth-child(3) > .sublist > li').should('have.text', '1 - Conventional')
+      cy.get('.Aggregations :nth-child(3) > .sublist > li').should('have.text', 'Conventional')
       cy.get('.Error').should('not.exist')
   
       // Test validity of download link

--- a/src/data-browser/constants/variables.js
+++ b/src/data-browser/constants/variables.js
@@ -206,9 +206,8 @@ function buildWithId(label, definition, list) {
   const obj = makeObj(label, definition)
   
   list.forEach(o => {
-    const nameWithId = `${o.id} - ${o.name}`
     obj.options.push({id: o.id, name: o.name})
-    obj.mapping[o.id] = nameWithId
+    obj.mapping[o.id] = o.name
   })
 
   return obj


### PR DESCRIPTION
Closes #1047 

In the HMDA Data Browser, we previously removed the numeric Option ID from the checkbox label, but did not make the change consistent across the other page elements that display the label. This PR corrects that inconsistency in both the UI and the Cypress tests.

|before|after|
|--|--|
|<img width="473" alt="Screen Shot 2021-07-26 at 2 40 43 PM" src="https://user-images.githubusercontent.com/2592907/127056514-24b4df17-32a2-4691-8e92-58aa9b3d04ce.png">|<img width="474" alt="Screen Shot 2021-07-26 at 2 41 00 PM" src="https://user-images.githubusercontent.com/2592907/127056533-0e25d4b3-a7e1-4e66-98fb-71a907ce7bb4.png">|
