### PR TITLE
feat(fig): add homepage links for FIG and Supplemental 2022

### DIFF
--- a/src/data-publication/ChangeLog/change-log-data.json
+++ b/src/data-publication/ChangeLog/change-log-data.json
@@ -1,6 +1,16 @@
 {
   "log": [
     {
+      "date": "09/10/21",
+      "type": "release",
+      "product": "documentation",
+      "description": "The 2022 Filing Instructions Guide (FIG) and 2022 Supplemental Guide for Quarterly Filers have been released.",
+      "links": [
+        {"text": "2022 Filing Instructions Guide (FIG)", "url": "https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2022-hmda-fig.pdf"},
+        {"text": "2022 Supplemental Guide for Quarterly Filers", "url": "https://s3.amazonaws.com/cfpb-hmda-public/prod/help/supplemental-guide-for-quarterly-filers-for-2022.pdf"}
+      ]
+    },
+    {
       "date": "08/10/21",
       "type": "release",
       "product": "datasets",

--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -57,7 +57,7 @@ const Home = ({ config }) => {
             <ul>
               <li>Filing Instructions Guide</li>
               <ul>
-                {[2021, 2020, 2019, 2018, 2017].map(year => {
+                {[2022, 2021, 2020, 2019, 2018, 2017].map(year => {
                   if (year === 2018) {
                     return (
                       <li key={`${year}`}>
@@ -117,6 +117,14 @@ const Home = ({ config }) => {
                   for data submission resources.
                 </li>
               </ul>
+              <li>
+                <a
+                  href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/supplemental-guide-for-quarterly-filers-for-2022.pdf"
+                  download={true}
+                >
+                  Supplemental Guide for Quarterly Filers for 2022
+                </a>
+              </li>
               <li>
                 <a
                   href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/supplemental-guide-for-quarterly-filers-for-2021.pdf"


### PR DESCRIPTION
Closes #1109 

Adds homepage links for 2022 FIG and Supplemental Quarterly

<img width="447" alt="Screen Shot 2021-09-10 at 8 59 22 AM" src="https://user-images.githubusercontent.com/2592907/132874771-bfa05e07-04de-42c3-a856-d1f0dd933af0.png">

Update Change Log with release announcement
 
<img width="1010" alt="Screen Shot 2021-09-10 at 9 09 43 AM" src="https://user-images.githubusercontent.com/2592907/132875976-ae8de576-ad7f-4970-a4eb-07e3cbf43714.png">
