### PR TITLE
fix: Update maintenance banner logic

### DIFF
--- a/src/MaintenanceMessage.css
+++ b/src/MaintenanceMessage.css
@@ -18,7 +18,6 @@
 
 #maintenance-message .closer {
   line-height: 20px;
-  display: none;
   margin: 0;
 }
 
@@ -27,9 +26,18 @@
 }
 
 #maintenance-message .closer button {
+  background: rgb(133, 133, 133);
+  color: white;
+  border: 1px solid black;
   margin: 0;
   margin-right: 1rem;
   padding: .5rem 1rem;
+}
+
+#maintenance-message .closer button:hover,
+#maintenance-message .closer button:focus {
+  background: rgb(213, 213, 213);
+  color: black;
 }
 
 #maintenance-message.success {

--- a/src/MaintenanceMessage.jsx
+++ b/src/MaintenanceMessage.jsx
@@ -4,12 +4,12 @@ import './MaintenanceMessage.css'
 let maintenanceClosed = false
 
 const MaintenanceMessage = ({ config, closeCallback }) => {
-  const { announcement, maintenanceMode } = config
+  const { filingAnnouncement, maintenanceMode } = config
 
-  if(!maintenanceMode || !announcement) return null
+  if(!maintenanceMode || !filingAnnouncement) return null
 
   const isOpen = maintenanceMode && !maintenanceClosed
-  const cname = announcement.type + (!isOpen ? ' closed' : '')
+  const cname = filingAnnouncement.type + (!isOpen ? ' closed' : '')
 
   const closeHandler = e => {
     e.preventDefault()
@@ -24,7 +24,7 @@ const MaintenanceMessage = ({ config, closeCallback }) => {
           x
         </button>
       </p>
-      <p>{announcement.message}</p>
+      <p>{filingAnnouncement.message}</p>
     </div>
   )
 }

--- a/src/filing/home/container.jsx
+++ b/src/filing/home/container.jsx
@@ -12,7 +12,7 @@ export class HomeContainer extends Component {
         filingPeriod={this.props.match.params.filingPeriod}
         filingYears={this.props.filingPeriods}
         maintenanceMode={this.props.maintenanceMode}
-        announcement={this.props.announcement}
+        filingAnnouncement={this.props.filingAnnouncement}
       />
     )
     return <InstitutionsContainer />

--- a/src/filing/home/index.jsx
+++ b/src/filing/home/index.jsx
@@ -13,9 +13,9 @@ const Home = props => {
     <main className={cname} id="main-content">
       <section className="hero">
         <div className="full-width">
-          {!!props.maintenanceMode && !!props.announcement && (
+          {!!props.maintenanceMode && !!props.filingAnnouncement && (
             <Alert type='error' heading='System Temporarily Unavailable'>
-              <p>{props.announcement.message}</p>
+              <p>{props.filingAnnouncement.message}</p>
             </Alert>
           )}
           <h1>Get started filing your HMDA data</h1>


### PR DESCRIPTION
Closes #1094 

- Note: This needs to be deployed prior to the start of the extended downtime
- Updates Maintenance banner logic to utilize the `filingAnnouncement` message
  - This was required after we updated the `announcement` entry to accept multiple messages
- Re-introduces the ability to close the Footer maintenance message
