### PR TITLE
Enable multiple configured homepage announcements

### DIFF
--- a/src/common/OptionCarousel.css
+++ b/src/common/OptionCarousel.css
@@ -1,6 +1,6 @@
 .oc {
   position: relative;
-  user-select: all;
+  user-select: text;
 }
 
 .oc .progress {
@@ -59,7 +59,7 @@
 
 .oc-option {
   position: relative;
-  user-select: none;
+  user-select: text;
 }
 
 .oc-option.inline {

--- a/src/homepage/AnnouncementBanner.jsx
+++ b/src/homepage/AnnouncementBanner.jsx
@@ -12,9 +12,9 @@ const TIMEZONE_OFFSET_HOURS = new Date().getTimezoneOffset() / 60
 
 /* Length of time, in days, to display the announcement after the event has occurred. */
 const SCHEDULED_EVENT_DURATIONS = {
-  annualOpen: 45,    // Annual Filing period is open.
+  annualOpen: 60,    // Annual Filing period is open.
   annualClose: 30,   // Annual Filing Timely deadline is passed.  Resubmissions still accepted.
-  quarterlyOpen: 30, // Quarterly Filing period is open.
+  quarterlyOpen: 60, // Quarterly Filing period is open.
   quarterlyClose: 0, // Quarterly Filing period is closed (no message)
 }
 
@@ -153,7 +153,19 @@ export const AnnouncementBanner = ({
   const announcements = scheduledFilingAnnouncements(defaultPeriod, filingQuarters, filingPeriods)
 
   // Prioritize the message set in the external configuration
-  if (announcement) announcements.unshift(<ConfiguredAlert {...announcement} />)
+  if (announcement) {
+    if (Array.isArray(announcement)) {
+      // Support multiple unscheduled announcements
+      announcement.length && announcement
+        .reverse()
+        .forEach((item) =>
+          announcements.unshift(<ConfiguredAlert {...item} />)
+        )
+    } else if (announcement) {
+      // Single announcement object (maintenance script)
+      announcements.unshift(<ConfiguredAlert {...announcement} />);
+    }
+  }
 
   // Display an auto-advancing, navigable carousel of announcements
   return (


### PR DESCRIPTION
Closes #1074 

- Allows multiple announcements to be configured via external configuration files (i.e. prod-config.json, dev-config.json)
- Extends the number of days for which we show "X filing period is open" to 60 days
- CSS adjustment to allow announcement banner text to be user-selectable.

Note: This PR is a precursor to publishing the extended downtime announcement banner. 
 
Example of single announcement config:
```
  "announcement":  {
      "message": "On June 17, 2021, the Disclosure Reports, MSA/MD Aggregate Reports, Snapshot National Loan-Level dataset, and Dynamic National Loan-Level dataset for 2020 were released. These files are accessible from the ",
      "type": "info",
      "heading": "Data Publication Release",
      "link": {
        "url": "https://ffiec.cfpb.gov/data-publication/",
        "text": "HMDA Data Publications page."
      }
    }
```

Example of multiple announcement config:
```
  "announcement": [
    {
      "message": "On Friday, the weekend will begin.",
      "type": "warning",
      "heading": "The Weekend is Coming"
    },
    {
      "message": "On June 17, 2021, the Disclosure Reports, MSA/MD Aggregate Reports, Snapshot National Loan-Level dataset, and Dynamic National Loan-Level dataset for 2020 were released. These files are accessible from the ",
      "type": "info",
      "heading": "Data Publication Release",
      "link": {
        "url": "https://ffiec.cfpb.gov/data-publication/",
        "text": "HMDA Data Publications page."
      }
    }
  ],
```