### PR TITLE
Update Cypress testing pod build process

### DIFF
--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -33,16 +33,9 @@ RUN yum install -y unzip
 
 RUN npm install yarn -g
 
-RUN mkdir -p ~/.cache/Cypress/8.3.0/Cypress && \
-    wget --no-check-certificate http://download.cypress.io/desktop/8.3.0?platform=linux -O /tmp/z.$$ && \
-    unzip -d ~/.cache/Cypress/8.3.0/ /tmp/z.$$ && \
-    rm /tmp/z.$$ && \
-    chmod +x ~/.cache/Cypress/8.3.0/Cypress/Cypress && \
-    rm -rf /var/lib/apt/lists/*
-
 COPY / hmda-frontend/
 
-WORKDIR hmda-frontend/
+WORKDIR /hmda-frontend/
 
 RUN yarn
 
@@ -50,3 +43,5 @@ RUN useradd -ms /bin/bash hmda_cypress_user && \
   chown -R hmda_cypress_user:hmda_cypress_user /hmda-frontend/
 
 USER hmda_cypress_user
+
+RUN yarn cypress install

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Collection of HMDA frontend apps",
   "main": "./src/index.js",
   "engines": {
-    "node": ">=14.17.6"
+    "node": ">=14.17.x"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Closes #1135 

- Expand definition of compatible Node engines
- Update Cypress installation method in the testing pod