### PR TITLE
Data Browser FAQ - Update dataset freeze dates

### DIFF
--- a/src/documentation/markdown/2018/data-browser-faq.md
+++ b/src/documentation/markdown/2018/data-browser-faq.md
@@ -13,7 +13,13 @@ Answer: A comma-separated values (CSV) file derives its name from a file contain
 Answer: The columns of the Static and Dynamic dataset, including data available through the Data Browser, have been reordered to create logical groupings. This reordering was done to facilitate analysis in desktop spreadsheet software for files pulled from the Data Browser.
 
 ### Which dataset is used by the Data Browser? 
-Answer: The Data Browser uses the static dataset. The static data for the 2018 collection were frozen on August 7, 2019.
+Answer: The Data Browser uses the [Snapshot](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/) dataset.
+
+| Collection Year | Data Freeze Date |
+|---|---|
+|[2018](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2018)|August 7, 2019|
+|[2019](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2019)|April 27, 2020|
+|[2020](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2020)|May 3, 2021|
 
 ### I have a suggestion/improvement, who can I contact?
 Answer: For questions/suggestions regarding the HMDA Data Browser, [contact hmdahelp@cfpb.gov](mailto:hmdahelp@cfpb.gov).

--- a/src/documentation/markdown/2019/data-browser-faq.md
+++ b/src/documentation/markdown/2019/data-browser-faq.md
@@ -13,7 +13,13 @@ Answer: A comma-separated values (CSV) file derives its name from a file contain
 Answer: The columns of the Static and Dynamic dataset, including data available through the Data Browser, have been reordered to create logical groupings. This reordering was done to facilitate analysis in desktop spreadsheet software for files pulled from the Data Browser.
 
 ### Which dataset is used by the Data Browser? 
-Answer: The Data Browser uses the static dataset. The static data for the 2018 collection were frozen on August 7, 2019. The static data for the 2019 collection were frozen on April 27, 2020.
+Answer: The Data Browser uses the [Snapshot](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/) dataset.
+
+| Collection Year | Data Freeze Date |
+|---|---|
+|[2018](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2018)|August 7, 2019|
+|[2019](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2019)|April 27, 2020|
+|[2020](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2020)|May 3, 2021|
 
 ### I have a suggestion/improvement, who can I contact?
 Answer: For questions/suggestions regarding the HMDA Data Browser, [contact hmdahelp@cfpb.gov](mailto:hmdahelp@cfpb.gov).

--- a/src/documentation/markdown/2020/data-browser-faq.md
+++ b/src/documentation/markdown/2020/data-browser-faq.md
@@ -13,7 +13,13 @@ Answer: A comma-separated values (CSV) file derives its name from a file contain
 Answer: The columns of the Static and Dynamic dataset, including data available through the Data Browser, have been reordered to create logical groupings. This reordering was done to facilitate analysis in desktop spreadsheet software for files pulled from the Data Browser.
 
 ### Which dataset is used by the Data Browser? 
-Answer: The Data Browser uses the static dataset. The static data for the 2018 collection were frozen on August 7, 2019. The static data for the 2019 collection were frozen on April 27, 2020.
+Answer: The Data Browser uses the [Snapshot](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/) dataset.
+
+| Collection Year | Data Freeze Date |
+|---|---|
+|[2018](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2018)|August 7, 2019|
+|[2019](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2019)|April 27, 2020|
+|[2020](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2020)|May 3, 2021|
 
 ### I have a suggestion/improvement, who can I contact?
 Answer: For questions/suggestions regarding the HMDA Data Browser, [contact hmdahelp@cfpb.gov](mailto:hmdahelp@cfpb.gov).

--- a/src/documentation/markdown/2021/data-browser-faq.md
+++ b/src/documentation/markdown/2021/data-browser-faq.md
@@ -13,7 +13,12 @@ Answer: A comma-separated values (CSV) file derives its name from a file contain
 Answer: The columns of the Static and Dynamic dataset, including data available through the Data Browser, have been reordered to create logical groupings. This reordering was done to facilitate analysis in desktop spreadsheet software for files pulled from the Data Browser.
 
 ### Which dataset is used by the Data Browser? 
-Answer: The Data Browser uses the static dataset. The static data for the 2018 collection were frozen on August 7, 2019. The static data for the 2019 collection were frozen on April 27, 2020.
+Answer: The Data Browser uses the [Snapshot](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/) dataset.
 
+| Collection Year | Data Freeze Date |
+|---|---|
+|[2018](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2018)|August 7, 2019|
+|[2019](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2019)|April 27, 2020|
+|[2020](https://ffiec.cfpb.gov/data-publication/snapshot-national-loan-level-dataset/2020)|May 3, 2021|
 ### I have a suggestion/improvement, who can I contact?
 Answer: For questions/suggestions regarding the HMDA Data Browser, contact [hmdahelp@cfpb.gov](mailto:hmdahelp@cfpb.gov).


### PR DESCRIPTION
Closes #414 

# Changes
- Adds the freeze date for the 2020 dataset.
- Lists freeze dates in a table for improved readability and expansion
- Changes `static dataset` to `Snapshot dataset` for clarity and consistency

|Before|After|
|---|---|
|<img width="954" alt="Screen Shot 2021-10-19 at 4 42 29 PM" src="https://user-images.githubusercontent.com/2592907/138000675-c86570e4-525e-48d3-84c4-0fa062c8624c.png">|<img width="419" alt="Screen Shot 2021-10-19 at 4 39 15 PM" src="https://user-images.githubusercontent.com/2592907/138000522-9734f453-608e-41f8-ab7e-a15fa9b8f446.png">|

# Testing
- run `yarn dev-docs`
- run `yarn ci`
- Visit http://localhost:3000/documentation/2021/data-browser-faq/
