### PR TITLE
Remove the all-clear announcement

### DIFF
--- a/src/common/constants/dev-beta-config.json
+++ b/src/common/constants/dev-beta-config.json
@@ -1,14 +1,16 @@
 {
   "name": "dev-beta",
-  "announcement": {
-    "message": "On June 17, 2021, the Disclosure Reports, MSA/MD Aggregate Reports, Snapshot National Loan-Level dataset, and Dynamic National Loan-Level dataset for 2020 were released. These files are accessible from the ",
-    "type": "info",
-    "heading": "Announcement",
-    "link": {
-      "url": "https://ffiec.cfpb.gov/data-publication/",
-      "text": "HMDA Data Publications page."
+  "announcement": [
+    {
+      "message": "On June 17, 2021, the Disclosure Reports, MSA/MD Aggregate Reports, Snapshot National Loan-Level dataset, and Dynamic National Loan-Level dataset for 2020 were released. These files are accessible from the ",
+      "type": "info",
+      "heading": "Announcement",
+      "link": {
+        "url": "https://ffiec.cfpb.gov/data-publication/",
+        "text": "HMDA Data Publications page."
+      }
     }
-  },
+  ],
   "defaultPeriod": "2021-Q1",
   "defaultDocsPeriod": "2021",
   "publicationReleaseYearDesc": [

--- a/src/common/constants/dev-config.json
+++ b/src/common/constants/dev-config.json
@@ -2,11 +2,6 @@
   "name": "dev",
   "announcement": [
     {
-      "message": "Our scheduled maintenance is complete. HMDA filers may resume submission and resubmission of HMDA files. Please contact hmdahelp@cfpb.gov if you are experiencing issues.",
-      "type": "success",
-      "heading": "HMDA Filing Platform is available"
-    },
-    {
       "message": "On June 17, 2021, the Disclosure Reports, MSA/MD Aggregate Reports, Snapshot National Loan-Level dataset, and Dynamic National Loan-Level dataset for 2020 were released. These files are accessible from the ",
       "type": "info",
       "heading": "Data Publication Release",

--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -2,11 +2,6 @@
   "name": "prod-beta",
   "announcement": [
     {
-      "message": "Our scheduled maintenance is complete. HMDA filers may resume submission and resubmission of HMDA files. Please contact hmdahelp@cfpb.gov if you are experiencing issues.",
-      "type": "success",
-      "heading": "HMDA Filing Platform is available"
-    },
-    {
       "message": "On June 17, 2021, the Disclosure Reports, MSA/MD Aggregate Reports, Snapshot National Loan-Level dataset, and Dynamic National Loan-Level dataset for 2020 were released. These files are accessible from the ",
       "type": "info",
       "heading": "Data Publication Release",

--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -2,11 +2,6 @@
   "name": "prod",
   "announcement": [
     {
-      "message": "Our scheduled maintenance is complete. HMDA filers may resume submission and resubmission of HMDA files. Please contact hmdahelp@cfpb.gov if you are experiencing issues.",
-      "type": "success",
-      "heading": "HMDA Filing Platform is available"
-    },
-    {
       "message": "On June 17, 2021, the Disclosure Reports, MSA/MD Aggregate Reports, Snapshot National Loan-Level dataset, and Dynamic National Loan-Level dataset for 2020 were released. These files are accessible from the ",
       "type": "info",
       "heading": "Data Publication Release",


### PR DESCRIPTION
Closes #1130 

- Removes the post-migration all-clear message
- Updates the `dev-beta-config` to use an array of announcement messages