### PR TITLE
Dynamic Announcement Banner height

### DIFF
--- a/src/common/OptionCarousel.css
+++ b/src/common/OptionCarousel.css
@@ -1,6 +1,15 @@
 .oc {
   position: relative;
   user-select: text;
+  margin-bottom: -1rem;
+  transition: height .5s ease;
+  display: flex;
+  align-items: center;
+}
+
+.oc .alert {
+  margin: 0;
+  padding-top: 3rem;
 }
 
 .oc .progress {
@@ -8,11 +17,12 @@
   flex-flow: row nowrap;
   position: absolute;
   user-select: none;
-  top: 5px;
-  right: 5px;
+  top: 0;
+  right: 0;
   z-index: 1;
-  border-radius: 5px;
   background: rgba(153, 153, 153, .8); 
+  border-top-left-radius: 5px;
+  border-bottom-left-radius: 5px;
 }
 
 .oc .progress button {
@@ -60,6 +70,7 @@
 .oc-option {
   position: relative;
   user-select: text;
+  flex-basis: 100%;
 }
 
 .oc-option.inline {

--- a/src/common/OptionCarousel.jsx
+++ b/src/common/OptionCarousel.jsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from 'react'
-import { ReactComponent as IconPlay } from '../common/images/play.svg'
-import { ReactComponent as IconPause } from '../common/images/pause.svg'
-import './OptionCarousel.css'
+import React, { useState, useEffect } from "react"
+import { ReactComponent as IconPlay } from "../common/images/play.svg"
+import { ReactComponent as IconPause } from "../common/images/pause.svg"
+import "./OptionCarousel.css"
+
+let timeout = false
 
 /**
  * A component to enable testing of potential changes in a live site by clicking to cycle through available options
@@ -10,75 +12,141 @@ import './OptionCarousel.css'
  * @param {Boolean} hideIcon Hide the icon marking these elements as part of the carousel
  * @param {String} className Optional classname to add to carousel elements
  * @param {Integer} cycleTime Number of seconds to wait before displaying the next option, if multiple options are passed. Setting this to 0 will turn off the auto advance behavior.
- * @returns 
+ * @param {String} fixedHeight Use a static container height
  */
 export const OptionCarousel = ({
   options = [],
   showControls = true,
   cycleTime = 2,
   hideIcon = false,
-  className = '',
-  fixedHeight = 'auto'
+  className = "",
+  fixedHeight = null
 }) => {
-  const [idx, setIdx] = useState(0)
-  const [paused, setPaused] = useState(false)  // Auto-advance?
   if (!options || !options.length) return null
 
-  const hasMultiple = options.length > 1
-  const next = () => setIdx((idx + 1) % options.length)
-  const prev = () =>
-    setIdx(idx - 1 < 0 ? options.length - 1 : (idx - 1) % options.length)
+  const [idx, setIdx] = useState(0)
+  const [paused, setPaused] = useState(false) // Auto-advance?
+  const [currHeight, setCurrHeight] = useState(fixedHeight || "100px")
+  const [winWidth, setWinWidth] = useState(window.innerWidth)
 
+  const styles = { height: currHeight }
+  const totalCount = options.length
+  const hasMultiple = totalCount > 1
+  const showNavigator = showControls && hasMultiple
+  const hideIconClass = hideIcon ? "no-icon" : ""
+  const classname = [className, "oc-option", hideIconClass]
+    .filter((x) => x)
+    .join(" ")
+
+  /* Debounced window resize event listener used to track window width */
+  window.onresize = () => {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => setWinWidth(window.innerWidth), 450)
+  }
+
+  /* Adjust carousel container height when window is resized */
+  useEffect(() => {
+    if (fixedHeight) return () => null // Skip dynamic height adjustment
+
+    // Minimum height in pixels
+    const baseHeight = () => {
+      if (winWidth > 675) return 50
+      if (winWidth > 500) return 70
+      if (winWidth > 300) return 85
+      return 100
+    }
+
+    // Values derived from observation
+    const multiplier = () => {
+      if (winWidth > 500) return 13
+      if (winWidth > 400) return 14
+      if (winWidth > 300) return 15
+      return 20
+    }
+
+    // Calculate container height based on the longest message
+    let tallest = Math.max(...options.map((o) => o.props.message.length))
+
+    // Estimate how many rows the text will occupy, adding a 2 row cushion
+    const estimatedRows =
+      Math.round((tallest / window.innerWidth) * multiplier()) + 2
+
+    // Calculate container height based on # rows * presumed px height of text
+    const estHeight = baseHeight() + estimatedRows * 17
+
+    // Set height in pixels
+    setCurrHeight(`${estHeight}px`)
+  }, [winWidth])
+
+  return (
+    <div className="oc" style={styles}>
+      <span className={classname}>
+        {showNavigator && (
+          <OptionNavigator
+            {...{ idx, setIdx, paused, setPaused, totalCount, cycleTime }}
+          />
+        )}
+        {options[idx]}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * Navigation controller that displays which option is currently being shown
+ * @param {Integer} idx // Index of current option being displayed
+ * @param {Boolean} paused // Flag indicating if auto-advance is paused
+ * @param {Integer} totalCount // Number of options
+ * @returns
+ */
+const OptionNavigator = ({
+  idx,
+  setIdx,
+  paused,
+  totalCount,
+  setPaused,
+  cycleTime,
+}) => {
+  const next = () => setIdx((idx + 1) % totalCount)
+  const prev = () => setIdx(idx - 1 < 0 ? totalCount - 1 : (idx - 1) % totalCount)
+
+  /* Automatically cycle through available options */
   let autoAdvance
   useEffect(() => {
     if (paused) {
       autoAdvance && clearTimeout(autoAdvance)
     } else {
-      if (!options.length) return null
+      if (totalCount < 1) return null
       const secs = parseInt(cycleTime)
-      if (hasMultiple && secs) {
+      if (secs > 0) {
         autoAdvance = setTimeout(next, secs * 1000)
         return () => clearTimeout(autoAdvance)
       }
     }
   }, [idx, paused])
 
-  const hideIconClass = hideIcon ? 'no-icon' : ''
-  const classname = [className, 'oc-option', hideIconClass].filter((x) => x).join(' ')
-  const styles = { height: fixedHeight }
-
   return (
-    <div className='oc' style={styles}>
-      {showControls && hasMultiple && (
-        <div className='progress-wrapper'>
-          <div className={'progress'}>
-            <button
-              className='previous clickable'
-              onClick={prev}
-              title='Previous'
-            >
-              &lt;
-            </button>
-            <button className='count' tabIndex='-1'>
-              {idx + 1}/{options.length}
-            </button>
-            <button className='next clickable' onClick={next} title='Next'>
-              &gt;
-            </button>
-            <button
-              className='pause clickable'
-              title={paused ? 'Resume auto-advance' : 'Pause auto-advance'}
-              onClick={() => setPaused(!paused)}
-            >
-              <span className='svg icon'>
-                {paused ? <IconPlay /> : <IconPause />}
-              </span>
-            </button>
-          </div>
-        </div>
-      )}
-
-      <span className={classname}>{options[idx]}</span>
+    <div className="progress-wrapper">
+      <div className={"progress"}>
+        <button className="previous clickable" onClick={prev} title="Previous">
+          &lt;
+        </button>
+        <button className="count" tabIndex="-1">
+          {idx + 1}/{totalCount}
+        </button>
+        <button className="next clickable" onClick={next} title="Next">
+          &gt;
+        </button>
+        <button
+          className="pause clickable"
+          title={paused ? "Resume auto-advance" : "Pause auto-advance"}
+          onClick={() => setPaused(!paused)}
+        >
+          <span className="svg icon">
+            {paused ? <IconPlay /> : <IconPause />}
+          </span>
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/common/useAutoAdvance.jsx
+++ b/src/common/useAutoAdvance.jsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from "react"
+let advanceTimeout = null
+
+/**
+ * Custom hook to encapsulate logic for manually and automatically
+ * cycling through a series of options.
+ * @param {Integer} cycleTime Number of seconds to wait before displaying the next option, if multiple options are passed. Setting this to 0 will turn off the auto advance behavior.
+ * @param {Integer} totalCount Number of available options
+ * @param {Boolean} autoAdvance Enable auto-advance by default
+ * @returns {Object} Values and callbacks for option navigation
+ */
+export const useAutoAdvance = ({
+  cycleTime = 2,
+  totalCount = 0,
+  autoAdvance = true,
+}) => {
+  
+  const [currentIdx, setCurrentIdx] = useState(0)
+  const [isPaused, setPaused] = useState(!autoAdvance) // Auto-advance?
+
+  const showNext = () => setCurrentIdx((currentIdx + 1) % totalCount)
+  const showPrevious = () =>
+    setCurrentIdx(
+      currentIdx - 1 < 0 ? totalCount - 1 : (currentIdx - 1) % totalCount
+    )
+
+  /* Automatically cycle through available options */
+  useEffect(() => {
+    if (isPaused) clearTimeout(advanceTimeout)
+    else {
+      if (totalCount < 1) return null
+      const secs = parseInt(cycleTime)
+      if (secs > 0) {
+        advanceTimeout = setTimeout(showNext, secs * 1000)
+        return () => clearTimeout(advanceTimeout)
+      }
+    }
+  }, [currentIdx, isPaused])
+
+  return {
+    currentIdx,
+    isPaused,
+    setPaused,
+    showNext,
+    showPrevious,
+  }
+}

--- a/src/common/useDynamicHeight.jsx
+++ b/src/common/useDynamicHeight.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react"
+/**
+ * Adjust container height based on the longest
+ * option message and the current window width.
+ * @param {String} fixedHeight Static height used by parent container
+ * @param {Integer} maxLength Length of longest option text, used to calculate minimum height
+ * @param {Function} setCurrHeight Callback to set dynamic height
+ */
+export const useDynamicHeight = ({ setCurrHeight, maxLength, fixedHeight }) => {
+  const [winWidth, setWinWidth] = useState(window.innerWidth)
+
+  if (fixedHeight) return null // Skip dynamic height adjustment
+
+  /* Debounced window resize event listener used to track window width */
+  let timeout = false
+  window.onresize = () => {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => setWinWidth(window.innerWidth), 250)
+  }
+
+  /* Adjust height on window resize */
+  useEffect(() => {
+    // Minimum height in pixels
+    const baseHeight = () => {
+      if (winWidth > 675) return 50
+      if (winWidth > 500) return 70
+      if (winWidth > 300) return 85
+      return 100
+    }
+
+    // Values derived from observation
+    const multiplier = () => {
+      if (winWidth > 500) return 13
+      if (winWidth > 400) return 14
+      if (winWidth > 300) return 15
+      return 20
+    }
+
+    // Estimate how many rows the text will occupy, adding a 2 row cushion
+    const estimatedRows = Math.round((maxLength / winWidth) * multiplier()) + 2
+
+    // Calculate container height based on # rows * presumed px height of text
+    const estHeight = baseHeight() + estimatedRows * 17
+
+    // Set height in pixels
+    setCurrHeight(`${estHeight}px`)
+  }, [winWidth])
+}

--- a/src/homepage/AnnouncementBanner.jsx
+++ b/src/homepage/AnnouncementBanner.jsx
@@ -175,7 +175,6 @@ export const AnnouncementBanner = ({
       cycleTime={5}
       hideIcon
       showControls
-      fixedHeight='100px'
     />
   )
 }


### PR DESCRIPTION
Closes #1156 

Enables dynamic height adjustment of the AnnouncementBanner to avoid overflow of long messages, which would block access to the Homepage links at narrow display widths.  

This method limits the amount of times other elements on the Homepage are shifted by only calculating the AnnouncementBanner container height once per window resize, ensuring that the longest message has the room it needs to display without overlaying other elements.  

## Demo

https://user-images.githubusercontent.com/2592907/137787076-97a78164-f48e-482f-8e23-e406c5c8a6e5.mov


