### PR TITLE
Aggregate/Disclosure Reports - Include Report ID in UI labels for all…

### DIFF
--- a/src/data-publication/reports/Aggregate.jsx
+++ b/src/data-publication/reports/Aggregate.jsx
@@ -168,7 +168,7 @@ class Aggregate extends React.Component {
                       ? 'Select a report'
                       : params.stateId ? '' : ''
                 }
-                id={params.reportId && params.year === '2017' ? report.value : ''}
+                id={params.reportId ? report.value : ''}
                 link={
                   params.msaMdId
                     ? `/data-publication/aggregate-reports/${params.year}/${state.id}/${msaMd.id}`

--- a/src/data-publication/reports/Disclosure.jsx
+++ b/src/data-publication/reports/Disclosure.jsx
@@ -224,7 +224,7 @@ class Disclosure extends React.Component {
                     ? ''
                     : ''
                 }
-                id={params.reportId && params.year === '2017' ? report.value : ''}
+                id={params.reportId ? report.value : ''}
                 link={
                   params.msaMdId
                     ? `/data-publication/disclosure-reports/${params.year}/${institutionId}/${

--- a/src/data-publication/reports/Reports.jsx
+++ b/src/data-publication/reports/Reports.jsx
@@ -38,8 +38,10 @@ const Reports = props => {
 
   const options = data.map(option => {
     if (option.value) {
-      const label = params.year !== '2017' ? option.label : `${option.value} - ${option.label}`
-      return { value: option.value, label }
+      return {
+        value: option.value,
+        label: `${option.value} - ${option.label}`,
+      }
     }
 
     return {


### PR DESCRIPTION
Closes #127 

## Changes
Updates the Aggregate/Disclosure reports for 2018+ to include the report ID in the report labels to match the UI for 2017 reports.

## Testing
- Update [SearchList](https://github.com/cfpb/hmda-frontend/blob/master/src/data-publication/reports/SearchList.jsx#L25) to use `https://ffiec.cfpb.gov/v2/reporting/filers/${year}`
- Update [fetchMsas](https://github.com/cfpb/hmda-frontend/blob/master/src/data-publication/reports/fetchMsas.js#L4) to use `https://ffiec.cfpb.gov/v2/reporting/filers/${year}/${institutionId}/msaMds`
- Visit http://localhost:3000/data-publication/disclosure-reports/2019/549300I4IUWMEMGLST06/30980, observe that report IDs are included
- Visit http://localhost:3000/data-publication/aggregate-reports/2019/AL/11500, observe that report IDs are included

## Screenshots
|Section|Aggregate Reports|Disclosure Reports|
|---|---|---|
|Header|<img width="1006" alt="agg-header" src="https://user-images.githubusercontent.com/2592907/137822618-6fae2ff6-d99f-4e73-97e5-1029537b7f0a.png">|<img width="1019" alt="disc-header" src="https://user-images.githubusercontent.com/2592907/137822627-36c27d9f-0a7b-417b-aa96-9765afadbb25.png">| 
|Menu|<img width="1025" alt="agg-menu" src="https://user-images.githubusercontent.com/2592907/137822659-a1443246-caf9-4f05-8ad5-82a7990e561a.png">|<img width="1022" alt="disc-menu" src="https://user-images.githubusercontent.com/2592907/137822689-6dce88e4-d697-4b86-8b58-26fd933a14de.png">|
