### PR TITLE
Announce Extended Downtime

### DIFF
--- a/src/common/constants/dev-config.json
+++ b/src/common/constants/dev-config.json
@@ -1,14 +1,21 @@
 {
   "name": "dev",
-  "announcement": {
-    "message": "On June 17, 2021, the Disclosure Reports, MSA/MD Aggregate Reports, Snapshot National Loan-Level dataset, and Dynamic National Loan-Level dataset for 2020 were released. These files are accessible from the ",
-    "type": "info",
-    "heading": "Announcement",
-    "link": {
-      "url": "https://ffiec.cfpb.gov/data-publication/",
-      "text": "HMDA Data Publications page."
+  "announcement": [
+    {
+      "message": "The HMDA Filing application will be unavailable from August 31st through September 10th while we perform scheduled system maintenance.  During this time users will be unable to login, submit, or view HMDA data via the Filing application.  Data Browser, Data Publications, Tools, and Documentation will not be affected and will remain accessible during this maintenance window.",
+      "type": "warning",
+      "heading": "Scheduled Maintenance (Aug 31 - Sept 10)"
+    },
+    {
+      "message": "On June 17, 2021, the Disclosure Reports, MSA/MD Aggregate Reports, Snapshot National Loan-Level dataset, and Dynamic National Loan-Level dataset for 2020 were released. These files are accessible from the ",
+      "type": "info",
+      "heading": "Data Publication Release",
+      "link": {
+        "url": "https://ffiec.cfpb.gov/data-publication/",
+        "text": "HMDA Data Publications page."
+      }
     }
-  },
+  ],
   "defaultPeriod": "2021-Q2",
   "defaultDocsPeriod": "2021",
   "publicationReleaseYear": "2020",
@@ -41,7 +48,11 @@
   },
   "showMaps": true,
   "maintenanceMode": false,
-  "filingAnnouncement": null,
+  "filingAnnouncement": {
+    "message": "The HMDA Filing application will be unavailable from August 31st through September 10th while we perform scheduled system maintenance.  During this time users will be unable to login, submit, or view HMDA data via the Filing application.  Data Browser, Data Publications, Tools, and Documentation will not be affected and will remain accessible during this maintenance window.",
+    "type": "warning",
+    "heading": "Scheduled Maintenance (Aug 31 - Sept 10)"
+  },
   "dataPublicationYears": {
     "shared": [
       "2020",

--- a/src/common/constants/dev-config.json
+++ b/src/common/constants/dev-config.json
@@ -2,7 +2,7 @@
   "name": "dev",
   "announcement": [
     {
-      "message": "The HMDA Filing application will be unavailable from August 31st through September 10th while we perform scheduled system maintenance.  During this time users will be unable to login, submit, or view HMDA data via the Filing application.  Data Browser, Data Publications, Tools, and Documentation will not be affected and will remain accessible during this maintenance window.",
+      "message": "Submission and Re-submission of HMDA files will be unavailable 8/31 to 9/10. All other HMDA services will function normally.",
       "type": "warning",
       "heading": "Scheduled Maintenance (Aug 31 - Sept 10)"
     },
@@ -49,7 +49,7 @@
   "showMaps": true,
   "maintenanceMode": false,
   "filingAnnouncement": {
-    "message": "The HMDA Filing application will be unavailable from August 31st through September 10th while we perform scheduled system maintenance.  During this time users will be unable to login, submit, or view HMDA data via the Filing application.  Data Browser, Data Publications, Tools, and Documentation will not be affected and will remain accessible during this maintenance window.",
+    "message": "Submission and Re-submission of HMDA test files will be unavailable 8/31 to 9/10. All other HMDA services will function normally.",
     "type": "warning",
     "heading": "Scheduled Maintenance (Aug 31 - Sept 10)"
   },

--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -1,14 +1,21 @@
 {
   "name": "prod-beta",
-  "announcement": {
-    "message": "This month, we are testing new updates to the Beta platform. Outages may intermittently occur during this time. Please note that the Beta platform is for testing purposes only. Send any feedback or questions regarding your Beta platform usage experience to ",
-    "type": "info",
-    "heading": "Announcement",
-    "link": {
-      "url": "mailto:hmdahelp@cfpb.gov?subject=HMDA Beta Platform",
-      "text": "hmdahelp@cfpb.gov."
+  "announcement": [
+    {
+      "message": "This month, we are testing new updates to the Beta platform. Outages may intermittently occur during this time. Please note that the Beta platform is for testing purposes only. Send any feedback or questions regarding your Beta platform usage experience to ",
+      "type": "info",
+      "heading": "Announcement",
+      "link": {
+        "url": "mailto:hmdahelp@cfpb.gov?subject=HMDA Beta Platform",
+        "text": "hmdahelp@cfpb.gov."
+      }
+    },
+    {
+      "message": "Submission and Re-submission of HMDA test files will be unavailable 8/31 to 9/10. All other HMDA services will function normally.",
+      "type": "warning",
+      "heading": "Scheduled Maintenance (Aug 31 - Sept 10)"
     }
-  },
+  ],
   "defaultPeriod": "2021-Q2",
   "defaultDocsPeriod": "2021",
   "publicationReleaseYear": "2020",
@@ -41,7 +48,11 @@
   },
   "showMaps": true,
   "maintenanceMode": false,
-  "filingAnnouncement": null,
+  "filingAnnouncement": {
+    "message": "Submission and Re-submission of HMDA test files will be unavailable 8/31 to 9/10. All other HMDA services will function normally.",
+    "type": "warning",
+    "heading": "Scheduled Maintenance (Aug 31 - Sept 10)"
+  },
   "dataPublicationYears": {
     "shared": [
       "2020",

--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -2,7 +2,7 @@
   "name": "prod",
   "announcement": [
     {
-      "message": "The HMDA Filing application will be unavailable from August 31st through September 10th while we perform scheduled system maintenance.  During this time users will be unable to login, submit, or view HMDA data via the Filing application.  Data Browser, Data Publications, Tools, and Documentation will not be affected and will remain accessible during this maintenance window.",
+      "message": "Submission and Re-submission of HMDA files will be unavailable 8/31 to 9/10. All other HMDA services will function normally.",
       "type": "warning",
       "heading": "Scheduled Maintenance (Aug 31 - Sept 10)"
     },
@@ -46,7 +46,7 @@
   "showMaps": true,
   "maintenanceMode": false,
   "filingAnnouncement": {
-    "message": "The HMDA Filing application will be unavailable from August 31st through September 10th while we perform scheduled system maintenance.  During this time users will be unable to login, submit, or view HMDA data via the Filing application.  Data Browser, Data Publications, Tools, and Documentation will not be affected and will remain accessible during this maintenance window.",
+    "message": "Submission and Re-submission of HMDA test files will be unavailable 8/31 to 9/10. All other HMDA services will function normally.",
     "type": "warning",
     "heading": "Scheduled Maintenance (Aug 31 - Sept 10)"
   },

--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -1,14 +1,21 @@
 {
   "name": "prod",
-  "announcement": {
-    "message": "On June 17, 2021, the Disclosure Reports, MSA/MD Aggregate Reports, Snapshot National Loan-Level dataset, and Dynamic National Loan-Level dataset for 2020 were released. These files are accessible from the ",
-    "type": "info",
-    "heading": "Announcement",
-    "link": {
-      "url": "https://ffiec.cfpb.gov/data-publication/",
-      "text": "HMDA Data Publications page."
+  "announcement": [
+    {
+      "message": "The HMDA Filing application will be unavailable from August 31st through September 10th while we perform scheduled system maintenance.  During this time users will be unable to login, submit, or view HMDA data via the Filing application.  Data Browser, Data Publications, Tools, and Documentation will not be affected and will remain accessible during this maintenance window.",
+      "type": "warning",
+      "heading": "Scheduled Maintenance (Aug 31 - Sept 10)"
+    },
+    {
+      "message": "On June 17, 2021, the Disclosure Reports, MSA/MD Aggregate Reports, Snapshot National Loan-Level dataset, and Dynamic National Loan-Level dataset for 2020 were released. These files are accessible from the ",
+      "type": "info",
+      "heading": "Data Publication Release",
+      "link": {
+        "url": "https://ffiec.cfpb.gov/data-publication/",
+        "text": "HMDA Data Publications page."
+      }
     }
-  },
+  ],
   "defaultPeriod": "2021-Q2",
   "defaultDocsPeriod": "2021",
   "publicationReleaseYear": "2020",
@@ -38,7 +45,11 @@
   },
   "showMaps": true,
   "maintenanceMode": false,
-  "filingAnnouncement": null,
+  "filingAnnouncement": {
+    "message": "The HMDA Filing application will be unavailable from August 31st through September 10th while we perform scheduled system maintenance.  During this time users will be unable to login, submit, or view HMDA data via the Filing application.  Data Browser, Data Publications, Tools, and Documentation will not be affected and will remain accessible during this maintenance window.",
+    "type": "warning",
+    "heading": "Scheduled Maintenance (Aug 31 - Sept 10)"
+  },
   "dataPublicationYears": {
     "shared": [
       "2020",


### PR DESCRIPTION
Closes #1076 

<strike>Note: Dependent on the deployment of changes in #1074</strike> (Complete ✅ )

Adds banners announcing the extended downtime to both the HMDA homepage and the Filing app, for Prod and Beta environments.

## Homepage
  
<img width="979" alt="homepage-banner" src="https://user-images.githubusercontent.com/2592907/129950255-5a458f74-a454-4812-9351-044447629cf5.png">

## Filing application
  
<img width="1049" alt="filing-banner" src="https://user-images.githubusercontent.com/2592907/129950275-15863c0e-a171-48fc-856e-9895622d95d6.png">


## Beta Filing app
<img width="1052" alt="beta-filing-banner" src="https://user-images.githubusercontent.com/2592907/129950288-852c1bd9-5af6-42bd-b7aa-35e1f2c39d0f.png">

