### PR TITLE
Consistent PRA Link on mailing list form

### DIFF
--- a/src/common/MailingListSignup.jsx
+++ b/src/common/MailingListSignup.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { SUBSCRIPTION_ENDPOINT, HMDA_FILING_TOPIC_ID } from './constants/cfgov'
 import { useSubscriptionLogic } from './mailingListServices'
 import { EmailInput } from './EmailInput'
+import { ExternalLink } from './ExternalLink'
 import './MailingListSignupForm.css'
 
 // Common form heading
@@ -14,13 +15,12 @@ const Heading = () => (
 )
 
 const PrivacyStatement = () => (
-  <a
-    href='https://content.consumerfinance.gov/privacy/email-campaign-privacy-act-statement/'
-    target='_blank'
+  <ExternalLink
+    url='https://content.consumerfinance.gov/privacy/email-campaign-privacy-act-statement/'
     className='privacy-statement'
   >
     See Privacy Act statement
-  </a>
+  </ExternalLink>
 )
 
 /** A compact HMDA Mailing List Subscription form */

--- a/src/common/MailingListSignup.jsx
+++ b/src/common/MailingListSignup.jsx
@@ -13,6 +13,16 @@ const Heading = () => (
   </h3>
 )
 
+const PrivacyStatement = () => (
+  <a
+    href='https://content.consumerfinance.gov/privacy/email-campaign-privacy-act-statement/'
+    target='_blank'
+    className='privacy-statement'
+  >
+    See Privacy Act statement
+  </a>
+)
+
 /** A compact HMDA Mailing List Subscription form */
 export const MailingSignupSmall = () => {
   const { emailAddress, onEmailChange, onSubmit, currentStatus, submitButton } =
@@ -28,13 +38,7 @@ export const MailingSignupSmall = () => {
       {currentStatus}
       <div className='submit-container'>
         {submitButton}
-        <a
-          href='https://content.consumerfinance.gov/privacy/email-campaign-privacy-act-statement/'
-          target='_blank'
-          className='privacy-statement'
-        >
-          See Privacy Act statement
-        </a>
+        <PrivacyStatement />
       </div>
     </form>
   )
@@ -56,6 +60,7 @@ export const MailingSignupLarge = () => {
         <div className='submit-container'>{submitButton}</div>
       </div>
       {currentStatus}
+      <PrivacyStatement />
     </form>
   )
 }

--- a/src/common/MailingListSignupForm.css
+++ b/src/common/MailingListSignupForm.css
@@ -69,6 +69,14 @@
   margin-left: -5px;
 }
 
+.MailingListSignupForm.large .privacy-statement {
+  display: inline-block;
+  width: 100%;
+  margin-top: 1em;
+  padding-right: .5em;
+  text-align: right;
+}
+
 .MailingListSignupForm.large .submit-container button {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
@@ -101,7 +109,7 @@
 
   .MailingListSignupForm.large #email,
   .MailingListSignupForm.large .submit-container button {
-    margin-top: .5rem !important;
+    margin-top: 1rem !important;
   }
 }
 
@@ -120,6 +128,11 @@
 
   .MailingListSignupForm.large .submit-container button {
     border-radius: 5px;
+  }
+
+  .MailingListSignupForm.large .privacy-statement {
+    text-align: left;
+    margin: .5em 0 0 0;
   }
 }
 
@@ -155,7 +168,7 @@
     flex-flow: wrap;
   }
 
-  .MailingListSignupForm.small .submit-container .privacy-statement {
+  .MailingListSignupForm.small .privacy-statement {
     margin: 1rem 0 0 0;
     padding: 0;
   }

--- a/src/common/MailingListSignupForm.css
+++ b/src/common/MailingListSignupForm.css
@@ -81,6 +81,7 @@
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   padding: 8px 20px;
+  height: 3.5rem;
 }
 
 .MailingListSignupForm.large .title {


### PR DESCRIPTION
Closes #1297 

- Extracts PRA link into reusable component
- Adds link to MailingList.large

Link is responsively aligned with the form's submit button:

small screen | larger screen
---|---
<img width="307" alt="Screen Shot 2022-01-04 at 10 10 19 AM" src="https://user-images.githubusercontent.com/2592907/148098486-d8c0eade-e06d-46e1-9cfc-603480f08db3.png">|<img width="800" alt="Screen Shot 2022-01-04 at 10 10 29 AM" src="https://user-images.githubusercontent.com/2592907/148098505-e72cc026-0ab7-4c3a-92e1-551a53e77b8d.png">

