### PR TITLE
ARID2017 Documentation Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ cypress/videos/
 cypress/screenshots/
 cypress/downloads/
 package-lock.json
+## Documentation Markdown files served locally for testing during development 
+public/markdown
 
 # Editor Configs #
 .vscode/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The HDMA Frontend monorepo hosts the public facing applications for the collecti
         * [Create Institutions](#create-institutions)
         * [Bypass API Authentication](#bypass-api-authentication)
         * [Configure the UI](#configure-the-ui)
+      - [Updating or Previewing Documentation](#updating-or-previewing-documentation)
     + [Running via Docker](#running-via-docker)
   * [Testing](#testing)
     + [Unit Tests](#unit-tests)
@@ -153,6 +154,12 @@ REACT_APP_LEIS=INSTITUTION1,INSTITUTION2 yarn ci
 ```
 
 You can now visit the filing application at http://localhost:3000/filing.
+
+
+#### Updating or Previewing Documentation
+In production, Markdown files for documentation are served from Github and dynamically rendered in the application. This architecture makes it difficult to preview changes made locally. 
+
+The script `yarn run dev-docs` will copy `/src/documentation/markdown` to `/public/markdown` for local preview. Files copied into the `/public/markdown` folder are ignored by git to avoid duplication.
 
 ### Running via Docker
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "react-scripts build",
     "test": "yarn run cypress run",
     "ci": "REACT_APP_ENVIRONMENT=CI yarn start -p 3000",
-    "ci-data": "yarn newman run cypress/ci/tests/CREATE_INSTITUTIONS.postman_collection.json -e cypress/ci/config/PLATFORM_ENV.postman_environment.json -d cypress/ci/config/institutions.json"
+    "ci-data": "yarn newman run cypress/ci/tests/CREATE_INSTITUTIONS.postman_collection.json -e cypress/ci/config/PLATFORM_ENV.postman_environment.json -d cypress/ci/config/institutions.json",
+    "dev-docs": "cp -R ./src/documentation/markdown ./public/"
   },
   "keywords": [
     "HMDA"

--- a/src/data-publication/reports/snapshot/index.jsx
+++ b/src/data-publication/reports/snapshot/index.jsx
@@ -19,7 +19,8 @@ function linkToDocs(year = '2018'){
     <li key="1"><a href={`/documentation/${year}/public-ts-schema/`}>Public Transmittal Sheet Schema</a></li>,
     <li key="2"><a href={`/documentation/${year}/public-panel-schema/`}>Public Panel Schema</a></li>,
     <li key="3"><a href={`/documentation/${year}/lar-data-fields/`}>Public HMDA Data Fields with Values and Definitions</a></li>,
-    <li key="4"><a href={`/documentation/${year}/panel-data-fields/`}>Public Panel Values and Definitions</a></li>
+    <li key="4"><a href={`/documentation/${year}/panel-data-fields/`}>Public Panel Values and Definitions</a></li>,
+    <li key="5"><a href={`/documentation/${year}/arid2017-to-lei-schema/`}>ARID2017 to LEI Reference Table Schema</a></li>
   ]
 }
 

--- a/src/documentation/markdown/2017/arid2017-to-lei-schema.md
+++ b/src/documentation/markdown/2017/arid2017-to-lei-schema.md
@@ -1,0 +1,9 @@
+## ARID2017 to LEI Reference Table - Schema  
+
+|Field|Max Length|Type|
+|-----|----------|----|
+respondent\_name||Alphanumeric
+arid\_2017||Alphanumeric
+lei\_2018|20|Alphanumeric
+lei\_2019|20|Alphanumeric
+lei\_2020|20|Alphanumeric

--- a/src/documentation/markdown/2017/identifiers-faq.md
+++ b/src/documentation/markdown/2017/identifiers-faq.md
@@ -4,26 +4,28 @@
 The following information below details guidance regarding institution identifiers in 2017 and 2018. 
 
 #### What are the institution identifiers for 2018?  
- <a target="_blank" rel="noopener noreferrer" href="http://ffiec.cfpb.gov/documentation/2021/filing-faq#what-is-a-legal-entity-identifier-lei">LEI (Legal Entity Identifier)</a> sourced from a <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">Global LEI Foundation (GLEIF)</a> operating unit is the unique identifier for HMDA Filers. Institutions can be searched by name or LEI on this site.
+For 2018 and forward, <a target="_blank" rel="noopener noreferrer" href="http://ffiec.cfpb.gov/documentation/2021/filing-faq#what-is-a-legal-entity-identifier-lei">LEI (Legal Entity Identifier)</a> sourced from a <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">Global LEI Foundation (GLEIF)</a> operating unit is the unique identifier for HMDA Filers. Institutions can be searched by name or LEI on this site.
 
 #### What are the institution identifiers for 2017?  
 For 2017 and prior, an institution's unique identifier is the concatenation of Agency Code and Respondent ID. The use of both Agency Code and Respondent ID is important as Respondent ID by itself is not always sufficient to uniquely identify an institution.
 
 Respondent ID is for 2017 and prior is one of the following: OCC charter number, FDIC certificate number, NCUA charter number, National Information Center (NIC) RSSD, or federal tax ID. The OCC, FDIC, NCUA, and RSSD identifiers all use a sequential integer system. Meaning that identifiers start at 1 and progress in increments of 1 when new institutions are registered. This creates the potential for duplicate IDs for HMDA filers. Joining an institution's Agency Code to its Respondent ID ensures that the resulting identifier is unique.
 
-**How can I map 2017 institution identifiers to 2018 institution identifiers?**
-The 2018 Panel file contains two identifiers related to 2017 identity: ID\_2017 and ARID\_2017. Use the ARID\_2017 column to match to the concatenation of Agency Code and Respondent ID from 2017. The ID\_2017 column relates to the file name of an institution's modified LAR data found on this page.
-See the <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2018/public-panel-schema/">2018 HMDA Panel - File schema</a> and <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2018/panel-data-fields/">2018 HMDA Panel - Field definitions</a>.
+#### How can I map 2017 institution identifiers to 2018 institution identifiers?  
+The _ARID2017 to LEI Reference Table_ provides a mapping of 2017 Agency Code and Respondent IDs (ARID2017) to their current institution identifiers (LEI). This table is available on the <a href="https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/">Snapshot National Loan Level Dataset</a> page, with direct links to each available table format provided below.
 
-### Institution Name Changes:
+- <a download href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/arid2017tolei/arid2017_to_lei_xref_csv.zip">ARID2017 to LEI Reference Table (CSV)</a>  
+- <a download href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/arid2017tolei/arid2017_to_lei_xref_psv.zip">ARID2017 to LEI Reference Table (Pipe Delimited)</a>
 
-**What happens with institution name changes for 2018 and beyond?**
+### Institution Name Changes
+
+#### What happens with institution name changes for 2018 and beyond?  
 In 2018 and subsequent years, an institution's name in the HMDA Panel dataset is pulled from <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">GLEIF</a> using the <a target="_blank" rel="noopener noreferrer" href="http://ffiec.cfpb.gov/documentation/2021/filing-faq#what-is-a-legal-entity-identifier-lei">LEI</a> provided by that institution. If the institution changes their legal name with <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">GLEIF</a> after the publication of the HMDA Panel, that change will populate in the subsequent HMDA Panel.
 
 #### What happens with institution name changes for 2017 and prior?  
 In 2017 an institution's name in the HMDA Panel is pulled from the National Information Center (NIC) dataset. If an institution changed its legal name in NIC after the publication of the HMDA Panel, this change was not back populated.
 
-### Institution Agency Code Changes:
+### Institution Agency Code Changes
 #### Do institutions change their agency code?  
 An institution’s Agency Code can change from year to year. These changes are driven by changes to an institution's data in an institution's official regulatory data. Agency Code changes are uncommon, but do occur. Note that changes to Agency Code may create a change in Respondent ID in 2017 and prior years.
 

--- a/src/documentation/markdown/2017/panel-data-fields.md
+++ b/src/documentation/markdown/2017/panel-data-fields.md
@@ -35,7 +35,7 @@
   - Varying values
 
 ### [arid\_2017](#arid_2017)
-- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, take the arid\_2017 column from the 2018 panel and use this to join to the concatenation of the agency code and respondent ID in the 2017 panel. Respondent ID in 2017 and prior is not a unique value and must be joined to agency code to generate a primary key for the HMDA dataset. For 2018 and forward, LEI will be the primary key. For more information on institution identifiers, please see the <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2020/identifiers-faq/">Institution Identifiers FAQ</a>
+- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, use the _ARID2017 to LEI Reference Table_ available on the <a href='/data-publication/snapshot-national-loan-level-dataset/2020'>Snapshot National Loan Level Dataset</a> page. For 2018 and forward, LEI will be the primary key.
 - **Values:**
   - Varying values
 

--- a/src/documentation/markdown/2018/arid2017-to-lei-schema.md
+++ b/src/documentation/markdown/2018/arid2017-to-lei-schema.md
@@ -1,0 +1,9 @@
+## ARID2017 to LEI Reference Table - Schema  
+
+|Field|Max Length|Type|
+|-----|----------|----|
+respondent\_name||Alphanumeric
+arid\_2017||Alphanumeric
+lei\_2018|20|Alphanumeric
+lei\_2019|20|Alphanumeric
+lei\_2020|20|Alphanumeric

--- a/src/documentation/markdown/2018/identifiers-faq.md
+++ b/src/documentation/markdown/2018/identifiers-faq.md
@@ -4,26 +4,28 @@
 The following information below details guidance regarding institution identifiers in 2017 and 2018. 
 
 #### What are the institution identifiers for 2018?  
- <a target="_blank" rel="noopener noreferrer" href="http://ffiec.cfpb.gov/documentation/2021/filing-faq#what-is-a-legal-entity-identifier-lei">LEI (Legal Entity Identifier)</a> sourced from a <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">Global LEI Foundation (GLEIF)</a> operating unit is the unique identifier for HMDA Filers. Institutions can be searched by name or LEI on this site.
+For 2018 and forward, <a target="_blank" rel="noopener noreferrer" href="http://ffiec.cfpb.gov/documentation/2021/filing-faq#what-is-a-legal-entity-identifier-lei">LEI (Legal Entity Identifier)</a> sourced from a <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">Global LEI Foundation (GLEIF)</a> operating unit is the unique identifier for HMDA Filers. Institutions can be searched by name or LEI on this site.
 
 #### What are the institution identifiers for 2017?  
 For 2017 and prior, an institution's unique identifier is the concatenation of Agency Code and Respondent ID. The use of both Agency Code and Respondent ID is important as Respondent ID by itself is not always sufficient to uniquely identify an institution.
 
 Respondent ID is for 2017 and prior is one of the following: OCC charter number, FDIC certificate number, NCUA charter number, National Information Center (NIC) RSSD, or federal tax ID. The OCC, FDIC, NCUA, and RSSD identifiers all use a sequential integer system. Meaning that identifiers start at 1 and progress in increments of 1 when new institutions are registered. This creates the potential for duplicate IDs for HMDA filers. Joining an institution's Agency Code to its Respondent ID ensures that the resulting identifier is unique.
 
-**How can I map 2017 institution identifiers to 2018 institution identifiers?**
-The 2018 Panel file contains two identifiers related to 2017 identity: ID\_2017 and ARID\_2017. Use the ARID\_2017 column to match to the concatenation of Agency Code and Respondent ID from 2017. The ID\_2017 column relates to the file name of an institution's modified LAR data found on this page.
-See the <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2018/public-panel-schema/">2018 HMDA Panel - File schema</a> and <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2018/panel-data-fields/">2018 HMDA Panel - Field definitions</a>.
+#### How can I map 2017 institution identifiers to 2018 institution identifiers?  
+The _ARID2017 to LEI Reference Table_ provides a mapping of 2017 Agency Code and Respondent IDs (ARID2017) to their current institution identifiers (LEI). This table is available on the <a href="https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/">Snapshot National Loan Level Dataset</a> page, with direct links to each available table format provided below.
 
-### Institution Name Changes:
+- <a download href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/arid2017tolei/arid2017_to_lei_xref_csv.zip">ARID2017 to LEI Reference Table (CSV)</a>  
+- <a download href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/arid2017tolei/arid2017_to_lei_xref_psv.zip">ARID2017 to LEI Reference Table (Pipe Delimited)</a>
 
-**What happens with institution name changes for 2018 and beyond?**
+### Institution Name Changes
+
+#### What happens with institution name changes for 2018 and beyond?  
 In 2018 and subsequent years, an institution's name in the HMDA Panel dataset is pulled from <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">GLEIF</a> using the <a target="_blank" rel="noopener noreferrer" href="http://ffiec.cfpb.gov/documentation/2021/filing-faq#what-is-a-legal-entity-identifier-lei">LEI</a> provided by that institution. If the institution changes their legal name with <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">GLEIF</a> after the publication of the HMDA Panel, that change will populate in the subsequent HMDA Panel.
 
 #### What happens with institution name changes for 2017 and prior?  
 In 2017 an institution's name in the HMDA Panel is pulled from the National Information Center (NIC) dataset. If an institution changed its legal name in NIC after the publication of the HMDA Panel, this change was not back populated.
 
-### Institution Agency Code Changes:
+### Institution Agency Code Changes
 #### Do institutions change their agency code?  
 An institution’s Agency Code can change from year to year. These changes are driven by changes to an institution's data in an institution's official regulatory data. Agency Code changes are uncommon, but do occur. Note that changes to Agency Code may create a change in Respondent ID in 2017 and prior years.
 

--- a/src/documentation/markdown/2018/panel-data-fields.md
+++ b/src/documentation/markdown/2018/panel-data-fields.md
@@ -34,7 +34,7 @@
   - Varying values
 
 ### [arid\_2017](#arid_2017)
-- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, take the arid_2017 column from the 2018 panel and use this to join to the concatenation of the agency code and respondent ID in the 2017 panel. Respondent ID in 2017 and prior is not a unique value and must be joined to agency code to generate a primary key for the HMDA dataset. For 2018 and forward, LEI will be the primary key.
+- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, use the _ARID2017 to LEI Reference Table_ available on the <a href='/data-publication/snapshot-national-loan-level-dataset/2020'>Snapshot National Loan Level Dataset</a> page. For 2018 and forward, LEI will be the primary key.
 - **Values:**
   - Varying values
 

--- a/src/documentation/markdown/2019/arid2017-to-lei-schema.md
+++ b/src/documentation/markdown/2019/arid2017-to-lei-schema.md
@@ -1,0 +1,9 @@
+## ARID2017 to LEI Reference Table - Schema  
+
+|Field|Max Length|Type|
+|-----|----------|----|
+respondent\_name||Alphanumeric
+arid\_2017||Alphanumeric
+lei\_2018|20|Alphanumeric
+lei\_2019|20|Alphanumeric
+lei\_2020|20|Alphanumeric

--- a/src/documentation/markdown/2019/identifiers-faq.md
+++ b/src/documentation/markdown/2019/identifiers-faq.md
@@ -11,19 +11,21 @@ For 2017 and prior, an institution's unique identifier is the concatenation of A
 
 Respondent ID is for 2017 and prior is one of the following: OCC charter number, FDIC certificate number, NCUA charter number, National Information Center (NIC) RSSD, or federal tax ID. The OCC, FDIC, NCUA, and RSSD identifiers all use a sequential integer system. Meaning that identifiers start at 1 and progress in increments of 1 when new institutions are registered. This creates the potential for duplicate IDs for HMDA filers. Joining an institution's Agency Code to its Respondent ID ensures that the resulting identifier is unique.
 
-**How can I map 2017 institution identifiers to 2018 institution identifiers?**
-The 2018 Panel file contains two identifiers related to 2017 identity: ID\_2017 and ARID\_2017. Use the ARID\_2017 column to match to the concatenation of Agency Code and Respondent ID from 2017. The ID\_2017 column relates to the file name of an institution's modified LAR data found on this page.
-See the <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2018/public-panel-schema/">2018 HMDA Panel - File schema</a> and <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2018/panel-data-fields/">2018 HMDA Panel - Field definitions</a>.
+#### How can I map 2017 institution identifiers to 2018 institution identifiers?  
+The _ARID2017 to LEI Reference Table_ provides a mapping of 2017 Agency Code and Respondent IDs (ARID2017) to their current institution identifiers (LEI). This table is available on the <a href="https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/">Snapshot National Loan Level Dataset</a> page, with direct links to each available table format provided below.
 
-### Institution Name Changes:
+- <a download href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/arid2017tolei/arid2017_to_lei_xref_csv.zip">ARID2017 to LEI Reference Table (CSV)</a>  
+- <a download href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/arid2017tolei/arid2017_to_lei_xref_psv.zip">ARID2017 to LEI Reference Table (Pipe Delimited)</a>
 
-**What happens with institution name changes for 2018 and beyond?**
+### Institution Name Changes
+
+#### What happens with institution name changes for 2018 and beyond?  
 In 2018 and subsequent years, an institution's name in the HMDA Panel dataset is pulled from <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">GLEIF</a> using the <a target="_blank" rel="noopener noreferrer" href="http://ffiec.cfpb.gov/documentation/2021/filing-faq#what-is-a-legal-entity-identifier-lei">LEI</a> provided by that institution. If the institution changes their legal name with <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">GLEIF</a> after the publication of the HMDA Panel, that change will populate in the subsequent HMDA Panel.
 
 #### What happens with institution name changes for 2017 and prior?  
 In 2017 an institution's name in the HMDA Panel is pulled from the National Information Center (NIC) dataset. If an institution changed its legal name in NIC after the publication of the HMDA Panel, this change was not back populated.
 
-### Institution Agency Code Changes:
+### Institution Agency Code Changes
 #### Do institutions change their agency code?  
 An institution’s Agency Code can change from year to year. These changes are driven by changes to an institution's data in an institution's official regulatory data. Agency Code changes are uncommon, but do occur. Note that changes to Agency Code may create a change in Respondent ID in 2017 and prior years.
 

--- a/src/documentation/markdown/2019/panel-data-fields.md
+++ b/src/documentation/markdown/2019/panel-data-fields.md
@@ -34,7 +34,7 @@
   - Varying values
 
 ### [arid\_2017](#arid_2017)
-- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, take the arid_2017 column from the 2018 panel and use this to join to the concatenation of the agency code and respondent ID in the 2017 panel. Respondent ID in 2017 and prior is not a unique value and must be joined to agency code to generate a primary key for the HMDA dataset. For 2018 and forward, LEI will be the primary key.
+- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, use the _ARID2017 to LEI Reference Table_ available on the <a href='/data-publication/snapshot-national-loan-level-dataset/2020'>Snapshot National Loan Level Dataset</a> page. For 2018 and forward, LEI will be the primary key.
 - **Values:**
   - Varying values
 

--- a/src/documentation/markdown/2020/arid2017-to-lei-schema.md
+++ b/src/documentation/markdown/2020/arid2017-to-lei-schema.md
@@ -1,0 +1,9 @@
+## ARID2017 to LEI Reference Table - Schema  
+
+|Field|Max Length|Type|
+|-----|----------|----|
+respondent\_name||Alphanumeric
+arid\_2017||Alphanumeric
+lei\_2018|20|Alphanumeric
+lei\_2019|20|Alphanumeric
+lei\_2020|20|Alphanumeric

--- a/src/documentation/markdown/2020/identifiers-faq.md
+++ b/src/documentation/markdown/2020/identifiers-faq.md
@@ -11,19 +11,21 @@ For 2017 and prior, an institution's unique identifier is the concatenation of A
 
 Respondent ID is for 2017 and prior is one of the following: OCC charter number, FDIC certificate number, NCUA charter number, National Information Center (NIC) RSSD, or federal tax ID. The OCC, FDIC, NCUA, and RSSD identifiers all use a sequential integer system. Meaning that identifiers start at 1 and progress in increments of 1 when new institutions are registered. This creates the potential for duplicate IDs for HMDA filers. Joining an institution's Agency Code to its Respondent ID ensures that the resulting identifier is unique.
 
-**How can I map 2017 institution identifiers to 2018 institution identifiers?**
-The 2018 Panel file contains two identifiers related to 2017 identity: ID\_2017 and ARID\_2017. Use the ARID\_2017 column to match to the concatenation of Agency Code and Respondent ID from 2017. The ID\_2017 column relates to the file name of an institution's modified LAR data found on this page.
-See the <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2018/public-panel-schema/">2018 HMDA Panel - File schema</a> and <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2018/panel-data-fields/">2018 HMDA Panel - Field definitions</a>.
+#### How can I map 2017 institution identifiers to 2018 institution identifiers?  
+The _ARID2017 to LEI Reference Table_ provides a mapping of 2017 Agency Code and Respondent IDs (ARID2017) to their current institution identifiers (LEI). This table is available on the <a href="https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/">Snapshot National Loan Level Dataset</a> page, with direct links to each available table format provided below.
 
-### Institution Name Changes:
+- <a download href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/arid2017tolei/arid2017_to_lei_xref_csv.zip">ARID2017 to LEI Reference Table (CSV)</a>  
+- <a download href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/arid2017tolei/arid2017_to_lei_xref_psv.zip">ARID2017 to LEI Reference Table (Pipe Delimited)</a>
 
-**What happens with institution name changes for 2018 and beyond?**
+### Institution Name Changes
+
+#### What happens with institution name changes for 2018 and beyond?  
 In 2018 and subsequent years, an institution's name in the HMDA Panel dataset is pulled from <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">GLEIF</a> using the <a target="_blank" rel="noopener noreferrer" href="http://ffiec.cfpb.gov/documentation/2021/filing-faq#what-is-a-legal-entity-identifier-lei">LEI</a> provided by that institution. If the institution changes their legal name with <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">GLEIF</a> after the publication of the HMDA Panel, that change will populate in the subsequent HMDA Panel.
 
 #### What happens with institution name changes for 2017 and prior?  
 In 2017 an institution's name in the HMDA Panel is pulled from the National Information Center (NIC) dataset. If an institution changed its legal name in NIC after the publication of the HMDA Panel, this change was not back populated.
 
-### Institution Agency Code Changes:
+### Institution Agency Code Changes
 #### Do institutions change their agency code?  
 An institution’s Agency Code can change from year to year. These changes are driven by changes to an institution's data in an institution's official regulatory data. Agency Code changes are uncommon, but do occur. Note that changes to Agency Code may create a change in Respondent ID in 2017 and prior years.
 
@@ -31,7 +33,7 @@ An institution’s Agency Code can change from year to year. These changes are d
 #### Do respondent IDs change with agency code changes?  
 Changes to an institution's Agency Code may result in changes to that institution's Respondent ID, especially in the case of depository institutions. Please see the <a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2017-hmda-fig.pdf#page=14">2017 HMDA FIG Table 1</a> for a breakout of how Respondent ID is derived based on Agency Code.
 
-**How do I distinguish between a depository and a non-depository institution?**
+### How do I distinguish between a depository and a non-depository institution?  
 In order to distinguish between depository and non-depository institutions in the HMDA data, refer to the <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2020/panel-data-fields/">HMDA Panel</a> data field <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2020/panel-data-fields/#other_lender_code">Other Lender Code</a>. Depository institutions all have Code 0 as their Other Lender Code. The remaining codes are all for non-depository institutions.
 
 The use of Other Lender Code to distinguish between institution types is more accurate than using Agency Code. 
@@ -43,4 +45,3 @@ Agency Code is not intended to differentiate between depository and non-deposito
 For example, if a non-depository has a parent entity that has Agency Code 1 for OCC, the non-depository will also have Agency Code 1. 
 
 Additionally, all institutions that shares an ownership chain with an institution that has a CFPB <a target="_blank" rel="noopener noreferrer" href="https://www.consumerfinance.gov/compliance/supervision-examinations/institutions/">large depository</a> institution will have a CFPB Agency Code.
-

--- a/src/documentation/markdown/2020/panel-data-fields.md
+++ b/src/documentation/markdown/2020/panel-data-fields.md
@@ -33,11 +33,6 @@
 - **Values:**
   - Varying values
 
-### [arid\_2017](#arid_2017)
-- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, use the _ARID2017 to LEI Reference Table_ available on the <a href='/data-publication/snapshot-national-loan-level-dataset/2020'>Snapshot National Loan Level Dataset</a> page. For 2018 and forward, LEI will be the primary key.
-- **Values:**
-  - Varying values
-
 ### [respondent\_rssd](#respondent_rssd)
 - **Description:** The National Information Center RSSD of the institution
 - **Values:**

--- a/src/documentation/markdown/2020/panel-data-fields.md
+++ b/src/documentation/markdown/2020/panel-data-fields.md
@@ -34,7 +34,7 @@
   - Varying values
 
 ### [arid\_2017](#arid_2017)
-- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, take the arid_2017 column from the 2018 panel and use this to join to the concatenation of the agency code and respondent ID in the 2017 panel. Respondent ID in 2017 and prior is not a unique value and must be joined to agency code to generate a primary key for the HMDA dataset. For 2018 and forward, LEI will be the primary key.
+- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, use the _ARID2017 to LEI Reference Table_ available on the <a href='/data-publication/snapshot-national-loan-level-dataset/2020'>Snapshot National Loan Level Dataset</a> page. For 2018 and forward, LEI will be the primary key.
 - **Values:**
   - Varying values
 

--- a/src/documentation/markdown/2020/public-panel-schema.md
+++ b/src/documentation/markdown/2020/public-panel-schema.md
@@ -7,7 +7,6 @@ lei|20|Alphanumeric
 tax\_id|10|Alphanumeric
 agency\_code|1|Numeric
 id\_2017||Alphanumeric
-arid\_2017||Alphanumeric
 respondent\_rssd||Numeric
 respondent\_name||Alphanumeric
 respondent\_state|2|Alphanumeric

--- a/src/documentation/markdown/2021/arid2017-to-lei-schema.md
+++ b/src/documentation/markdown/2021/arid2017-to-lei-schema.md
@@ -1,0 +1,9 @@
+## ARID2017 to LEI Reference Table - Schema  
+
+|Field|Max Length|Type|
+|-----|----------|----|
+respondent\_name||Alphanumeric
+arid\_2017||Alphanumeric
+lei\_2018|20|Alphanumeric
+lei\_2019|20|Alphanumeric
+lei\_2020|20|Alphanumeric

--- a/src/documentation/markdown/2021/identifiers-faq.md
+++ b/src/documentation/markdown/2021/identifiers-faq.md
@@ -11,19 +11,21 @@ For 2017 and prior, an institution's unique identifier is the concatenation of A
 
 Respondent ID is for 2017 and prior is one of the following: OCC charter number, FDIC certificate number, NCUA charter number, National Information Center (NIC) RSSD, or federal tax ID. The OCC, FDIC, NCUA, and RSSD identifiers all use a sequential integer system. Meaning that identifiers start at 1 and progress in increments of 1 when new institutions are registered. This creates the potential for duplicate IDs for HMDA filers. Joining an institution's Agency Code to its Respondent ID ensures that the resulting identifier is unique.
 
-**How can I map 2017 institution identifiers to 2018 institution identifiers?**
-The 2018 Panel file contains two identifiers related to 2017 identity: ID\_2017 and ARID\_2017. Use the ARID\_2017 column to match to the concatenation of Agency Code and Respondent ID from 2017. The ID\_2017 column relates to the file name of an institution's modified LAR data found on this page.
-See the <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2018/public-panel-schema/">2018 HMDA Panel - File schema</a> and <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/documentation/2018/panel-data-fields/">2018 HMDA Panel - Field definitions</a>.
+#### How can I map 2017 institution identifiers to 2018 institution identifiers?  
+The _ARID2017 to LEI Reference Table_ provides a mapping of 2017 Agency Code and Respondent IDs (ARID2017) to their current institution identifiers (LEI). This table is available on the <a href="https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/">Snapshot National Loan Level Dataset</a> page, with direct links to each available table format provided below.
 
-### Institution Name Changes:
+- <a download href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/arid2017tolei/arid2017_to_lei_xref_csv.zip">ARID2017 to LEI Reference Table (CSV)</a>  
+- <a download href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/arid2017tolei/arid2017_to_lei_xref_psv.zip">ARID2017 to LEI Reference Table (Pipe Delimited)</a>
 
-**What happens with institution name changes for 2018 and beyond?**
+### Institution Name Changes
+
+#### What happens with institution name changes for 2018 and beyond?  
 In 2018 and subsequent years, an institution's name in the HMDA Panel dataset is pulled from <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">GLEIF</a> using the <a target="_blank" rel="noopener noreferrer" href="http://ffiec.cfpb.gov/documentation/2021/filing-faq#what-is-a-legal-entity-identifier-lei">LEI</a> provided by that institution. If the institution changes their legal name with <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">GLEIF</a> after the publication of the HMDA Panel, that change will populate in the subsequent HMDA Panel.
 
 #### What happens with institution name changes for 2017 and prior?  
 In 2017 an institution's name in the HMDA Panel is pulled from the National Information Center (NIC) dataset. If an institution changed its legal name in NIC after the publication of the HMDA Panel, this change was not back populated.
 
-### Institution Agency Code Changes:
+### Institution Agency Code Changes
 #### Do institutions change their agency code?  
 An institution’s Agency Code can change from year to year. These changes are driven by changes to an institution's data in an institution's official regulatory data. Agency Code changes are uncommon, but do occur. Note that changes to Agency Code may create a change in Respondent ID in 2017 and prior years.
 

--- a/src/documentation/markdown/2021/panel-data-fields.md
+++ b/src/documentation/markdown/2021/panel-data-fields.md
@@ -33,16 +33,11 @@
 - **Values:**
   - Varying values
 
-### [arid\_2017](#arid_2017)
-- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, use the _ARID2017 to LEI Reference Table_ available on the <a href='/data-publication/snapshot-national-loan-level-dataset/2020'>Snapshot National Loan Level Dataset</a> page. For 2018 and forward, LEI will be the primary key.
-- **Values:**
-  - Varying values
-
 ### [respondent\_rssd](#respondent_rssd)
 - **Description:** The National Information Center RSSD of the institution
 - **Values:**
   - -1: NULL/blank
-- Varying values
+  - Varying values
 
 ### [respondent\_name](#respondent_name)
 - **Description:** The name of the institution as registered with <a target="_blank" rel="noopener noreferrer" href="https://www.gleif.org/">GLEIF</a>

--- a/src/documentation/markdown/2021/panel-data-fields.md
+++ b/src/documentation/markdown/2021/panel-data-fields.md
@@ -34,7 +34,7 @@
   - Varying values
 
 ### [arid\_2017](#arid_2017)
-- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, take the arid_2017 column from the 2018 panel and use this to join to the concatenation of the agency code and respondent ID in the 2017 panel. Respondent ID in 2017 and prior is not a unique value and must be joined to agency code to generate a primary key for the HMDA dataset. For 2018 and forward, LEI will be the primary key.
+- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, use the _ARID2017 to LEI Reference Table_ available on the <a href='/data-publication/snapshot-national-loan-level-dataset/2020'>Snapshot National Loan Level Dataset</a> page. For 2018 and forward, LEI will be the primary key.
 - **Values:**
   - Varying values
 

--- a/src/documentation/markdown/2021/public-panel-schema.md
+++ b/src/documentation/markdown/2021/public-panel-schema.md
@@ -7,7 +7,6 @@ lei|20|Alphanumeric
 tax\_id|10|Alphanumeric
 agency\_code|1|Numeric
 id\_2017||Alphanumeric
-arid\_2017||Alphanumeric
 respondent\_rssd||Numeric
 respondent\_name||Alphanumeric
 respondent\_state|2|Alphanumeric

--- a/src/documentation/markdownUtils.js
+++ b/src/documentation/markdownUtils.js
@@ -5,7 +5,12 @@ function isBadYear(year){
 }
 
 function getMarkdownUrl(year, slug) {
-  return `https://raw.githubusercontent.com/cfpb/hmda-frontend/master/src/documentation/markdown/${year}/${slug}.md`
+  const localOrRemoteUrl =
+    window.location.hostname.indexOf("localhost") > -1
+      ? window.location.origin
+      : "https://raw.githubusercontent.com/cfpb/hmda-frontend/master/src/documentation"
+      
+  return `${localOrRemoteUrl}/markdown/${year}/${slug}.md`
 }
 
 export {

--- a/src/documentation/publications/SnapshotDynamic.jsx
+++ b/src/documentation/publications/SnapshotDynamic.jsx
@@ -4,22 +4,24 @@ import Product from '../Product.jsx'
 
 const links = {
   2017: [
-    <li key="0" ><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_dataformat.pdf">Snapshot File Specifications – LAR, TS, and Reporter Panel</a></li>,
-    <li key="1"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_codesheet.pdf">Snapshot File Specifications – LAR Code Sheet</a></li>,
-    <li key="2"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_LAR_Spec.csv">Dynamic File Specifications – Loan/Application Records</a></li>,
-    <li key="3"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_TS_Spec.csv">Dynamic File Specifications – Transmittal Sheet Records</a></li>,
-    <li key="4"><Link to="/documentation/2017/lar-data-fields/">Public HMDA Data Fields with Values and Definitions</Link></li>,
-    <li key="5"><Link to="/documentation/2017/ts-data-fields/">Public Transmittal Sheet Data Fields with Values and Definitions</Link></li>,
-    <li key="6"><Link to="/documentation/2017/panel-data-fields/">Public Panel Data Fields with Values and Definitions</Link></li>
+    <li key="2017-0" ><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_dataformat.pdf">Snapshot File Specifications – LAR, TS, and Reporter Panel</a></li>,
+    <li key="2017-1"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_codesheet.pdf">Snapshot File Specifications – LAR Code Sheet</a></li>,
+    <li key="2017-2"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_LAR_Spec.csv">Dynamic File Specifications – Loan/Application Records</a></li>,
+    <li key="2017-3"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_TS_Spec.csv">Dynamic File Specifications – Transmittal Sheet Records</a></li>,
+    <li key="2017-4"><Link to="/documentation/2017/lar-data-fields/">Public HMDA Data Fields with Values and Definitions</Link></li>,
+    <li key="2017-5"><Link to="/documentation/2017/ts-data-fields/">Public Transmittal Sheet Data Fields with Values and Definitions</Link></li>,
+    <li key="2017-6"><Link to="/documentation/2017/panel-data-fields/">Public Panel Data Fields with Values and Definitions</Link></li>,
+    <li key="2017-7"><Link to="/documentation/2021/arid2017-to-lei-schema/">ARID2017 to LEI Reference Table Schema</Link></li>
   ],
   2018: [
-    <li key="4"><Link to="/documentation/2018/lar-data-fields/">Public HMDA Data Fields with Values and Definitions</Link></li>,
-    <li key="5"><Link to="/documentation/2018/derived-data-fields/">Derived Data Fields</Link></li>,
-    <li key="6"><Link to="/documentation/2018/public-lar-schema/">Public LAR Schema</Link></li>,
-    <li key="7"><Link to="/documentation/2018/public-ts-schema/">Public Transmittal Sheet Schema</Link></li>,
-    <li key="8"><Link to="/documentation/2018/ts-data-fields/">Public Transmittal Sheet Data Fields with Values and Definitions</Link></li>,
-    <li key="9"><Link to="/documentation/2018/public-panel-schema/">Public Panel Schema</Link></li>,
-    <li key="10"><Link to="/documentation/2018/panel-data-fields/">Public Panel Data Fields with Values and Definitions</Link></li>
+    <li key="2018-4"><Link to="/documentation/2018/lar-data-fields/">Public HMDA Data Fields with Values and Definitions</Link></li>,
+    <li key="2018-5"><Link to="/documentation/2018/derived-data-fields/">Derived Data Fields</Link></li>,
+    <li key="2018-6"><Link to="/documentation/2018/public-lar-schema/">Public LAR Schema</Link></li>,
+    <li key="2018-7"><Link to="/documentation/2018/public-ts-schema/">Public Transmittal Sheet Schema</Link></li>,
+    <li key="2018-8"><Link to="/documentation/2018/ts-data-fields/">Public Transmittal Sheet Data Fields with Values and Definitions</Link></li>,
+    <li key="2018-9"><Link to="/documentation/2018/public-panel-schema/">Public Panel Schema</Link></li>,
+    <li key="2018-10"><Link to="/documentation/2018/panel-data-fields/">Public Panel Data Fields with Values and Definitions</Link></li>,
+    <li key="2018-11"><Link to="/documentation/2018/arid2017-to-lei-schema/">ARID2017 to LEI Reference Table Schema</Link></li>
   ],
   2019: [
     <li key="2019-1"><Link to="/documentation/2019/lar-data-fields/">Public HMDA Data Fields with Values and Definitions</Link></li>,
@@ -28,7 +30,8 @@ const links = {
     <li key="2019-4"><Link to="/documentation/2019/public-ts-schema/">Public Transmittal Sheet Schema</Link></li>,
     <li key="2019-5"><Link to="/documentation/2019/ts-data-fields/">Public Transmittal Sheet Data Fields with Values and Definitions</Link></li>,
     <li key="2019-6"><Link to="/documentation/2019/public-panel-schema/">Public Panel Schema</Link></li>,
-    <li key="2019-7"><Link to="/documentation/2019/panel-data-fields/">Public Panel Data Fields with Values and Definitions</Link></li>
+    <li key="2019-7"><Link to="/documentation/2019/panel-data-fields/">Public Panel Data Fields with Values and Definitions</Link></li>,
+    <li key="2019-8"><Link to="/documentation/2019/arid2017-to-lei-schema/">ARID2017 to LEI Reference Table Schema</Link></li>
   ],
   2020: [
     <li key="2020-1"><Link to="/documentation/2020/lar-data-fields/">Public HMDA Data Fields with Values and Definitions</Link></li>,
@@ -37,7 +40,8 @@ const links = {
     <li key="2020-4"><Link to="/documentation/2020/public-ts-schema/">Public Transmittal Sheet Schema</Link></li>,
     <li key="2020-5"><Link to="/documentation/2020/ts-data-fields/">Public Transmittal Sheet Data Fields with Values and Definitions</Link></li>,
     <li key="2020-6"><Link to="/documentation/2020/public-panel-schema/">Public Panel Schema</Link></li>,
-    <li key="2020-7"><Link to="/documentation/2020/panel-data-fields/">Public Panel Data Fields with Values and Definitions</Link></li>
+    <li key="2020-7"><Link to="/documentation/2020/panel-data-fields/">Public Panel Data Fields with Values and Definitions</Link></li>,
+    <li key="2020-8"><Link to="/documentation/2020/arid2017-to-lei-schema/">ARID2017 to LEI Reference Table Schema</Link></li>
   ],
   2021: [
     <li key="2021-1"><Link to="/documentation/2021/lar-data-fields/">Public HMDA Data Fields with Values and Definitions</Link></li>,
@@ -46,7 +50,8 @@ const links = {
     <li key="2021-4"><Link to="/documentation/2021/public-ts-schema/">Public Transmittal Sheet Schema</Link></li>,
     <li key="2021-5"><Link to="/documentation/2021/ts-data-fields/">Public Transmittal Sheet Data Fields with Values and Definitions</Link></li>,
     <li key="2021-6"><Link to="/documentation/2021/public-panel-schema/">Public Panel Schema</Link></li>,
-    <li key="2021-7"><Link to="/documentation/2021/panel-data-fields/">Public Panel Data Fields with Values and Definitions</Link></li>
+    <li key="2021-7"><Link to="/documentation/2021/panel-data-fields/">Public Panel Data Fields with Values and Definitions</Link></li>,
+    <li key="2021-8"><Link to="/documentation/2021/arid2017-to-lei-schema/">ARID2017 to LEI Reference Table Schema</Link></li>
   ],
 }
 


### PR DESCRIPTION
Closes #1067 

# Identifiers FAQ
Replaces the methodology for matching ARID2017 to LEI with links to the new reference table. Fixes formatting.
|Before|After|
|--|--|
|<img width="951" alt="Identifier-before" src="https://user-images.githubusercontent.com/2592907/134245712-d479725d-7d2b-4a61-8597-7e231e51c7df.png">|<img width="919" alt="Identifier-after" src="https://user-images.githubusercontent.com/2592907/134245802-6dcd7d49-feec-4fcb-b120-a471c047c422.png">|

# Panel Data Fields FAQ
Replaces the methodology with a link to `Snapshot Dataset` page so users can access the reference table.
Deletes this entry for 2020 and 2021.
|Before|After|
|--|--|
|<img width="957" alt="Panel-before" src="https://user-images.githubusercontent.com/2592907/134245647-d0001a5b-2f55-4048-9141-4c75c5d0e55c.png">|<img width="962" alt="Panel-after" src="https://user-images.githubusercontent.com/2592907/134245664-2c04bea3-b601-4d2f-ac2a-2f41f1072fbe.png">|

# Add reference table to Documentation listings (last line)
## Annual Documentation Index
- Example URL: https://ffiec.cfpb.gov/documentation/2021/

|Before|After|
|--|--|
|<img width="876" alt="Screen Shot 2021-09-21 at 3 00 30 PM" src="https://user-images.githubusercontent.com/2592907/134247124-c11b4e25-d271-4222-b64f-fdab88f94f23.png">|<img width="882" alt="ref-table-publications-docs" src="https://user-images.githubusercontent.com/2592907/134246474-ff49e077-ada7-48ec-bb61-6ab76b27f5a1.png">|
 

## Snapshot Dataset - File specifications (last line)
- Example URL: https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2020

|Before|After|
|--|--|
|<img width="439" alt="Screen Shot 2021-09-21 at 3 00 43 PM" src="https://user-images.githubusercontent.com/2592907/134247253-6a5408a9-5cd7-4c4f-9b03-f34b46c6d650.png">|<img width="443" alt="ref-table-snapshot-filespecs" src="https://user-images.githubusercontent.com/2592907/134246589-f714a747-4800-4db8-a6d1-d637cd34ca23.png">|

# Creates ARID2017 to LEI table schema
<img width="526" alt="ref-table-schema" src="https://user-images.githubusercontent.com/2592907/134245919-b688ad7b-eb66-4f72-9176-caf9a553fd89.png">
 
# Easier local development of Documentation 
- Creates a `yarn` script to copy source files for local preview
- Updates the `markdownUtils` to render files from the local environment, instead of from Github, in dev environment