### PR TITLE
fix: Documentation formatting

### DIFF
--- a/src/documentation/markdown/2017/panel-data-fields.md
+++ b/src/documentation/markdown/2017/panel-data-fields.md
@@ -30,7 +30,7 @@
   |**9**|_CFPB_|Consumer Financial Protection Bureau|
 
 ### [id\_2017](#id_2017)
-- **Description:** This identifier is used in naming modified LAR files for <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/data-publication/modified-lar/2017">Data Publication - Modified LAR 2017</a>
+- **Description:** The 2017 HMDA Platform primary identifier for an institution. This identifier is used in the naming of <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/data-publication/modified-lar/2017">2017 Modified LAR</a> files.
 - **Values:**
   - Varying values
 

--- a/src/documentation/markdown/2017/panel-data-fields.md
+++ b/src/documentation/markdown/2017/panel-data-fields.md
@@ -35,7 +35,7 @@
   - Varying values
 
 ### [arid\_2017](#arid_2017)
-- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, take the arid_2017 column from the 2018 panel and use this to join to the concatenation of the agency code and respondent ID in the 2017 panel. Respondent ID in 2017 and prior is not a unique value and must be joined to agency code to generate a primary key for the HMDA dataset. For 2018 and forward, LEI will be the primary key. For more information on institution identifiers, please see the <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2020/identifiers-faq/">Institution Identifiers FAQ</a>
+- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, take the arid\_2017 column from the 2018 panel and use this to join to the concatenation of the agency code and respondent ID in the 2017 panel. Respondent ID in 2017 and prior is not a unique value and must be joined to agency code to generate a primary key for the HMDA dataset. For 2018 and forward, LEI will be the primary key. For more information on institution identifiers, please see the <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2020/identifiers-faq/">Institution Identifiers FAQ</a>
 - **Values:**
   - Varying values
 

--- a/src/documentation/markdown/2018/panel-data-fields.md
+++ b/src/documentation/markdown/2018/panel-data-fields.md
@@ -29,7 +29,7 @@
   |**9**|_CFPB_|Consumer Financial Protection Bureau|
 
 ### [id\_2017](#id_2017)
-- **Description:** The 2017 HMDA Platform primary identifier for an institution. This identifier is used in naming modified LAR files for <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/data-publication/modified-lar/2017">Data Publication - Modified LAR 2017</a>
+- **Description:** The 2017 HMDA Platform primary identifier for an institution. This identifier is used in the naming of <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/data-publication/modified-lar/2017">2017 Modified LAR</a> files.
 - **Values:**
   - Varying values
 

--- a/src/documentation/markdown/2019/panel-data-fields.md
+++ b/src/documentation/markdown/2019/panel-data-fields.md
@@ -29,7 +29,7 @@
   |**9**|_CFPB_|Consumer Financial Protection Bureau|
 
 ### [id\_2017](#id_2017)
-- **Description:** The 2017 HMDA Platform primary identifier for an institution. This identifier is used in naming modified LAR files for <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/data-publication/modified-lar/2017">Data Publication - Modified LAR 2017</a>
+- **Description:** The 2017 HMDA Platform primary identifier for an institution. This identifier is used in the naming of <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/data-publication/modified-lar/2017">2017 Modified LAR</a> files.
 - **Values:**
   - Varying values
 

--- a/src/documentation/markdown/2020/panel-data-fields.md
+++ b/src/documentation/markdown/2020/panel-data-fields.md
@@ -29,7 +29,7 @@
   |**9**|_CFPB_|Consumer Financial Protection Bureau|
 
 ### [id\_2017](#id_2017)
-- **Description:** The 2017 HMDA Platform primary identifier for an institution. This identifier is used in naming modified LAR files for <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/data-publication/modified-lar/2017">Data Publication - Modified LAR 2017</a>
+- **Description:** The 2017 HMDA Platform primary identifier for an institution. This identifier is used in the naming of <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/data-publication/modified-lar/2017">2017 Modified LAR</a> files.
 - **Values:**
   - Varying values
 

--- a/src/documentation/markdown/2021/panel-data-fields.md
+++ b/src/documentation/markdown/2021/panel-data-fields.md
@@ -29,7 +29,7 @@
   |**9**|_CFPB_|Consumer Financial Protection Bureau|
 
 ### [id\_2017](#id_2017)
-- **Description:** The 2017 HMDA Platform primary identifier for an institution. This identifier is used in naming modified LAR files for <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/data-publication/modified-lar/2017">Data Publication - Modified LAR 2017</a>
+- **Description:** The 2017 HMDA Platform primary identifier for an institution. This identifier is used in the naming of <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/data-publication/modified-lar/2017">2017 Modified LAR</a> files.
 - **Values:**
   - Varying values
 


### PR DESCRIPTION
Closes #1062 

- Fixes an unescaped underscore, which was causing an anchor tag to be mis-rendered
- Removes a hyphen in an anchor label, which was causing an additional paragraph tag to be rendered, resulting in the anchor being incorrectly placed on a new line.

|before|after|
|--|--|
|<img width="949" alt="Screen Shot 2021-08-10 at 5 32 01 PM" src="https://user-images.githubusercontent.com/2592907/128948951-ad1d4681-0f22-476d-a5c9-b3a307a619a2.png">|<img width="942" alt="Screen Shot 2021-08-10 at 5 34 38 PM" src="https://user-images.githubusercontent.com/2592907/128948957-d0f422de-3c76-43f7-a3cd-d8d0c5089a8a.png">|
