### PR TITLE
HMDA Help - Admin-selectable years

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = { presets: ['@babel/preset-env'] }

--- a/src/common/constants/configHelpers.js
+++ b/src/common/constants/configHelpers.js
@@ -43,7 +43,7 @@ export const getFilingYears = (config, options = defaultOpts) => {
     const [year, quarter] = splitYearQuarter(config.defaultPeriod)
     if (year) {
       const upcomingYear = quarter !== 'Q3' ? year : parseInt(year, 10) + 1
-      years.add(upcomingYear)
+      years.add(upcomingYear.toString())
     }
   }
 

--- a/src/common/constants/configHelpers.js
+++ b/src/common/constants/configHelpers.js
@@ -33,15 +33,16 @@ export const getFilingYears = (config, options = defaultOpts) => {
     isVisible && years.add(splitYearQuarter(period)[0])
   })
 
-  // Additional inclusions for HMDA Help users to enable administrative tasks
-  // for future/closed filing periods.
+  // Additions for HMDA Help users
   if (withAdmin) {
     config.timedGuards.preview.forEach(adminPeriod =>
       years.add(splitYearQuarter(adminPeriod)[0])
     )
 
-    const nextYear = parseInt(splitYearQuarter(config.defaultPeriod)[0], 10) + 1
-    years.add(nextYear.toString())
+    // Starting in Q3, automatically enable institution management for the upcoming year
+    const [year, quarter] = splitYearQuarter(config.defaultPeriod)
+    const upcomingYear = quarter !== 'Q3' ? year : parseInt(year, 10) + 1
+    years.add(upcomingYear.toString())
   }
 
   return Array.from(years)

--- a/src/common/constants/configHelpers.js
+++ b/src/common/constants/configHelpers.js
@@ -42,7 +42,7 @@ export const getFilingYears = (config, options = defaultOpts) => {
     // Starting in Q3, automatically enable institution management for the upcoming year
     const [year, quarter] = splitYearQuarter(config.defaultPeriod)
     const upcomingYear = quarter !== 'Q3' ? year : parseInt(year, 10) + 1
-    upcomingYear && years.add(upcomingYear.toString())
+    if (upcomingYear) years.add(upcomingYear.toString())
   }
 
   return Array.from(years)

--- a/src/common/constants/configHelpers.js
+++ b/src/common/constants/configHelpers.js
@@ -42,7 +42,7 @@ export const getFilingYears = (config, options = defaultOpts) => {
     // Starting in Q3, automatically enable institution management for the upcoming year
     const [year, quarter] = splitYearQuarter(config.defaultPeriod)
     const upcomingYear = quarter !== 'Q3' ? year : parseInt(year, 10) + 1
-    years.add(upcomingYear.toString())
+    upcomingYear && years.add(upcomingYear.toString())
   }
 
   return Array.from(years)

--- a/src/common/constants/configHelpers.js
+++ b/src/common/constants/configHelpers.js
@@ -41,8 +41,10 @@ export const getFilingYears = (config, options = defaultOpts) => {
 
     // Starting in Q3, automatically enable institution management for the upcoming year
     const [year, quarter] = splitYearQuarter(config.defaultPeriod)
-    const upcomingYear = quarter !== 'Q3' ? year : parseInt(year, 10) + 1
-    if (upcomingYear) years.add(upcomingYear.toString())
+    if (year) {
+      const upcomingYear = quarter !== 'Q3' ? year : parseInt(year, 10) + 1
+      years.add(upcomingYear)
+    }
   }
 
   return Array.from(years)

--- a/src/common/constants/configHelpers.spec.js
+++ b/src/common/constants/configHelpers.spec.js
@@ -6,7 +6,7 @@ const baseConfig = {
   }
 }
 
-test('No defaultPeriod adds no Administrative years', () => {
+test('No defaultPeriod produces no additional Administrative years', () => {
   expect(
     getFilingYears({ ...baseConfig })
   ).toStrictEqual([])

--- a/src/common/constants/configHelpers.spec.js
+++ b/src/common/constants/configHelpers.spec.js
@@ -1,0 +1,37 @@
+import { getFilingYears } from './configHelpers'
+
+const baseConfig = {
+  timedGuards: {
+    preview: []
+  }
+}
+
+test('No defaultPeriod adds no Administrative years', () => {
+  expect(
+    getFilingYears({ ...baseConfig })
+  ).toStrictEqual([])
+})
+
+test('Admins can access the current year for Annual ', () => {
+  expect(
+    getFilingYears({ ...baseConfig, defaultPeriod: '2019' })
+  ).toStrictEqual(['2019'])
+})
+
+test('Admins can access the current year in Q1 ', () => {
+  expect(
+    getFilingYears({ ...baseConfig, defaultPeriod: '2021-Q1' })
+  ).toStrictEqual(['2021'])
+})
+
+test('Admins can access the current year in Q2', () => {
+  expect(
+    getFilingYears({ ...baseConfig, defaultPeriod: '2021-Q2' })
+  ).toStrictEqual(['2021'])
+})
+
+test('Admins can access the next year during Q3', () => {
+  expect(
+    getFilingYears({ ...baseConfig, defaultPeriod: '2021-Q3' })
+  ).toStrictEqual(['2022'])
+})


### PR DESCRIPTION
Closes #1294

- More nuanced derivation of Admin-selectable years to automatically provide access 
- Adds unit tests for `getFilingYears`

This fix will resolve the current Cypress error on prod-beta in the Institutions test suite where we attempt to create an Institution for a year too far in the future.