### PR TITLE
Display date of last update for S3 files

### DIFF
--- a/src/common/useS3LastUpdated.jsx
+++ b/src/common/useS3LastUpdated.jsx
@@ -1,9 +1,7 @@
-import React from 'react'
 import { useEffect, useState } from 'react'
-import LoadingIcon from './LoadingIcon'
 
 /**
- * Displays the last update date of an S3 file,
+ * Provides the last update date string of an S3 file,
  * displays a loading indicator while fetching.
  * @param {*} url S3 file
  * @param {*} shouldFetch Workaround to skip fetching of file headers
@@ -20,12 +18,11 @@ export const useS3LastUpdated = (url, shouldFetch) => {
       let date = new Date(lastMod)
       date.setHours(date.getHours() - 5) // Convert GMT to ET
 
-      setDateStr(` - Updated: ${date.toDateString()}`)
+      setDateStr(date.toDateString())
     })
   }, [url])
 
   if (!shouldFetch) return null
-  if (!dateStr) return <LoadingIcon className='LoadingInline' />
 
   return dateStr
 }

--- a/src/common/useS3LastUpdated.jsx
+++ b/src/common/useS3LastUpdated.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { useEffect, useState } from 'react'
+import LoadingIcon from './LoadingIcon'
+
+/**
+ * Displays the last update date of an S3 file,
+ * displays a loading indicator while fetching.
+ * @param {*} url S3 file
+ * @param {*} shouldFetch Workaround to skip fetching of file headers
+ * @returns Date string or LoadingIcon or null
+ */
+export const useS3LastUpdated = (url, shouldFetch) => {
+  const [dateStr, setDateStr] = useState()
+
+  useEffect(() => {
+    setDateStr(null)
+    if (!shouldFetch) return
+    fetch(url, { method: 'HEAD' }).then(response => {
+      const lastMod = response.headers.get('last-modified')
+      let date = new Date(lastMod)
+      date.setHours(date.getHours() - 5) // Convert GMT to ET
+
+      setDateStr(` - Updated: ${date.toDateString()}`)
+    })
+  }, [url])
+
+  if (!shouldFetch) return null
+  if (!dateStr) return <LoadingIcon className='LoadingInline' />
+
+  return dateStr
+}

--- a/src/data-publication/reports/DynamicDataset.css
+++ b/src/data-publication/reports/DynamicDataset.css
@@ -35,3 +35,8 @@
 .DynamicDataset .item:last-child {
   margin-right: 0;
 }
+
+.DynamicDataset #datasetList .modified {
+  margin-left: 2px;
+  color: grey;
+}

--- a/src/data-publication/reports/DynamicDataset.jsx
+++ b/src/data-publication/reports/DynamicDataset.jsx
@@ -3,16 +3,13 @@ import Heading from '../../common/Heading.jsx'
 import YearSelector from '../../common/YearSelector.jsx'
 import { DYNAMIC_DATASET } from '../constants/dynamic-dataset.js'
 import { withAppContext } from '../../common/appContextHOC.jsx'
-
+import { MakeListLink } from './MakeListLink'
 import './DynamicDataset.css'
 
