### PR TITLE
Announcement Banner - Use the correct annual filing year when checking for events

### DIFF
--- a/src/homepage/AnnouncementBanner.jsx
+++ b/src/homepage/AnnouncementBanner.jsx
@@ -54,7 +54,7 @@ const scheduledFilingAnnouncements = (
   filingPeriodStatus
 ) => {
   const [year, quarter] = splitYearQuarter(defaultPeriod)
-  const annualFilingYear = parseInt(year) - 1
+  const annualFilingYear = quarter ? parseInt(year) - 1 : parseInt(year)
   const closingAnnualFiling = new Date().getFullYear() - 3
   const announcements = []
 

--- a/src/homepage/AnnouncementBanner.jsx
+++ b/src/homepage/AnnouncementBanner.jsx
@@ -55,7 +55,7 @@ const scheduledFilingAnnouncements = (
 ) => {
   const [year, quarter] = splitYearQuarter(defaultPeriod)
   const annualFilingYear = quarter ? parseInt(year) - 1 : parseInt(year)
-  const closingAnnualFiling = new Date().getFullYear() - 3
+  const closingAnnualFiling = new Date().getFullYear() - 4
   const announcements = []
 
   let status = filingPeriodStatus[defaultPeriod]


### PR DESCRIPTION
Closes #1287

- When we are in a Quarterly period, the previous calendar year is the latest open annual filing period; Else our default period is already the latest annual filing period, so we use it
- End of annual collection happens in data year + 4 (ex. 2018 collection ends in 2018+4 = 2022), so we should be checking for closure events accordingly (current year - 4 = 2022 - 4 = 2018). 