### PR TITLE
Wrap Alert child string in a Fragment

### DIFF
--- a/src/common/mailingListServices.jsx
+++ b/src/common/mailingListServices.jsx
@@ -26,6 +26,7 @@ const StatusMessage = ({ invalid, error, success }) => {
    */
   const Status = ({ type, message }) => {
     if (!message) return
+    // Note: Alert's child must be an element, hence the use of a Fragment below
     return (
       <Alert type={type}>
         <>{message}</>

--- a/src/common/mailingListServices.jsx
+++ b/src/common/mailingListServices.jsx
@@ -28,7 +28,7 @@ const StatusMessage = ({ invalid, error, success }) => {
     if (!message) return
     return (
       <Alert type={type}>
-        {message}
+        <>{message}</>
       </Alert>
     )
   }


### PR DESCRIPTION
Closes #1202

I believe that because of the way our Alert component clones its children, we must wrap this `message` string in a Fragment.  Otherwise the Frontend crashes.

<img width="844" alt="Screen Shot 2021-11-19 at 3 39 54 PM" src="https://user-images.githubusercontent.com/2592907/142700374-509a6622-3ca4-41b5-9355-7e7721eacf87.png">