-function makeListLink(href, val) {
-  return (
-    <li>
-      <a href={href}>{val}</a>
-    </li>
-  )
-}
+const linkToDocs2017 = ({ lar_spec, ts_spec }) => [
+  <MakeListLink href={lar_spec} label='Loan/Application Records (LAR)' />,
+  <MakeListLink href={ts_spec} label='Transmittal Sheet Records (TS)' />
+]
 
 function linkToDocs(year = '2018'){
   return [
@@ -31,40 +28,49 @@ const DynamicDataset = props => {
   const dataForYear = DYNAMIC_DATASET[year]
 
   return (
-    <div className="DynamicDataset" id="main-content">
+    <div className='DynamicDataset' id='main-content'>
       <Heading
         type={1}
-        headingText="Dynamic National Loan-Level Dataset"
-        paragraphText="The dynamic files contain the national HMDA datasets for
+        headingText='Dynamic National Loan-Level Dataset'
+        paragraphText='The dynamic files contain the national HMDA datasets for
           all HMDA reporters, modified by the Bureau to protect applicant and
           borrower privacy, updated to include late submissions and
           resubmissions. The dynamic files are available to download in a pipe
           delimited text file format. The dynamic datasets are updated on Mondays
-          with HMDA submissions received through the previous Sunday night."
+          with HMDA submissions received through the previous Sunday night.'
       />
 
       <YearSelector year={year} url={url} years={years} />
 
-      {year ?
-        <div className="grid">
-          <div className="item">
+      {year && (
+        <div className='grid'>
+          <div className='item'>
             <Heading type={4} headingText={year + ' Dynamic Datasets'} />
             <ul id='datasetList'>
-              {makeListLink(dataForYear.lar, 'Loan/Application Records (LAR)')}
-              {makeListLink(dataForYear.ts, 'Transmittal Sheet Records (TS)')}
+              <MakeListLink
+                href={dataForYear.lar}
+                label='Loan/Application Records (LAR)'
+                showLastUpdated
+              />
+              <MakeListLink
+                href={dataForYear.ts}
+                label='Transmittal Sheet Records (TS)'
+                showLastUpdated
+              />
             </ul>
           </div>
-          <div className="item">
-            <Heading type={4} headingText={year + ' Dynamic File Specifications'} />
+          <div className='item'>
+            <Heading
+              type={4}
+              headingText={year + ' Dynamic File Specifications'}
+            />
             <ul>
-              {year === '2017' ? makeListLink(dataForYear.lar_spec, 'Loan/Application Records (LAR)') : null}
-              {year === '2017' ? makeListLink(dataForYear.ts_spec, 'Transmittal Sheet Records (TS)') : null}
-              {year !== '2017' ? linkToDocs(year) : null}
+              {year === '2017' ? linkToDocs2017(dataForYear) : linkToDocs(year)}
             </ul>
           </div>
         </div>
-        : null }
-      </div>
+      )}
+    </div>
   )
 }
 

--- a/src/data-publication/reports/MakeListLink.jsx
+++ b/src/data-publication/reports/MakeListLink.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useS3LastUpdated } from '../../common/useS3LastUpdated'
+import LoadingIcon from '../../common/LoadingIcon'
 
 /**
  * Display a downloadable list item with/without last updated date
@@ -17,7 +18,11 @@ export const MakeListLink = ({ href, children, label, showLastUpdated }) => {
       <a download href={href}>
         {children || label}
       </a>
-      {lastUpdated && <span className='modified'>{lastUpdated}</span>}
+      {lastUpdated ? (
+        <span className='modified'> - Updated: {lastUpdated}</span>
+      ) : showLastUpdated ? (
+        <LoadingIcon className='LoadingInline' />
+      ) : null}
     </li>
   )
 }

--- a/src/data-publication/reports/MakeListLink.jsx
+++ b/src/data-publication/reports/MakeListLink.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { useS3LastUpdated } from '../../common/useS3LastUpdated'
+
+/**
+ * Display a downloadable list item with/without last updated date
+ * @param {String} href S3 url
+ * @param {Boolean} showLastUpdated Include last update date?
+ * @param {Element} children Link text
+ * @returns Element
+ */
+export const MakeListLink = ({ href, children, showLastUpdated }) => {
+  const lastUpdated = useS3LastUpdated(href, showLastUpdated)
+
+  return (
+    <li key={href}>
+      <a download href={href}>
+        {children}
+      </a>
+      {lastUpdated && <span className='modified'>{lastUpdated}</span>}
+    </li>
+  )
+}

--- a/src/data-publication/reports/MakeListLink.jsx
+++ b/src/data-publication/reports/MakeListLink.jsx
@@ -6,15 +6,16 @@ import { useS3LastUpdated } from '../../common/useS3LastUpdated'
  * @param {String} href S3 url
  * @param {Boolean} showLastUpdated Include last update date?
  * @param {Element} children Link text
+ * @param {String} label Link text
  * @returns Element
  */
-export const MakeListLink = ({ href, children, showLastUpdated }) => {
+export const MakeListLink = ({ href, children, label, showLastUpdated }) => {
   const lastUpdated = useS3LastUpdated(href, showLastUpdated)
 
   return (
     <li key={href}>
       <a download href={href}>
-        {children}
+        {children || label}
       </a>
       {lastUpdated && <span className='modified'>{lastUpdated}</span>}
     </li>

--- a/src/data-publication/reports/snapshot/Snapshot.css
+++ b/src/data-publication/reports/snapshot/Snapshot.css
@@ -39,3 +39,8 @@
 .Snapshot .item li > ul {
   margin-top: 0.5em;
 }
+
+.Snapshot #datasetList .modified {
+  margin-left: 2px;
+  color: grey;
+}

--- a/src/data-publication/reports/snapshot/index.jsx
+++ b/src/data-publication/reports/snapshot/index.jsx
@@ -53,7 +53,7 @@ const Snapshot = props => {
           protect applicant and borrower privacy. The snapshot files are available
           to download in both .csv and pipe delimited text file formats.`}
       >
-        {year === '2017' ? (
+        {year === '2017' && (
           <p className='text-small'>
             Snapshot data has preserved some elements of historic LAR data files
             that are not present in the Dynamic Data. These columns are &quot;As
@@ -62,7 +62,7 @@ const Snapshot = props => {
             procedures that handle both files will need to recognize this
             difference.
           </p>
-        ) : null}
+        )}
         <p className='text-small'>
           Use caution when analyzing loan amount and income, which do not have
           an upper limit and may contain outliers.
@@ -81,9 +81,10 @@ const Snapshot = props => {
             <Heading type={4} headingText={year + ' File Specifications'} />
             <ul>
               {year === '2017' ? (
-                <MakeListLink href={dataForYear.dataformat}>
-                  LAR, TS and Reporter Panel
-                </MakeListLink>
+                <MakeListLink
+                  href={dataForYear.dataformat}
+                  label='LAR, TS and Reporter Panel'
+                />
               ) : (
                 linkToDocs(year)
               )}

--- a/src/data-publication/reports/snapshot/index.jsx
+++ b/src/data-publication/reports/snapshot/index.jsx
@@ -3,15 +3,8 @@ import Heading from '../../../common/Heading.jsx'
 import YearSelector from '../../../common/YearSelector.jsx'
 import { SNAPSHOT_DATASET } from '../../constants/snapshot-dataset.js'
 import { withAppContext } from '../../../common/appContextHOC.jsx'
+import { MakeListLink } from '../MakeListLink'
 import './Snapshot.css'
-
-function makeListLink(href, val) {
-  return (
-    <li key={href}>
-      <a download={true} href={href}>{val}</a>
-    </li>
-  )
-}
 
 function linkToDocs(year = '2018'){
   return [
@@ -32,8 +25,8 @@ function renderDatasets(datasets){
           <li key={i}>
             {dataset.label}
             <ul>
-              {makeListLink(dataset.csv, 'CSV')}
-              {makeListLink(dataset.txt, 'Pipe Delimited')}
+              <MakeListLink href={dataset.csv} showLastUpdated>CSV</MakeListLink>
+              <MakeListLink href={dataset.csv} showLastUpdated>Pipe Delimited</MakeListLink>
             </ul>
           </li>
         )
@@ -46,30 +39,31 @@ const Snapshot = props => {
   const { params, url } = props.match
   const { year } = params
   const { snapshot, shared  } = props.config.dataPublicationYears
-  const years =  snapshot || shared
+  const years = snapshot || shared
   const dataForYear = SNAPSHOT_DATASET[year]
   const snapshotDate = year ? dataForYear.snapshot_date : 'a fixed date per year'
 
   return (
-    <div className="Snapshot" id="main-content">
+    <div className='Snapshot' id='main-content'>
       <Heading
         type={1}
-        headingText="Snapshot National Loan Level Dataset"
+        headingText='Snapshot National Loan Level Dataset'
         paragraphText={`The snapshot files contain the national HMDA datasets as of
           ${snapshotDate} for all HMDA reporters, as modified by the Bureau to
           protect applicant and borrower privacy. The snapshot files are available
-          to download in both .csv and pipe delimited text file formats.`}>
-        {year === '2017'
-          ? <p className="text-small">
-              Snapshot data has preserved some elements of historic LAR data files
-              that are not present in the Dynamic Data. These columns are &quot;As of
-              Date&quot;, &quot;Edit Status&quot;, &quot;Sequence Number&quot;, and &quot;Application Date
-              Indicator&quot;. Be aware that data load procedures that handle both files
-              will need to recognize this difference.
-            </p>
-          : null
-        }
-        <p className="text-small">
+          to download in both .csv and pipe delimited text file formats.`}
+      >
+        {year === '2017' ? (
+          <p className='text-small'>
+            Snapshot data has preserved some elements of historic LAR data files
+            that are not present in the Dynamic Data. These columns are &quot;As
+            of Date&quot;, &quot;Edit Status&quot;, &quot;Sequence Number&quot;,
+            and &quot;Application Date Indicator&quot;. Be aware that data load
+            procedures that handle both files will need to recognize this
+            difference.
+          </p>
+        ) : null}
+        <p className='text-small'>
           Use caution when analyzing loan amount and income, which do not have
           an upper limit and may contain outliers.
         </p>
@@ -77,23 +71,26 @@ const Snapshot = props => {
 
       <YearSelector year={year} url={url} years={years} />
 
-      { year ?
-        <div className="grid">
-          <div className="item">
+      {year ? (
+        <div className='grid'>
+          <div className='item'>
             <Heading type={4} headingText={year + ' Datasets'} />
             {renderDatasets(dataForYear.datasets)}
           </div>
-          <div className="item">
+          <div className='item'>
             <Heading type={4} headingText={year + ' File Specifications'} />
             <ul>
-              {year === '2017'
-                ? makeListLink(dataForYear.dataformat, 'LAR, TS and Reporter Panel')
-                : linkToDocs(year)
-              }
+              {year === '2017' ? (
+                <MakeListLink href={dataForYear.dataformat}>
+                  LAR, TS and Reporter Panel
+                </MakeListLink>
+              ) : (
+                linkToDocs(year)
+              )}
             </ul>
           </div>
         </div>
-        : null }
+      ) : null}
     </div>
   )
 }

--- a/src/data-publication/reports/snapshot/index.jsx
+++ b/src/data-publication/reports/snapshot/index.jsx
@@ -71,7 +71,7 @@ const Snapshot = props => {
 
       <YearSelector year={year} url={url} years={years} />
 
-      {year ? (
+      {year && (
         <div className='grid'>
           <div className='item'>
             <Heading type={4} headingText={year + ' Datasets'} />
@@ -90,7 +90,7 @@ const Snapshot = props => {
             </ul>
           </div>
         </div>
-      ) : null}
+      )}
     </div>
   )
 }

--- a/src/tools/index.css
+++ b/src/tools/index.css
@@ -15,6 +15,10 @@
   padding-right: 75px;
 }
 
+.Tools .modified {
+  color: grey
+}
+
 @media print {
   .Tools #main-content{
     width: 100%;

--- a/src/tools/lar-formatting/AppIntro.jsx
+++ b/src/tools/lar-formatting/AppIntro.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { withAppContext } from '../../common/appContextHOC.jsx'
 import Heading from '../../common/Heading.jsx'
+import { MakeListLink } from '../../data-publication/reports/MakeListLink'
 
 const AppIntro = ({ config = {} }) => {
   const { defaultDocsPeriod } = config
@@ -28,14 +29,11 @@ const AppIntro = ({ config = {} }) => {
     <h4 key={2}>Downloads</h4>,
 
     <ul key={3}>
-      <li>
-        <a
-          href="https://s3.amazonaws.com/cfpb-hmda-public/prod/larft/HMDA_LAR_Formatting_Tool.xlsm"
-          download={true}
-        >
-          LAR Formatting Tool for data collected in or after 2018
-        </a>
-      </li>
+      <MakeListLink
+        href='https://s3.amazonaws.com/cfpb-hmda-public/prod/larft/HMDA_LAR_Formatting_Tool.xlsm'
+        label='LAR Formatting Tool for data collected in or after 2018'
+        showLastUpdated
+      />
     </ul>
   ]
 }


### PR DESCRIPTION
Closes #1196

# Changes
- Displays the date when S3 hosted Snapshot and Dynamic dataset files were last updated

# Screenshots
Snapshot | Dynamic
---|---
<img width="969" alt="Screen Shot 2021-12-14 at 2 48 18 PM" src="https://user-images.githubusercontent.com/2592907/146257958-3dbd61ff-bacd-44f7-b122-df0014dcbb4d.png">|<img width="885" alt="Screen Shot 2021-12-14 at 2 48 01 PM" src="https://user-images.githubusercontent.com/2592907/146257999-e4136ab0-6152-46e0-8fb7-497e9e4ba5e6.png">

LAR Formatting Tool | 
---|
<img width="820" alt="Screen Shot 2021-12-15 at 1 52 13 PM" src="https://user-images.githubusercontent.com/2592907/146263440-085f49df-0344-44d5-b2d4-5e5af22ba73c.png">|

