### PR TITLE
Correct Markdown lists; Use ExternalLink where possible

### DIFF
--- a/src/common/ExternalLink.jsx
+++ b/src/common/ExternalLink.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-export const ExternalLink = ({ url, text, className, children }) => {
+const ExternalLink = ({ url, text, className, children, title }) => {
   return <a
     target='_blank'
     rel='noopener noreferrer'
     href={url}
     className={'external link ' + className}
+    title={title}
   >
     {children || text || url}
   </a>

--- a/src/data-browser/ImageCard.jsx
+++ b/src/data-browser/ImageCard.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
+import ExternalLink from '../common/ExternalLink'
+
 import './ImageCard.css'
 
 const TileImage = ({ src }) => <img className='tile-image' src={src} />
@@ -28,7 +30,11 @@ const ImageCard = (props) => {
           </span>
         </div>
       </Link>
-      {props.faq && <Link to={props.faq.url} target="_blank" rel="noopener noreferrer" className='faq'>{props.faq.label || "FAQ"}</Link>}
+      {props.faq && (
+        <ExternalLink url={props.faq.url} className='faq'>
+          {props.faq.label || 'FAQ'}
+        </ExternalLink>
+      )}
     </div>
   )
 }

--- a/src/data-browser/datasets/DocLink.jsx
+++ b/src/data-browser/datasets/DocLink.jsx
@@ -1,15 +1,14 @@
 import React from 'react'
+import ExternalLink from '../../common/ExternalLink'
 
-function makeUrl({year, definition}) {
+function makeUrl({ year, definition }) {
   return `/documentation/${year}/data-browser-filters/#${definition}`
 }
 
-const DocLink = props => {
-  return (
-    <a href={makeUrl(props)} target="_blank" rel="noopener noreferrer">
-      {props.children}
-    </a>
-  )
-}
+const DocLink = (props) => (
+  <ExternalLink url={makeUrl(props)}>
+    {props.children}
+  </ExternalLink>
+)
 
 export default DocLink

--- a/src/data-browser/datasets/Geography.jsx
+++ b/src/data-browser/datasets/Geography.jsx
@@ -30,6 +30,7 @@ import {
   before2018,
 } from './selectUtils.js'
 import { sanitizeArray } from '../query'
+import ExternalLink from '../../common/ExternalLink'
 
 import './Geography.css'
 
@@ -420,20 +421,14 @@ class Geography extends Component {
             <p className='lead'>
               You can use the HMDA Data Browser to filter and download CSV files
               of HMDA data. These files contain all{' '}
-              <a
-                target='_blank'
-                rel='noopener noreferrer'
-                href='/documentation/2018/lar-data-fields/'
-              >
+              <ExternalLink url='/documentation/2018/lar-data-fields/'>
                 data fields
-              </a>{' '}
+              </ExternalLink>{' '}
               available in the public data record and can be used for advanced
               analysis. You can also access the{' '}
-              <a
-                target='_blank'
-                rel='noopener noreferrer'
-                href="https://cfpb.github.io/hmda-platform/#data-browser">Data Browser API
-              </a>{' '}
+              <ExternalLink url='https://cfpb.github.io/hmda-platform/#data-browser'>
+                Data Browser API
+              </ExternalLink>{' '}
               directly. For questions/suggestions, contact hmdahelp@cfpb.gov.
             </p>
           </Heading>
@@ -473,7 +468,9 @@ class Geography extends Component {
           : null}
         <ActionsWarningsErrors
           downloadEnabled={enabled}
-          downloadCallback={checksExist ? this.requestSubsetCSV : this.requestItemCSV}
+          downloadCallback={
+            checksExist ? this.requestSubsetCSV : this.requestItemCSV
+          }
           downloadUrl={fileDownloadUrl}
           showSummaryButton={!details.aggregations}
           summaryEnabled={enabled && checksExist}

--- a/src/data-browser/datasets/ItemSelect.jsx
+++ b/src/data-browser/datasets/ItemSelect.jsx
@@ -11,6 +11,7 @@ import {
   makeItemPlaceholder,
   itemStyleFn
 } from './selectUtils.js'
+import ExternalLink from '../../common/ExternalLink'
 
 
 const ItemSelect = ({
@@ -30,13 +31,9 @@ const ItemSelect = ({
       <p>
         Start by selecting a geography filter using the dropdown menu
         below.&nbsp;
-        <a
-          target='_blank'
-          rel='noopener noreferrer'
-          href='/documentation/2018/data-browser-filters/#Nationwide'
-        >
+        <ExternalLink url='/documentation/2018/data-browser-filters/#Nationwide'>
           View more information on the available filters.
-        </a>
+        </ExternalLink>
       </p>
       <div className='inline-selects'>
         <CategorySelect category={category} onChange={onCategoryChange} />

--- a/src/data-browser/datasets/VariableSelect.jsx
+++ b/src/data-browser/datasets/VariableSelect.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Select from '../Select.jsx'
 import Pills from './Pills.jsx'
 import CheckboxContainer from './CheckboxContainer.jsx'
+import ExternalLink from '../../common/ExternalLink'
 import {
   setVariableSelect,
   removeSelected,
@@ -16,13 +17,9 @@ const VariableSelect = ({ options, variables, orderedVariables, year, checkFacto
       <h3>Step 3: Select a filter (optional)</h3>
       <p>
         Narrow down your selection by filtering on up to two{' '}
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="/documentation/2018/data-browser-filters/#action_taken"
-        >
+        <ExternalLink url="/documentation/2018/data-browser-filters/#action_taken">
           popular variables
-        </a>
+        </ExternalLink>
       </p>
       <Select id='VariableSelector'
         controlShouldRenderValue={false}

--- a/src/data-browser/maps/PopularVariableLink.jsx
+++ b/src/data-browser/maps/PopularVariableLink.jsx
@@ -1,13 +1,12 @@
 import React from 'react'
+import ExternalLink from '../../common/ExternalLink'
 
 export const PopularVariableLink = ({ children = 'popular variables', year }) => (
-  <a
-    target='_blank'
-    rel='noopener noreferrer'
-    href={`/documentation/${year}/data-browser-filters/#action_taken`}
+  <ExternalLink
+    url={`/documentation/${year}/data-browser-filters/#action_taken`}
   >
     {children}
-  </a>
+  </ExternalLink>
 )
 
 export default PopularVariableLink

--- a/src/data-browser/maps/selectUtils.jsx
+++ b/src/data-browser/maps/selectUtils.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import VARIABLES from '../constants/variables.js'
+import ExternalLink from '../../common/ExternalLink'
 
 const geographies = [
   {value: 'state', label: 'State'},
@@ -199,15 +200,13 @@ export const parseCombinedFilter = (selected) => {
 const formatGroupLabel = (data, year) => (
   <div className='menu-group'>
     <span className='menu-group-label'>{data.label}</span>
-    <a
-      target='_blank'
-      rel='noopener noreferrer'
+    <ExternalLink
       className='menu-group-badge'
       title={`Documentation for ${data.label} (${year})`}
-      href={`/documentation/${year}/data-browser-filters/#${data.definition}`}
+      url={`/documentation/${year}/data-browser-filters/#${data.definition}`}
     >
       Documentation
-    </a>
+    </ExternalLink>
   </div>
 )
 

--- a/src/data-publication/reports/Aggregate.jsx
+++ b/src/data-publication/reports/Aggregate.jsx
@@ -10,6 +10,7 @@ import STATES from '../constants/states.js'
 import stateToMsas from '../constants/stateToMsas.js'
 import { AGGREGATE_REPORTS } from '../constants/aggregate-reports.js'
 import { withAppContext } from '../../common/appContextHOC.jsx'
+import ExternalLink from '../../common/ExternalLink'
 
 import './Aggregate.css'
 
@@ -103,8 +104,8 @@ class Aggregate extends React.Component {
         paragraphText="These reports summarize lending activity by MSA/MD."
       >
           <p>To learn about modifications to these reports over the years, visit the{' '}
-          <a target="_blank" rel="noopener noreferrer" href={`/documentation/${years[0]}/ad-changes/`}>A&D Report Changes</a> page.<br/>
-          Looking for other HMDA data? Visit the new <a target="_blank" rel="noopener noreferrer" href="/data-browser/">HMDA Data Browser</a> to filter and download HMDA datasets.<br/>
+          <ExternalLink url={`/documentation/${years[0]}/ad-changes/`}>A&amp;D Report Changes</ExternalLink> page.<br/>
+          Looking for other HMDA data? Visit the new <ExternalLink url="/data-browser/">HMDA Data Browser</ExternalLink> to filter and download HMDA datasets.<br/>
           {year === '2018' ? 'The 2018 Aggregate Reports use the static dataset that was frozen on August 7, 2019.' : '\u00a0'}
           </p>
       </Heading>

--- a/src/data-publication/reports/Disclosure.jsx
+++ b/src/data-publication/reports/Disclosure.jsx
@@ -10,6 +10,7 @@ import Report from './Report.jsx'
 import fetchMsas from './fetchMsas.js'
 import { DISCLOSURE_REPORTS } from '../constants/disclosure-reports.js'
 import { withAppContext } from '../../common/appContextHOC.jsx'
+import ExternalLink from '../../common/ExternalLink'
 
 const detailsCache = {
   2020: {
@@ -142,8 +143,8 @@ class Disclosure extends React.Component {
         paragraphText={'These reports summarize lending activity for individual institutions, both nationwide and by MSA/MD. They are based on the most recent data submission made in each filing period. To find an institution\'s IRS (Institution Register Summary), select "Nationwide" from the MSA/MD dropdown after choosing an institution.'}
       >
           <p>To learn about modifications to these reports over the years, visit the{' '}
-          <a target="_blank" rel="noopener noreferrer" href={`/documentation/${years[0]}/ad-changes/`}>A&amp;D Report Changes</a> page.<br/>
-          Looking for other HMDA data? Visit the new <a target="_blank" rel="noopener noreferrer" href="/data-browser/">HMDA Data Browser</a> to filter and download HMDA datasets.
+          <ExternalLink url={`/documentation/${years[0]}/ad-changes/`}>A&amp;D Report Changes</ExternalLink> page.<br/>
+          Looking for other HMDA data? Visit the new <ExternalLink url="/data-browser/">HMDA Data Browser</ExternalLink> to filter and download HMDA datasets.
           </p>
       </Heading>
     )

--- a/src/data-publication/reports/NationalAggregate.jsx
+++ b/src/data-publication/reports/NationalAggregate.jsx
@@ -6,7 +6,7 @@ import Reports from './Reports.jsx'
 import Report from './Report.jsx'
 import { NATIONAL_AGGREGATE_REPORTS } from '../constants/national-aggregate-reports.js'
 import { withAppContext } from '../../common/appContextHOC.jsx'
-
+import ExternalLink from '../../common/ExternalLink'
 import './NationalAggregate.css'
 
 const detailsCache = {
@@ -52,8 +52,8 @@ class NationalAggregate extends React.Component {
           cross-tabulated by loan, borrower and geographic characteristics."
       >
           <p>To learn about modifications to these reports over the years, visit the{' '}
-          <a target="_blank" rel="noopener noreferrer" href={`/documentation/${years[0]}/ad-changes/`}>A&D Report Changes</a> page.<br/>
-          Looking for other HMDA data? Visit the new <a target="_blank" rel="noopener noreferrer" href="/data-browser/">HMDA Data Browser</a> to filter and download HMDA datasets.
+          <ExternalLink url={`/documentation/${years[0]}/ad-changes/`}>A&amp;D Report Changes</ExternalLink> page.<br/>
+          Looking for other HMDA data? Visit the new <ExternalLink url="/data-browser/">HMDA Data Browser</ExternalLink> to filter and download HMDA datasets.
           </p>
       </Heading>
     )

--- a/src/documentation/FigLinks.jsx
+++ b/src/documentation/FigLinks.jsx
@@ -1,27 +1,28 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import ExternalLink from '../common/ExternalLink'
 
 const links = {
   2017: [
-    <li key="0"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2017-hmda-fig.pdf">For data collected in 2017</a></li>,
+    <li key="0"><ExternalLink url="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2017-hmda-fig.pdf">For data collected in 2017</ExternalLink></li>,
   ],
   2018: [
-    <li key="1"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2018-hmda-fig.pdf">For data collected in 2018</a></li>,
-    <li key="2"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2018-hmda-fig-2018-hmda-rule.pdf">For data collected in 2018 incorporating the 2018 HMDA rule</a></li>
+    <li key="1"><ExternalLink url="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2018-hmda-fig.pdf">For data collected in 2018</ExternalLink></li>,
+    <li key="2"><ExternalLink url="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2018-hmda-fig-2018-hmda-rule.pdf">For data collected in 2018 incorporating the 2018 HMDA rule</ExternalLink></li>
   ],
   2019: [
-    <li key="3"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2019-hmda-fig.pdf">For data collected in 2019</a></li>,
+    <li key="3"><ExternalLink url="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2019-hmda-fig.pdf">For data collected in 2019</ExternalLink></li>,
     <li key="4"><Link to="/documentation/2019/annual-filing-dates/">Annual HMDA Filing Period Dates</Link></li>
   ],
   2020: [
-    <li key="5"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2020-hmda-fig.pdf">For data collected in 2020</a></li>,
-    <li key="6"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/supplemental-guide-for-quarterly-filers.pdf">Supplemental Guide for Quarterly Filers</a></li>,
+    <li key="5"><ExternalLink url="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2020-hmda-fig.pdf">For data collected in 2020</ExternalLink></li>,
+    <li key="6"><ExternalLink url="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/supplemental-guide-for-quarterly-filers.pdf">Supplemental Guide for Quarterly Filers</ExternalLink></li>,
     <li key="7"><Link to="/documentation/2020/annual-filing-dates/">Annual HMDA Filing Period Dates</Link></li>,
     <li key="8"><Link to="/documentation/2020/quarterly-filing-dates/">Quarterly HMDA Filing Period Dates</Link></li>
   ],
   2021: [
-    <li key="9"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2021-hmda-fig.pdf">For data collected in 2021 ( Last updated: 11/20/2020 )</a></li>,
-    <li key="10"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/supplemental-guide-for-quarterly-filers-for-2021.pdf">Supplemental Guide for Quarterly Filers for 2021</a></li>,
+    <li key="9"><ExternalLink url="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2021-hmda-fig.pdf">For data collected in 2021 ( Last updated: 11/20/2020 )</ExternalLink></li>,
+    <li key="10"><ExternalLink url="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/supplemental-guide-for-quarterly-filers-for-2021.pdf">Supplemental Guide for Quarterly Filers for 2021</ExternalLink></li>,
     <li key="11"><Link to="/documentation/2021/annual-filing-dates/">Annual HMDA Filing Period Dates</Link></li>,
     <li key="12"><Link to="/documentation/2021/quarterly-filing-dates/">Quarterly HMDA Filing Period Dates</Link></li>
   ]

--- a/src/documentation/Home.jsx
+++ b/src/documentation/Home.jsx
@@ -7,7 +7,7 @@ import FigLinks from './FigLinks.jsx'
 import Publications from './publications'
 import Tools from './tools'
 import { DOCS_YEARS } from '../common/constants/years.js'
-import { ExternalLink } from '../common/ExternalLink'
+import ExternalLink from '../common/ExternalLink.jsx'
 
 const Home = props => {
   const { year, url } = props
@@ -37,48 +37,15 @@ const Home = props => {
       </div>
       <div>
         <h2>HMDA APIs</h2>
-        <p>
-          Endpoints, schemas, and examples to help you access HMDA Data via the
-          HMDA APIs.
-        </p>
-        <ul>
-          <li>
-            <ExternalLink
-              url='https://cfpb.github.io/hmda-platform/'
-              text='HMDA APIs - Overview'
-            />
-          </li>
-          <li>
-            <ExternalLink
-              url='https://cfpb.github.io/hmda-platform/#data-browser-api'
-              text='HMDA Data Browser API'
-            />
-          </li>
-          <li>
-            <ExternalLink
-              url='https://cfpb.github.io/hmda-platform/#hmda-filing-api'
-              text='HMDA Filing API'
-            />
-          </li>
-          <li>
-            <ExternalLink
-              url='https://cfpb.github.io/hmda-platform/#hmda-public-verification-api'
-              text='HMDA Public Verification API'
-            />
-          </li>
-          <li>
-            <ExternalLink
-              url='https://cfpb.github.io/hmda-platform/#rate-spread-rate-spread-api'
-              text='HMDA Rate Spread API'
-            />
-          </li>
-          <li>
-            <ExternalLink
-              url='https://cfpb.github.io/hmda-platform/#check-digit'
-              text='HMDA Check Digit API'
-            />
-          </li>
-        </ul>
+          <p>Endpoints, schemas, and examples to help you access HMDA Data via the HMDA APIs.</p>
+          <ul>
+            <li><ExternalLink url="https://cfpb.github.io/hmda-platform/">HMDA APIs - Overview</ExternalLink></li>
+            <li><ExternalLink url="https://cfpb.github.io/hmda-platform/#data-browser-api">HMDA Data Browser API</ExternalLink></li>
+            <li><ExternalLink url="https://cfpb.github.io/hmda-platform/#hmda-filing-api">HMDA Filing API</ExternalLink></li>
+            <li><ExternalLink url="https://cfpb.github.io/hmda-platform/#hmda-public-verification-api">HMDA Public API</ExternalLink></li>
+            <li><ExternalLink url="https://cfpb.github.io/hmda-platform/#rate-spread">HMDA Rate Spread API</ExternalLink></li>
+            <li><ExternalLink url="https://cfpb.github.io/hmda-platform/#check-digit">HMDA Check Digit API</ExternalLink></li>
+          </ul>
       </div>
     </div>
   )

--- a/src/documentation/markdown/2018/filing-faq.md
+++ b/src/documentation/markdown/2018/filing-faq.md
@@ -40,13 +40,16 @@ You can use the <a target="_blank" rel="noopener noreferrer" href="https://s3.am
 The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/lar-formatting">**LAR Formatting Tool**</a> assists institutions that are not using their own vendor software in formatting their LAR files correctly. In order to successfully use the tool, Excel macros need to be enabled; please work with your IT department if this is not the case. Additionally, institutions should take note of the annotations that appear when hovering over each cell. These annotations describe what values can be included in each cell. The first tab of the tool entitled “Resources” gives instructions on use.  
 
 The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/file-format-verification">**File Format Verification Tool**</a> is a resource for testing whether your file meets certain formatting requirements specified in the HMDA FIG, specifically that the file
-is pipe-delimited;
-has the proper number of data fields; and
-has data fields formatted as integers, where necessary.
+
+- is pipe-delimited;
+- has the proper number of data fields; and
+- has data fields formatted as integers, where necessary. 
+
 The FFVT does not allow you to submit HMDA data. Additionally, there is a unique File Format Verification Tool for each HMDA data collection year, so please select the relevant year before uploading a file.
 
 #### I’m having issues when I try to upload my file, what should I do?
 If you are having issues uploading a new file and are receiving errors from a previous upload, please: 
+
 - refresh the page
 - log out
 - clear your browser’s cache (clear your browser’s history)
@@ -54,6 +57,7 @@ If you are having issues uploading a new file and are receiving errors from a pr
 - upload your file again  
 
 Additionally, if you are using Internet Explorer, we have found that filers have fewer browser caching issues using Google Chrome. The time required to upload may vary depending on the size of your institution’s LAR(s).  In some cases, very large files can take a day to fully upload.  Be sure to allocate enough time for the upload process to complete prior to the filing deadline.  **Do not refresh or close the browser window while the file is uploading**. If you continue to experience timeouts or other upload errors, we recommend ensuring that the following URLs are whitelisted in your digital loss prevention software to allow for the transfer of HMDA files:
+
  - ffiec.cfpb.gov
  - ffiec.beta.cfpb.gov
 
@@ -100,6 +104,7 @@ Please note that the fields 'Ethnicity of Applicant or Borrower 1-5' and 'Race o
 
 #### I am receiving validity edits regarding my county codes & census tracts. Can you explain how these fields are derived?
 Your county code is a 5 digit number that combines state and county codes. Your census tract should be an 11 digit number. Your census tract combines the 2 digit state, 3 digit county, and 6 digit tract code (with no decimal). The FFIEC census tool and FFIEC geocoder can assist in providing the correct state, county and census tract combinations.  
+
 - <a target="_blank" rel="noopener noreferrer" href="https://www.ffiec.gov/%5C/census/default.aspx">Census Tool</a>  
 - <a target="_blank" rel="noopener noreferrer" href="https://geomap.ffiec.gov/FFIECGeocMap/GeocodeMap1.aspx">Geocoder</a>  
 

--- a/src/documentation/markdown/2019/filing-faq.md
+++ b/src/documentation/markdown/2019/filing-faq.md
@@ -42,9 +42,11 @@ You can use the <a target="_blank" rel="noopener noreferrer" href="https://s3.am
 The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/lar-formatting">**LAR Formatting Tool**</a> assists institutions that are not using their own vendor software in formatting their LAR files correctly. In order to successfully use the tool, Excel macros need to be enabled; please work with your IT department if this is not the case. Additionally, institutions should take note of the annotations that appear when hovering over each cell. These annotations describe what values can be included in each cell. The first tab of the tool entitled “Resources” gives instructions on use.  
 
 The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/file-format-verification">**File Format Verification Tool**</a> is a resource for testing whether your file meets certain formatting requirements specified in the HMDA FIG, specifically that the file
+
 - is pipe-delimited;
 - has the proper number of data fields; and
 - has data fields formatted as integers, where necessary.
+
 The FFVT does not allow you to submit HMDA data. Additionally, there is a unique File Format Verification Tool for each HMDA data collection year, so please select the relevant year before uploading a file.  
 
 The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread">**Rate Spread calculator**</a> allows institutions to enter their loan data manually, or upload a CSV file of loan information that will help calculate the rate spread.  
@@ -54,16 +56,19 @@ The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/to
 
 #### I’m having issues when I try to upload my file, what should I do?
 If you are having issues uploading a new file and are receiving errors from a previous upload, please: 
+
 - refresh the page
 - log out
 - clear your browser’s cache (clear your browser’s history)
 - log back in
--  upload your file again  
+- upload your file again  
 
 Additionally, if you are using Internet Explorer, we have found that filers have fewer browser caching issues using Google Chrome. The time required to upload may vary depending on the size of your institution’s LAR(s).  In some cases, very large files can take a day to fully upload.  Be sure to allocate enough time for the upload process to complete prior to the filing deadline.  **Do not refresh or close the browser window while the file is uploading**. If you continue to experience timeouts or other upload errors, we recommend ensuring that the following URLs are whitelisted in your digital loss prevention software to allow for the transfer of HMDA files:
- - ffiec.cfpb.gov
- - ffiec.beta.cfpb.gov
- 
+
+- ffiec.cfpb.gov
+- ffiec.beta.cfpb.gov
+
+
 #### If I use separate systems to create my LAR, will uploading more than one at a time be an issue?
 If using two separate systems to create your LAR File, please combine all entries into one file. Uploading a new file will overwrite the first file uploaded.
 
@@ -113,6 +118,7 @@ Please note that the fields 'Ethnicity of Applicant or Borrower 1-5' and 'Race o
 
 #### I am receiving validity edits regarding my county codes & census tracts. Can you explain how these fields are derived?
 Your county code is a 5 digit number that combines state and county codes. Your census tract should be an 11 digit number. Your census tract combines the 2 digit state, 3 digit county, and 6 digit tract code (with no decimal). The FFIEC census tool and FFIEC geocoder can assist in providing the correct state, county and census tract combinations.  
+
 - <a target="_blank" rel="noopener noreferrer" href="https://www.ffiec.gov/%5C/census/default.aspx">Census Tool</a>  
 - <a target="_blank" rel="noopener noreferrer" href="https://geomap.ffiec.gov/FFIECGeocMap/GeocodeMap1.aspx">Geocoder</a>  
 

--- a/src/documentation/markdown/2020/filing-faq.md
+++ b/src/documentation/markdown/2020/filing-faq.md
@@ -40,6 +40,7 @@ You can use the <a target="_blank" rel="noopener noreferrer" href="https://s3.am
 The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/lar-formatting">**LAR Formatting Tool**</a> assists institutions that are not using their own vendor software in formatting their LAR files correctly. In order to successfully use the tool, **Excel macros need to be enabled**; please work with your IT department if this is not the case. Additionally, institutions should take note of the annotations that appear when hovering over each cell. These annotations describe what values can be included in each cell. The first tab of the tool entitled “Resources” gives instructions on use.  
 
 The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/file-format-verification">**File Format Verification Tool**</a> is a resource for testing whether your file meets certain formatting requirements specified in the HMDA FIG, specifically that the file
+
 - is pipe-delimited;
 - has the proper number of data fields; and
 - has data fields formatted as integers, where necessary.  
@@ -53,13 +54,15 @@ The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/to
 
 #### I’m having issues when I try to upload my file, what should I do?
 If you are having issues uploading a new file and are receiving errors from a previous upload, please: 
+
 - refresh the page
 - log out
 - clear your browser’s cache (clear your browser’s history)
 - log back in
--  upload your file again  
+- upload your file again  
 
 Additionally, if you are using Internet Explorer, we have found that filers have fewer browser caching issues using Google Chrome. The time required to upload may vary depending on the size of your institution’s LAR(s).  In some cases, very large files can take a day to fully upload.  Be sure to allocate enough time for the upload process to complete prior to the filing deadline.  **Do not refresh or close the browser window while the file is uploading**. If you continue to experience timeouts or other upload errors, we recommend ensuring that the following URLs are whitelisted in your digital loss prevention software to allow for the transfer of HMDA files:
+
  - ffiec.cfpb.gov
  - ffiec.beta.cfpb.gov
 
@@ -83,6 +86,7 @@ _Annual HMDA data submissions_ for the 2019 filing year are accepted January 1 -
 ![2020 annual filing dates](https://raw.githubusercontent.com/cfpb/hmda-frontend/master/src/documentation/markdown/images/annual_filing.png)  
 
 _Quarterly HMDA data submissions_ are separated into three quarters.  
+
 - Quarter 1 filing period: April 1 - May 30, 2020  
 - Quarter 2 filing period: July 1 - August 29, 2020  
 - Quarter 3 filing period: October 1 - November 29, 2020  
@@ -116,6 +120,7 @@ Please note that the fields 'Ethnicity of Applicant or Borrower 1-5' and 'Race o
 
 #### I am receiving validity edits regarding my county codes & census tracts. Can you explain how these fields are derived?
 Your county code is a 5 digit number that combines state and county codes. Your census tract should be an 11 digit number. Your census tract combines the 2 digit state, 3 digit county, and 6 digit tract code (with no decimal). The FFIEC census tool and FFIEC geocoder can assist in providing the correct state, county and census tract combinations.  
+
 - <a target="_blank" rel="noopener noreferrer" href="https://www.ffiec.gov/%5C/census/default.aspx">Census Tool</a>  
 - <a target="_blank" rel="noopener noreferrer" href="https://geomap.ffiec.gov/FFIECGeocMap/GeocodeMap1.aspx">Geocoder</a>  
 

--- a/src/documentation/markdown/2021/filing-faq.md
+++ b/src/documentation/markdown/2021/filing-faq.md
@@ -41,9 +41,11 @@ You can use the <a target="_blank" rel="noopener noreferrer" href="https://s3.am
 The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/lar-formatting">**LAR Formatting Tool**</a> assists institutions that are not using their own vendor software in formatting their LAR files correctly. In order to successfully use the tool, Excel macros need to be enabled; please work with your IT department if this is not the case. Additionally, institutions should take note of the annotations that appear when hovering over each cell. These annotations describe what values can be included in each cell. The first tab of the tool entitled “Resources” gives instructions on use.  
 
 The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/file-format-verification">**File Format Verification Tool**</a> is a resource for testing whether your file meets certain formatting requirements specified in the HMDA FIG, specifically that the file
+
 - is pipe-delimited;
 - has the proper number of data fields; and
 - has data fields formatted as integers, where necessary.
+
 The FFVT does not allow you to submit HMDA data. Additionally, there is a unique File Format Verification Tool for each HMDA data collection year, so please select the relevant year before uploading a file.  
 
 The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread">**Rate Spread calculator**</a> allows institutions to enter their loan data manually, or upload a CSV file of loan information that will help calculate the rate spread.  
@@ -53,13 +55,15 @@ The <a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/to
 
 #### I’m having issues when I try to upload my file, what should I do?
 If you are having issues uploading a new file and are receiving errors from a previous upload, please: 
+
 - refresh the page
 - log out
 - clear your browser’s cache (clear your browser’s history)
 - log back in
--  upload your file again  
+- upload your file again  
 
 Additionally, if you are using Internet Explorer, we have found that filers have fewer browser caching issues using Google Chrome. The time required to upload may vary depending on the size of your institution’s LAR(s).  In some cases, very large files can take a day to fully upload.  Be sure to allocate enough time for the upload process to complete prior to the filing deadline.  **Do not refresh or close the browser window while the file is uploading**. If you continue to experience timeouts or other upload errors, we recommend ensuring that the following URLs are whitelisted in your digital loss prevention software to allow for the transfer of HMDA files:
+
  - ffiec.cfpb.gov
  - ffiec.beta.cfpb.gov
 
@@ -82,7 +86,8 @@ _Annual HMDA data submissions_ for the 2019 filing year are accepted January 1 -
 
 ![2020 annual filing dates](https://raw.githubusercontent.com/cfpb/hmda-frontend/master/src/documentation/markdown/images/annual_filing.png)  
 
-_Quarterly HMDA data submissions_ are separated into three quarters.  
+_Quarterly HMDA data submissions_ are separated into three quarters. 
+
 - Quarter 1 filing period: April 1 - May 30, 2021  
 - Quarter 2 filing period: July 1 - August 30, 2021  
 - Quarter 3 filing period: October 1 - November 29, 2021  
@@ -116,6 +121,7 @@ Please note that the fields 'Ethnicity of Applicant or Borrower 1-5' and 'Race o
 
 #### I am receiving validity edits regarding my county codes & census tracts. Can you explain how these fields are derived?
 Your county code is a 5 digit number that combines state and county codes. Your census tract should be an 11 digit number. Your census tract combines the 2 digit state, 3 digit county, and 6 digit tract code (with no decimal). The FFIEC census tool and FFIEC geocoder can assist in providing the correct state, county and census tract combinations.  
+
 - <a target="_blank" rel="noopener noreferrer" href="https://www.ffiec.gov/%5C/census/default.aspx">Census Tool</a>  
 - <a target="_blank" rel="noopener noreferrer" href="https://geomap.ffiec.gov/FFIECGeocMap/GeocodeMap1.aspx">Geocoder</a>  
 

--- a/src/documentation/publications/ModifiedLar.jsx
+++ b/src/documentation/publications/ModifiedLar.jsx
@@ -1,30 +1,31 @@
 import React from 'react'
 import Product from '../Product.jsx'
 import { Link } from 'react-router-dom'
+import ExternalLink from '../../common/ExternalLink'
 
 const links = {
   permanent: [
-    <li key="0"><a target="_blank" rel="noopener noreferrer" href="/data-publication/documents#modified-lar">Supporting Documentation</a></li>,
-    <li key="1"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/ModifiedLarWithExcel.md">How to Open a Modified LAR Text Files with Excel</a></li>
+    <li key="0"><ExternalLink url="/data-publication/documents#modified-lar">Supporting Documentation</ExternalLink></li>,
+    <li key="1"><ExternalLink url="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/ModifiedLarWithExcel.md">How to Open a Modified LAR Text Files with Excel</ExternalLink></li>
   ],
   2017: [],
   2018: [
-    <li key="18-1"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
-    <li key="18-2"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2018-public-LAR-code-sheet.pdf">2018 Public LAR Code Sheet PDF</a></li>,
+    <li key="18-1"><ExternalLink url="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</ExternalLink></li>,
+    <li key="18-2"><ExternalLink url="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2018-public-LAR-code-sheet.pdf">2018 Public LAR Code Sheet PDF</ExternalLink></li>,
     <li key="18-3"><Link to="/documentation/2018/modified-lar-header/">Modified LAR Header</Link></li>,
     <li key="18-4"><Link to="/documentation/2018/modified-lar-schema/">Modified LAR Schema</Link></li>,
   ],
   2019: [
-    <li key="3"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
+    <li key="3"><ExternalLink url="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</ExternalLink></li>,
     <li key="19-2"><Link to="/documentation/2019/modified-lar-header/">Modified LAR Header</Link></li>,
     <li key="19-3"><Link to="/documentation/2019/modified-lar-schema/">Modified LAR Schema</Link></li>,
   ],
   2020: [
-    <li key="4"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
+    <li key="4"><ExternalLink url="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</ExternalLink></li>,
     <li key="20-2"><Link to="/documentation/2020/modified-lar-schema/">Modified LAR Schema</Link></li>,
   ],
   2021: [
-    <li key="21-1"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
+    <li key="21-1"><ExternalLink url="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</ExternalLink></li>,
     <li key="21-2"><Link to="/documentation/2021/modified-lar-schema/">Modified LAR Schema</Link></li>,
   ]
 }

--- a/src/documentation/publications/SnapshotDynamic.jsx
+++ b/src/documentation/publications/SnapshotDynamic.jsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import Product from '../Product.jsx'
+import ExternalLink from '../../common/ExternalLink'
 
 const links = {
   2017: [
-    <li key="2017-0" ><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_dataformat.pdf">Snapshot File Specifications – LAR, TS, and Reporter Panel</a></li>,
-    <li key="2017-1"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_codesheet.pdf">Snapshot File Specifications – LAR Code Sheet</a></li>,
-    <li key="2017-2"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_LAR_Spec.csv">Dynamic File Specifications – Loan/Application Records</a></li>,
-    <li key="2017-3"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_TS_Spec.csv">Dynamic File Specifications – Transmittal Sheet Records</a></li>,
+    <li key="2017-0"><ExternalLink url="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_dataformat.pdf">Snapshot File Specifications – LAR, TS, and Reporter Panel</ExternalLink></li>,
+    <li key="2017-1"><ExternalLink url="https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_codesheet.pdf">Snapshot File Specifications – LAR Code Sheet</ExternalLink></li>,
+    <li key="2017-2"><ExternalLink url="https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_LAR_Spec.csv">Dynamic File Specifications – Loan/Application Records</ExternalLink></li>,
+    <li key="2017-3"><ExternalLink url="https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_TS_Spec.csv">Dynamic File Specifications – Transmittal Sheet Records</ExternalLink></li>,
     <li key="2017-4"><Link to="/documentation/2017/lar-data-fields/">Public HMDA Data Fields with Values and Definitions</Link></li>,
     <li key="2017-5"><Link to="/documentation/2017/ts-data-fields/">Public Transmittal Sheet Data Fields with Values and Definitions</Link></li>,
     <li key="2017-6"><Link to="/documentation/2017/panel-data-fields/">Public Panel Data Fields with Values and Definitions</Link></li>,

--- a/src/documentation/tools/DataBrowser.jsx
+++ b/src/documentation/tools/DataBrowser.jsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import Product from '../Product.jsx'
+import ExternalLink from '../../common/ExternalLink'
 
 const links = {
   2017: [
-    <li key="0">The HMDA Data Browser currently allows users to filter and download HMDA datasets for 2018 and beyond. Historic data from 2007-2017 is <a target="_blank" rel="noopener noreferrer" href="https://www.consumerfinance.gov/data-research/hmda/historic-data/">available for download here</a>.</li>,
+    <li key="0">The HMDA Data Browser currently allows users to filter and download HMDA datasets for 2018 and beyond. Historic data from 2007-2017 is <ExternalLink url="https://www.consumerfinance.gov/data-research/hmda/historic-data/">available for download here</ExternalLink>.</li>,
     // <li key="1"><Link to="/documentation/2017/data-browser-filters/">Available Filters</Link></li>, // TODO: Uncomment when 2017 DB is released.
   ],
   2018: [

--- a/src/documentation/tools/RateSpread.jsx
+++ b/src/documentation/tools/RateSpread.jsx
@@ -1,23 +1,24 @@
 import React from 'react'
 import Product from '../Product.jsx'
+import ExternalLink from '../../common/ExternalLink'
 
 const links = {
   2017: [],
   2018: [
-    <li key="0"><a target="_blank" rel="noopener noreferrer" href="/tools/rate-spread/requirements">Data Requirements</a></li>,
-    <li key="1"><a target="_blank" rel="noopener noreferrer" href="/tools/rate-spread/methodology">Methodology for Determining Average Prime Offer Rates</a></li>
+    <li key="0"><ExternalLink url="/tools/rate-spread/requirements">Data Requirements</ExternalLink></li>,
+    <li key="1"><ExternalLink url="/tools/rate-spread/methodology">Methodology for Determining Average Prime Offer Rates</ExternalLink></li>
   ],
   2019: [
-    <li key="2019-0"><a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread/requirements">Data Requirements</a></li>,
-    <li key="2019-1"><a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread/methodology">Methodology for Determining Average Prime Offer Rates</a></li>
+    <li key="2019-0"><ExternalLink url="https://ffiec.cfpb.gov/tools/rate-spread/requirements">Data Requirements</ExternalLink></li>,
+    <li key="2019-1"><ExternalLink url="https://ffiec.cfpb.gov/tools/rate-spread/methodology">Methodology for Determining Average Prime Offer Rates</ExternalLink></li>
   ],
   2020: [
-    <li key="2020-0"><a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread/requirements">Data Requirements</a></li>,
-    <li key="2020-1"><a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread/methodology">Methodology for Determining Average Prime Offer Rates</a></li>
+    <li key="2020-0"><ExternalLink url="https://ffiec.cfpb.gov/tools/rate-spread/requirements">Data Requirements</ExternalLink></li>,
+    <li key="2020-1"><ExternalLink url="https://ffiec.cfpb.gov/tools/rate-spread/methodology">Methodology for Determining Average Prime Offer Rates</ExternalLink></li>
   ],
   2021: [
-    <li key="2021-0"><a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread/requirements">Data Requirements</a></li>,
-    <li key="2021-1"><a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread/methodology">Methodology for Determining Average Prime Offer Rates</a></li>
+    <li key="2021-0"><ExternalLink url="https://ffiec.cfpb.gov/tools/rate-spread/requirements">Data Requirements</ExternalLink></li>,
+    <li key="2021-1"><ExternalLink url="https://ffiec.cfpb.gov/tools/rate-spread/methodology">Methodology for Determining Average Prime Offer Rates</ExternalLink></li>
   ]
 }
 

--- a/src/filing/institutions/Header.jsx
+++ b/src/filing/institutions/Header.jsx
@@ -7,6 +7,7 @@ import { HeaderBeforeOpen } from './HeaderBeforeOpen.jsx'
 import { HeaderOpen } from './HeaderOpen'
 import { HeaderClosed } from './HeaderClosed'
 import { HeaderLate } from './HeaderLate'
+import ExternalLink from '../../common/ExternalLink'
 
 const InstitutionsHeader = ({ filingPeriodOrig, filingQuarters, filingQuartersLate, hasQuarterlyFilers }) => {
   if (!filingPeriodOrig || isBeta()) return null
@@ -71,14 +72,7 @@ export const HeaderDocsLink = ({ filingYear, isQuarter }) => {
   return (
     <>
       {text}
-      <a
-        href={url}
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Documentation
-      </a>{" "}
-      page.
+      <ExternalLink url={url}>Documentation</ExternalLink> page.
     </>
   )
 }

--- a/src/filing/institutions/MissingInstitutionsBanner.jsx
+++ b/src/filing/institutions/MissingInstitutionsBanner.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Alert from "../../common/Alert.jsx"
+import ExternalLink from '../../common/ExternalLink'
 
 export const MissingInstitutionsBanner = ({ leis = [] }) => {
   const hasMissingLeis = leis.length > 0
@@ -33,7 +34,7 @@ export const MissingLeiList = ({ leis = [] }) => {
   if(leis.length < 1) return null
 
   return (
-    <div className="missing-leis">
+    <div className='missing-leis'>
       <p>
         The following institutions are associated with your profile, but not for
         the currently selected year:
@@ -44,15 +45,8 @@ export const MissingLeiList = ({ leis = [] }) => {
         ))}
       </ul>
       <p>
-        To associate one or more of these institutions, please contact{" "}
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="mailto:hmdahelp@cfpb.gov"
-        >
-          HMDA Help
-        </a>
-        .
+        To associate one or more of these institutions, please contact{' '}
+        <ExternalLink url='mailto:hmdahelp@cfpb.gov'>HMDA Help</ExternalLink>.
       </p>
     </div>
   )

--- a/src/filing/refileWarning/index.jsx
+++ b/src/filing/refileWarning/index.jsx
@@ -10,6 +10,7 @@ import {
   MACRO_EDITS,
   VALIDATED
 } from '../constants/statusCodes.js'
+import ExternalLink from '../../common/ExternalLink'
 
 import './RefileWarning.css'
 
@@ -89,7 +90,19 @@ export const getText = props => {
       {text}
       {button}
       {periodAfter ? '.' : null}
-      <p style={{marginTop: '15px'}}>Need help? Visit our <a target="_blank" rel="noopener noreferrer" href={`/documentation/${props.match.params.filingPeriod}/`}>documentation page</a> or contact <a href="https://hmdahelp.consumerfinance.gov" target="_blank" rel="noopener noreferrer">HMDA Help</a>.</p>
+      <p style={{ marginTop: '15px' }}>
+        Need help? Visit our{' '}
+        <ExternalLink
+          url={`/documentation/${props.match.params.filingPeriod}/`}
+        >
+          documentation page
+        </ExternalLink>{' '}
+        or contact{' '}
+        <ExternalLink url='https://hmdahelp.consumerfinance.gov'>
+          HMDA Help
+        </ExternalLink>
+        .
+      </p>
     </div>
   )
 }

--- a/src/filing/submission/parseErrors/index.jsx
+++ b/src/filing/submission/parseErrors/index.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import RefileWarningComponent from '../../refileWarning/index.jsx'
 import submissionProgressHOC from '../progressHOC.jsx'
 import Pagination from '../../pagination/container.jsx'
+import ExternalLink from '../../../common/ExternalLink'
 
 import './ParseErrors.css'
 
@@ -91,9 +92,9 @@ class ParseErrors extends Component {
 
     return (
       <section
-        ref={el => (this.rendered = el)}
-        className="ParseErrors"
-        id="parseErrors"
+        ref={(el) => (this.rendered = el)}
+        className='ParseErrors'
+        id='parseErrors'
       >
         <RefileWarning />
         <header>
@@ -102,28 +103,27 @@ class ParseErrors extends Component {
               {props.pagination.total} {errorText} with Formatting Errors
             </h2>
           )}
-          <p className="usa-font-lead">
+          <p className='usa-font-lead'>
             The uploaded file is not formatted according to the requirements
             specified in the{' '}
-            <a
-              rel="noopener noreferrer"
-              target="_blank"
-              href={filingPeriod === '2018'
-                ? 'https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2018-hmda-fig-2018-hmda-rule.pdf'
-                : `https://s3.amazonaws.com/cfpb-hmda-public/prod/help/${filingPeriod}-hmda-fig.pdf`
+            <ExternalLink
+              url={
+                filingPeriod === '2018'
+                  ? 'https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2018-hmda-fig-2018-hmda-rule.pdf'
+                  : `https://s3.amazonaws.com/cfpb-hmda-public/prod/help/${filingPeriod}-hmda-fig.pdf`
               }
             >
               Filing Instructions Guide
-            </a>{' '}
-            for data collected in {filingPeriod}{filingPeriod === '2018'
+            </ExternalLink>{' '}
+            for data collected in {filingPeriod}
+            {filingPeriod === '2018'
               ? ' incorporating the 2018 HMDA Rule.'
-              : '.'
-            }
+              : '.'}
           </p>
         </header>
         {renderTSErrors(props)}
         {renderLarErrors(props)}
-        <Pagination isFetching={props.isFetching} target="parseErrors" />
+        <Pagination isFetching={props.isFetching} target='parseErrors' />
         <RefileWarning />
       </section>
     )

--- a/src/hmda-help/publications/DownloadButton.jsx
+++ b/src/hmda-help/publications/DownloadButton.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
+import ExternalLink from '../../common/ExternalLink'
 
 export const DownloadButton = ({ url }) => (
-  <a href={url} target="_blank" rel="noopener noreferrer">
-    Download
-  </a>
+  <ExternalLink url={url}>Download</ExternalLink>
 )

--- a/src/homepage/index.js
+++ b/src/homepage/index.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { isBeta } from '../common/Beta.jsx'
 import { withAppContext } from '../common/appContextHOC'
 import { AnnouncementBanner } from './AnnouncementBanner'
+import ExternalLink from '../common/ExternalLink'
 import './Home.css'
 
 export function isProd() {
@@ -40,13 +41,9 @@ const Home = ({ config }) => {
           <div className="card">
             <header>
               <h3>
-                <a
-                  href={`/filing/${defaultPeriod}/`}
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
+                <ExternalLink url={`/filing/${defaultPeriod}/`}>
                   Access the HMDA {isBeta() && 'Beta '} Filing Platform
-                </a>
+                </ExternalLink>
               </h3>
               <p>
                 Beginning with HMDA data collected in or after 2017, financial


### PR DESCRIPTION
- Corrects Markdown lists that were not being displayed with bullets
- Replaces use of `target="_blank" rel="noopener noreferrer"` with the common `ExternalLink` component