### PR TITLE
FFVT - Remove year checks

### DIFF
--- a/src/tools/file-format-verification/containers/UploadForm.jsx
+++ b/src/tools/file-format-verification/containers/UploadForm.jsx
@@ -43,7 +43,7 @@ function setAndParseFile(file) {
 
       // Submit file for backend parsing only if all client-side validations pass
       if (getState().app.upload.errors.length === 0) {
-        dispatch(triggerParse(file, getState().app.filingPeriod))
+        dispatch(triggerParse(file))
       }
     }).catch(err => {
       // Save client-side validation errors


### PR DESCRIPTION
Closes #1270 

We've established that there is only one FFVT parser for all years, and we no longer accept user-input on which year the submitted file is for, so we no longer need to check for valid years in the FFVT parsing logic.
