### PR TITLE
feat: Additional visual cues for Production environment

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -375,3 +375,11 @@ input[type='submit']:visited:disabled:active {
   background-color: #d6d7d9;
   color: #ffffff;
 }
+
+.nowrap {
+  white-space: nowrap;
+}
+
+.bold {
+  font-weight: bold;
+}

--- a/src/common/Alert.css
+++ b/src/common/Alert.css
@@ -120,6 +120,16 @@
   margin-bottom: 0
 }
 
+.alert .official {
+  font-weight: bold;
+  border-bottom: 2px solid #02bfe7;
+}
+
+.alert .simulated {
+  font-weight: bold;
+  border-bottom: 2px solid #fdb81e;
+}
+
 @media (min-width: 801px){
   .alert-text > .failed {
     width: 80%;

--- a/src/common/Alert.css
+++ b/src/common/Alert.css
@@ -120,16 +120,6 @@
   margin-bottom: 0
 }
 
-.alert .official {
-  font-weight: bold;
-  border-bottom: 2px solid #02bfe7;
-}
-
-.alert .simulated {
-  font-weight: bold;
-  border-bottom: 2px solid #fdb81e;
-}
-
 @media (min-width: 801px){
   .alert-text > .failed {
     width: 80%;

--- a/src/filing/common/Header.jsx
+++ b/src/filing/common/Header.jsx
@@ -7,6 +7,7 @@ import BannerUSA from '../../common/BannerUSA.jsx'
 
 import './Header.css'
 import logo from '../images/ffiec-logo.svg'
+import { isBeta } from '../../common/Beta';
 
 export const addActiveClass = (selected, current) => {
   if (selected === current) return 'active'
@@ -70,6 +71,7 @@ export const makeNav = (props, page) => {
 
 const Header = props => {
   const page = props.pathname.split('/').slice(-1)[0]
+  const platformLabel = isBeta() ? 'Beta' : 'Filing'
 
   return (
     <header className="Header header header-basic" id="header" role="banner">
@@ -84,7 +86,7 @@ const Header = props => {
               aria-label="Home"
             >
               <img src={logo} height="32px" alt="FFIEC" />
-              <span>HMDA Filing Platform</span>
+              <span>HMDA {platformLabel} Platform</span>
             </Link>
           </span>
         </div>

--- a/src/filing/institutions/HeaderOpen.jsx
+++ b/src/filing/institutions/HeaderOpen.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { formattedQtrBoundaryDate } from '../utils/date'
 import Alert from '../../common/Alert'
 import { HeaderDocsLink } from './Header'
+import { isBeta } from '../../common/Beta'
 
 export const HeaderOpen = ({
   filingQtr,
@@ -13,6 +14,18 @@ export const HeaderOpen = ({
   const filingDeadline = filingQtr
     ? `${formattedQtrBoundaryDate(filingQtr, filingQuarters, 1)}, ${filingYear}`
     : `${formattedQtrBoundaryDate("ANNUAL", filingQuarters, 1)}, ${+filingYear + 1}`
+
+  const officialOrSimulated = isBeta() ? (
+    <>
+      You may <span className="simulated">simulate filing of HMDA data</span> for
+      your authorized institutions below.
+    </>
+  ) : (
+    <>
+      You may <span className="official">file official HMDA data</span> for your
+      authorized institutions below.
+    </>
+  );
 
   return (
     <Alert>
@@ -43,7 +56,8 @@ export const HeaderOpen = ({
         <p className="font-lead">
           <HeaderDocsLink filingYear={filingYear} isQuarter={filingQtr} />
           <br />
-          You may file HMDA data for your authorized institutions below.
+          <br />
+          {officialOrSimulated}
         </p>
       </div>
     </Alert>

--- a/src/filing/institutions/HeaderOpen.jsx
+++ b/src/filing/institutions/HeaderOpen.jsx
@@ -57,6 +57,17 @@ export const HeaderOpen = ({
           <HeaderDocsLink filingYear={filingYear} isQuarter={filingQtr} />
           <br />
           <br />
+          {!isBeta() && (
+            <>
+              The{" "}
+              <a href="https://ffiec.beta.cfpb.gov/filing" target="_blank">
+                HMDA Beta Platform
+              </a>{" "}
+              is available to test your HMDA data prior to official submission.
+            </>
+          )}
+          <br />
+          <br />
           {officialOrSimulated}
         </p>
       </div>

--- a/src/filing/institutions/ViewButton.jsx
+++ b/src/filing/institutions/ViewButton.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import RefileButton from '../refileButton/container.jsx'
+import { isBeta } from '../../common/Beta';
 
 import {
   FAILED,
@@ -22,7 +23,7 @@ const InstitutionViewButton = ({ status, institution, filingPeriod, isClosedQuar
   if (code === FAILED) {
     return <RefileButton className="ViewButton" institution={institution} />
   } else if (code <= CREATED) {
-    text = 'Upload your file'
+    text = "Upload your " + (isBeta() ? 'test file' : 'official file')
   } else if (code < PARSED_WITH_ERRORS) {
     text = 'View upload progress'
   } else if (code === PARSED_WITH_ERRORS) {

--- a/src/filing/modals/Modal.css
+++ b/src/filing/modals/Modal.css
@@ -58,6 +58,21 @@
   transition: visibility 0.2s, opacity 0.2s;
 }
 
+.modal .inline {
+  display: flex;
+  flex-flow: nowrap;
+  justify-content: space-between;
+}
+
+.modal h3.notice {
+  margin: 1em 1.25em 0 0;
+  color: red;
+}
+
+.modal .red {
+  color: red;
+}
+
 div.showing-blurred-blocker {
   visibility: visible;
   opacity: 1;

--- a/src/filing/modals/confirmationModal/RefileText.css
+++ b/src/filing/modals/confirmationModal/RefileText.css
@@ -11,8 +11,3 @@
   letter-spacing: 0;
   color: red;
 }
-
-.RefileText .notice-wrapper {
-  display: flex;
-  flex-wrap: nowrap;
-}

--- a/src/filing/modals/confirmationModal/RefileText.css
+++ b/src/filing/modals/confirmationModal/RefileText.css
@@ -1,3 +1,18 @@
 .RefileText .question {
   margin-bottom: 1em;
 }
+
+.RefileText .emphasized {
+  font-weight: bolder;
+  letter-spacing: 1px;
+}
+
+.RefileText .emphasized.urgent {
+  letter-spacing: 0;
+  color: red;
+}
+
+.RefileText .notice-wrapper {
+  display: flex;
+  flex-wrap: nowrap;
+}

--- a/src/filing/modals/confirmationModal/RefileText.jsx
+++ b/src/filing/modals/confirmationModal/RefileText.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { VALIDATING, SIGNED } from '../../constants/statusCodes.js'
+import { isBeta } from '../../../common/Beta.jsx'
 
 import './RefileText.css'
 
@@ -19,30 +20,62 @@ export const getStatus = code => {
   }
 
   const message = status ? (
-    <p>
-      The HMDA data for this filing year <strong>{status}</strong>
-      {appendComplete}.
-    </p>
-  ) : null
+    <>
+      <br />
+      <p>
+        The HMDA data for this filing year <strong>{status}</strong>
+        {appendComplete}.
+      </p>
+    </>
+  ) : null;
 
   return message
 }
 
-const RefileText = props => {
+const BetaInfoBlock = () => (
+  <>
+    <span className="notice-wrapper">
+      <p className="usa-font-lead">
+        <b className='emphasized urgent'>Note: </b>Official HMDA data must be submitted on the live{" "}
+        <a href="https://ffiec.cfpb.gov" target="_blank">
+          HMDA Platform.
+        </a>
+      </p>
+    </span>
+    <br />
+  </>
+);
+
+const WarningDataWillBeDeleted = () =>
+  !isBeta() && (
+    <>
+      <br />
+      <span className="notice-wrapper">
+        <p className="usa-font-lead">
+          If you choose to proceed, your previously submitted HMDA data
+          <br />
+          <span className="emphasized urgent">
+            will be deleted and cannot be recovered.
+          </span>
+        </p>
+      </span>
+    </>
+  );
+
+const RefileText = (props) => {
+  const dataOfficialVsTest = isBeta() ? "HMDA test data" : "official HMDA data";
+
   return (
     <div className="RefileText">
+      {isBeta() && <BetaInfoBlock />}
       <p className="usa-font-lead">
-        Are you sure you want to replace your HMDA data for this filing?
-      </p>
-      <br />
-      <p className="usa-font-lead">
-        If you choose to proceed, your previously submitted HMDA data<br/>
-        <b>will be deleted and cannot be recovered.</b>
+        Are you sure you want to replace your {dataOfficialVsTest} for this filing?
       </p>
       {getStatus(props.code)}
+      <WarningDataWillBeDeleted />
     </div>
-  )
-}
+  );
+};
 
 RefileText.propTypes = {
   code: PropTypes.number.isRequired

--- a/src/filing/modals/confirmationModal/RefileText.jsx
+++ b/src/filing/modals/confirmationModal/RefileText.jsx
@@ -34,6 +34,11 @@ const RefileText = props => {
       <p className="usa-font-lead">
         Are you sure you want to replace your HMDA data for this filing?
       </p>
+      <br />
+      <p className="usa-font-lead">
+        If you choose to proceed, your previously submitted HMDA data<br/>
+        <b>will be deleted and cannot be recovered.</b>
+      </p>
       {getStatus(props.code)}
     </div>
   )

--- a/src/filing/modals/confirmationModal/RefileText.jsx
+++ b/src/filing/modals/confirmationModal/RefileText.jsx
@@ -72,7 +72,7 @@ const RefileText = (props) => {
       <p className="usa-font-lead">
         Are you sure you want to replace your {dataOfficialVsTest} for this filing?
       </p>
-      {getStatus(code, filingPeriod)}
+      {!isBeta() && getStatus(code, filingPeriod)}
       <WarningDataWillBeDeleted 
         institution={institution} 
         filingPeriod={filingPeriod}

--- a/src/filing/modals/confirmationModal/RefileText.jsx
+++ b/src/filing/modals/confirmationModal/RefileText.jsx
@@ -5,25 +5,25 @@ import { isBeta } from '../../../common/Beta.jsx'
 
 import './RefileText.css'
 
-export const getStatus = code => {
+export const getStatus = (code, filingPeriod) => {
   let status
   let appendComplete = null
 
   if (code > VALIDATING) {
     status = 'is in progress'
-    if (code === SIGNED) status = 'has already been submitted'
+    if (code === SIGNED) status = 'has already been submitted.'
   }
 
   if (code === SIGNED) {
     appendComplete =
-      ' and your new HMDA file will not be submitted until you clear and/or verify all edits and submit the data'
+      ' Resubmissions are not complete until you clear and/or verify all edits and submit the signed replacement data'
   }
 
   const message = status ? (
     <>
       <br />
       <p>
-        The HMDA data for this filing year <strong>{status}</strong>
+        HMDA data for <strong>{filingPeriod} {status}</strong>
         {appendComplete}.
       </p>
     </>
@@ -46,23 +46,24 @@ const BetaInfoBlock = () => (
   </>
 );
 
-const WarningDataWillBeDeleted = () =>
+const WarningDataWillBeDeleted = ({ institution, filingPeriod }) =>
   !isBeta() && (
     <>
       <br />
       <span className="notice-wrapper">
         <p className="usa-font-lead">
-          If you choose to proceed, your previously submitted HMDA data
-          <br />
-          <span className="emphasized urgent">
-            will be deleted and cannot be recovered.
-          </span>
+          The previously submitted {filingPeriod} HMDA data for{" "}
+          <span className="bold">{institution.name} </span>
+          <span className="emphasized urgent nowrap">
+            will be deleted and cannot be recovered
+          </span> if you choose to proceed.
         </p>
       </span>
     </>
   );
 
 const RefileText = (props) => {
+  const { institution, code, filingPeriod } = props
   const dataOfficialVsTest = isBeta() ? "HMDA test data" : "official HMDA data";
 
   return (
@@ -71,8 +72,11 @@ const RefileText = (props) => {
       <p className="usa-font-lead">
         Are you sure you want to replace your {dataOfficialVsTest} for this filing?
       </p>
-      {getStatus(props.code)}
-      <WarningDataWillBeDeleted />
+      {getStatus(code, filingPeriod)}
+      <WarningDataWillBeDeleted 
+        institution={institution} 
+        filingPeriod={filingPeriod}
+      />
     </div>
   );
 };

--- a/src/filing/modals/confirmationModal/container.jsx
+++ b/src/filing/modals/confirmationModal/container.jsx
@@ -18,13 +18,17 @@ export function mapStateToProps(state) {
   const { code } = state.app.submission.status
   const { newFile } =
     state.app.upload[lei] || state.app.upload['__DEFAULT_UPLOAD__']
+  const institution = lei && 
+    state.app.institutions.fetched && 
+    state.app.institutions.institutions[lei]
 
   return {
     lei,
     filingPeriod,
     code,
     showing,
-    newFile
+    newFile,
+    institution
   }
 }
 

--- a/src/filing/modals/confirmationModal/index.jsx
+++ b/src/filing/modals/confirmationModal/index.jsx
@@ -59,7 +59,7 @@ export default class ModalConfirm extends Component {
 
     if (!filingPeriod || !lei || !hideConfirmModal || !triggerRefile) return null
 
-    const dataOfficialVsTest = isBeta() ? 'HMDA test' : 'offical HMDA'
+    const dataOfficialVsTest = isBeta() ? 'HMDA test' : 'official HMDA'
 
     const headerOfficialVsTest = isBeta() 
       ? <h3 className="notice test">For Testing Purposes Only</h3> 

--- a/src/filing/modals/confirmationModal/index.jsx
+++ b/src/filing/modals/confirmationModal/index.jsx
@@ -52,6 +52,7 @@ export default class ModalConfirm extends Component {
       newFile,
       hideConfirmModal,
       triggerRefile,
+      institution
     } = this.props
 
     // get the page
@@ -78,7 +79,11 @@ export default class ModalConfirm extends Component {
           </span>
           <hr />
           <div className="modal-contents">
-            <RefileText code={code} />
+            <RefileText
+              code={code}
+              filingPeriod={filingPeriod}
+              institution={institution}
+            />
             <button
               tabIndex={showing ? 0 : -1}
               onClick={e => {

--- a/src/filing/modals/confirmationModal/index.jsx
+++ b/src/filing/modals/confirmationModal/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import RefileText from './RefileText.jsx'
+import { isBeta } from '../../../common/Beta.jsx'
 
 import '../Modal.css'
 
@@ -58,6 +59,12 @@ export default class ModalConfirm extends Component {
 
     if (!filingPeriod || !lei || !hideConfirmModal || !triggerRefile) return null
 
+    const dataOfficialVsTest = isBeta() ? 'HMDA test' : 'offical HMDA'
+
+    const headerOfficialVsTest = isBeta() 
+      ? <h3 className="notice test">For Testing Purposes Only</h3> 
+      : <h3 className="notice official">Official Submission</h3>
+
     return (
       <div
         className={
@@ -65,7 +72,10 @@ export default class ModalConfirm extends Component {
         }
       >
         <section role="dialog" className="modal">
-          <h2>Upload a new file?</h2>
+          <span className="inline space-between">
+            <h2>Upload a new file?</h2>
+            {headerOfficialVsTest}
+          </span>
           <hr />
           <div className="modal-contents">
             <RefileText code={code} />
@@ -82,7 +92,7 @@ export default class ModalConfirm extends Component {
               }}
               ref={button => (this.confirmButton = button)}
             >
-              Yes, replace HMDA data.
+              Yes, replace {dataOfficialVsTest} data.
             </button>
             <button
               tabIndex={showing ? 0 : -1}

--- a/src/filing/submission/ReadyToSign.jsx
+++ b/src/filing/submission/ReadyToSign.jsx
@@ -10,7 +10,7 @@ const SubmissionPageInfo = ({ isPassedQuarter }) => {
     content = <div>The filing deadline has passed. New signings are no longer accepted.</div>
   } else {
     type = 'info'
-    heading = 'Your filing is ready to be signed and submitted'
+    heading = 'Your official filing is ready to be signed and submitted'
     content = (
       <div>
         Please review your filing summary and sign your filing at the bottom of

--- a/src/filing/submission/signature/index.jsx
+++ b/src/filing/submission/signature/index.jsx
@@ -4,7 +4,7 @@ import ErrorWarning from '../../common/ErrorWarning.jsx'
 import Loading from '../../../common/LoadingIcon.jsx'
 import { VALIDATED, NO_MACRO_EDITS, SIGNED } from '../../constants/statusCodes.js'
 import Alert from '../../../common/Alert.jsx'
-
+import { isBeta } from '../../../common/Beta.jsx'
 import './Signature.css'
 
 const showWarning = props => {
@@ -64,10 +64,9 @@ const Signature = props => {
       <header>
         <h2>Signature</h2>
         <p className="font-lead">
-          To complete your submission, select the checkbox below. Next,
-          select the &quot;Submit HMDA data&quot; button to practice
-          submitting data. When the filing period opens, selecting the checkbox
-          will certify the accuracy and completeness of the data submitted.
+          To complete your official regulatory submission, select the checkbox below to certify the
+          accuracy and completeness of the data submitted. Then, click the
+          &quot;Submit HMDA data&quot; button.
         </p>
       </header>
 
@@ -87,7 +86,7 @@ const Signature = props => {
           />
           <label htmlFor="signatureAuth">
             I am an authorized representative of my institution with knowledge of
-            the data submitted and am certifying to the accuracy and completeness
+            the data submitted and I am certifying the accuracy and completeness
             of the data submitted.
           </label>
         </li>

--- a/src/filing/submission/signature/index.jsx
+++ b/src/filing/submission/signature/index.jsx
@@ -4,7 +4,6 @@ import ErrorWarning from '../../common/ErrorWarning.jsx'
 import Loading from '../../../common/LoadingIcon.jsx'
 import { VALIDATED, NO_MACRO_EDITS, SIGNED } from '../../constants/statusCodes.js'
 import Alert from '../../../common/Alert.jsx'
-import { isBeta } from '../../../common/Beta.jsx'
 import './Signature.css'
 
 const showWarning = props => {


### PR DESCRIPTION
Closes #1055 

- Site Header: Indicate 'Beta Platform' vs 'Filing Platform'
- Banner: Add link to Beta platform in the Production filing banner
- Upload: Provide additional details of the ramifications when uploading a file which will replace a previous submission. Include institution name and the filing period for the current submission. 
- Signing: Simplify the language around the signing of a submission 


# Site Header
|prod|beta|
|--|--|
|<img width="382" alt="Screen Shot 2021-08-10 at 4 14 17 PM" src="https://user-images.githubusercontent.com/2592907/128942068-4e72e197-56fd-4005-baf7-a912f38b5717.png">|<img width="376" alt="Screen Shot 2021-08-10 at 4 14 43 PM" src="https://user-images.githubusercontent.com/2592907/128942084-b3c5091a-3fda-4d77-8afd-1da688b47b34.png">|


# Banner
|prod|beta|
|--|--|
| <img width="743" alt="prod-banner" src="https://user-images.githubusercontent.com/2592907/128941081-645f322d-c3b4-43ec-be83-30a2e4113530.png">|banner not show in Beta|
 
# Upload
||prod|beta|
|--|--|--|
|Button label|<img width="737" alt="official-upload-button" src="https://user-images.githubusercontent.com/2592907/128786504-b072dbe0-ce31-4339-ad9d-3358d8589590.png">|<img width="734" alt="beta-upload-button" src="https://user-images.githubusercontent.com/2592907/128786525-b09e7b51-a671-462f-9c1b-dd230b924fc7.png">|
|w/o status msg|<img width="649" alt="official-no-status" src="https://user-images.githubusercontent.com/2592907/128786385-85e2a17a-ef71-4134-85fc-0e7c776fcb36.png">|<img width="651" alt="beta-no-status" src="https://user-images.githubusercontent.com/2592907/128786391-13a5084f-9675-41c3-a31b-9f03c9d88ca5.png">|
|with status msg|<img width="649" alt="official-status" src="https://user-images.githubusercontent.com/2592907/128786349-d0029039-24c7-455c-9386-7b529b26054a.png">|<img width="651" alt="beta-no-status" src="https://user-images.githubusercontent.com/2592907/128786391-13a5084f-9675-41c3-a31b-9f03c9d88ca5.png">|

# Signing - language
|before|after|
|--|--|
|<img width="810" alt="Screen Shot 2021-08-10 at 4 13 07 PM" src="https://user-images.githubusercontent.com/2592907/128941813-0c7512b7-99a6-41b1-bd1d-990779fe3786.png">|<img width="801" alt="Screen Shot 2021-08-10 at 4 13 16 PM" src="https://user-images.githubusercontent.com/2592907/128941826-44a5c3ec-8edd-4d6d-b927-697dd60bc3fb.png">|




