### PR TITLE
[Filing] Stalled uploads

### DIFF
--- a/src/filing/actions/receiveFiling.js
+++ b/src/filing/actions/receiveFiling.js
@@ -1,6 +1,18 @@
 import * as types from '../constants'
+import { isStalledUpload } from '../institutions/helpers'
+
 
 export default function receiveFiling(data) {
+  // Check for stalled uploads
+  data.submissions = data.submissions.map((sub) => {
+    const { status: { code }, start } = sub
+    
+    return {
+      ...sub,
+      isStalled: isStalledUpload(code, start),
+    }
+  })
+  
   return {
     type: types.RECEIVE_FILING,
     filing: data

--- a/src/filing/actions/receiveLatestSubmission.js
+++ b/src/filing/actions/receiveLatestSubmission.js
@@ -1,8 +1,14 @@
 import { RECEIVE_LATEST_SUBMISSION } from '../constants/index'
+import { isStalledUpload } from '../institutions/helpers'
 
 export default function receiveLatestSubmission(action) {
+  const { status: { code }, start } = action
+  
+  // Check for stalled uploads
+  action.isStalled = isStalledUpload(code, start)
+  
   return {
     type: RECEIVE_LATEST_SUBMISSION,
-    ...action
+    ...action,
   }
 }

--- a/src/filing/actions/receiveSubmission.js
+++ b/src/filing/actions/receiveSubmission.js
@@ -1,8 +1,13 @@
 import * as types from '../constants'
+import { isStalledUpload } from '../institutions/helpers'
 
 export default function receiveSubmission(data) {
+  const { status: { code }, start } = data
+  
   return {
     type: types.RECEIVE_SUBMISSION,
-    ...data
+    // Check for stalled uploads
+    isStalled: isStalledUpload(code, start),
+    ...data,
   }
 }

--- a/src/filing/institutions/Institution.jsx
+++ b/src/filing/institutions/Institution.jsx
@@ -45,7 +45,7 @@ const Institution = ({
             />
 
             <InstitutionViewButton
-              status={status}
+              submission={submission}
               institution={institution}
               filingPeriod={filing.period}
               isClosed={selectedPeriod.isClosed}

--- a/src/filing/institutions/Progress.jsx
+++ b/src/filing/institutions/Progress.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { isStalledUpload } from './helpers.js'
 import {
   PARSED_WITH_ERRORS,
   SYNTACTICAL_VALIDITY_EDITS,
@@ -15,9 +16,11 @@ import './Progress.css'
 
 const navMap = {
   upload: {
-    isErrored: submission => submission.status.code === PARSED_WITH_ERRORS,
+    isErrored: submission =>
+      submission.status.code === PARSED_WITH_ERRORS ||
+      isStalledUpload(submission.status.code, submission.start),
     isCompleted: submission => submission.status.code > UPLOADED,
-    errorText: 'uploaded with formatting errors',
+    errorText: 'upload error',
     completedText: 'uploaded'
   },
   'syntactical & validity edits': {

--- a/src/filing/institutions/Progress.jsx
+++ b/src/filing/institutions/Progress.jsx
@@ -2,13 +2,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {
   PARSED_WITH_ERRORS,
-  PARSED,
   SYNTACTICAL_VALIDITY_EDITS,
   NO_QUALITY_EDITS,
   NO_MACRO_EDITS,
   MACRO_EDITS,
   VALIDATED,
-  SIGNED
+  SIGNED,
+  UPLOADED,
 } from '../constants/statusCodes.js'
 
 import './Progress.css'
@@ -16,7 +16,7 @@ import './Progress.css'
 const navMap = {
   upload: {
     isErrored: submission => submission.status.code === PARSED_WITH_ERRORS,
-    isCompleted: submission => submission.status.code >= PARSED,
+    isCompleted: submission => submission.status.code > UPLOADED,
     errorText: 'uploaded with formatting errors',
     completedText: 'uploaded'
   },

--- a/src/filing/institutions/Progress.jsx
+++ b/src/filing/institutions/Progress.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { isStalledUpload } from './helpers.js'
 import {
   PARSED_WITH_ERRORS,
   SYNTACTICAL_VALIDITY_EDITS,
@@ -17,8 +16,7 @@ import './Progress.css'
 const navMap = {
   upload: {
     isErrored: submission =>
-      submission.status.code === PARSED_WITH_ERRORS ||
-      isStalledUpload(submission.status.code, submission.start),
+      submission.status.code === PARSED_WITH_ERRORS || submission.isStalled,
     isCompleted: submission => submission.status.code > UPLOADED,
     errorText: 'upload error',
     completedText: 'uploaded'

--- a/src/filing/institutions/Status.jsx
+++ b/src/filing/institutions/Status.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import CSVDownload from '../common/CSVContainer.jsx'
 import { CREATED, NO_QUALITY_EDITS, NO_MACRO_EDITS, SIGNED, VALIDATING } from '../constants/statusCodes.js'
-import { isStalledUpload } from './helpers.js'
 
 import './Status.css'
 
@@ -20,7 +19,7 @@ const defaultSubmission = closed => ({
 
 const InstitutionStatus = ({ submission, filing, isClosed }) => {
   const currSubmission = submission || defaultSubmission(isClosed)
-  const { start } = currSubmission
+  const { isStalled } = currSubmission
   const { code, message, description } = currSubmission.status
   const qualityOverride = code > NO_QUALITY_EDITS && (currSubmission.qualityExists && !currSubmission.qualityVerified)
   const submitOverride = code === NO_MACRO_EDITS
@@ -30,7 +29,7 @@ const InstitutionStatus = ({ submission, filing, isClosed }) => {
   let heading = message 
   let body = description 
 
-  if (isStalledUpload(code, start)) {
+  if (isStalled) {
     heading = 'Your previous upload attempt failed.'
     body = 'Please upload a new file.'
   } else if (qualityOverride) {

--- a/src/filing/institutions/ViewButton.jsx
+++ b/src/filing/institutions/ViewButton.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
-import { isStalledUpload } from './helpers.js'
 import RefileButton from '../refileButton/container.jsx'
 import { isBeta } from '../../common/Beta';
 
@@ -18,12 +17,12 @@ import {
 import './ViewButton.css'
 
 const InstitutionViewButton = ({ submission, institution, filingPeriod, isClosed }) => {
-  const { status, start } = submission
+  const { status, isStalled } = submission
   const code = status ? status.code : CREATED
   let text
   
   if (isClosed && code <= CREATED) return null
-  if (code === FAILED || isStalledUpload(code, start)) {
+  if (code === FAILED || isStalled) {
     return <RefileButton className="ViewButton" institution={institution} />
   } else if (code <= CREATED) {
     text = "Upload your " + (isBeta() ? 'test file' : 'official file')

--- a/src/filing/institutions/ViewButton.jsx
+++ b/src/filing/institutions/ViewButton.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
+import { isStalledUpload } from './helpers.js'
 import RefileButton from '../refileButton/container.jsx'
 import { isBeta } from '../../common/Beta';
 
@@ -11,16 +12,18 @@ import {
   NO_SYNTACTICAL_VALIDITY_EDITS,
   VALIDATING,
   NO_MACRO_EDITS,
-  VALIDATED
+  VALIDATED,
 } from '../constants/statusCodes.js'
 
 import './ViewButton.css'
 
-const InstitutionViewButton = ({ status, institution, filingPeriod, isClosed }) => {
+const InstitutionViewButton = ({ submission, institution, filingPeriod, isClosed }) => {
+  const { status, start } = submission
   const code = status ? status.code : CREATED
   let text
+  
   if (isClosed && code <= CREATED) return null
-  if (code === FAILED) {
+  if (code === FAILED || isStalledUpload(code, start)) {
     return <RefileButton className="ViewButton" institution={institution} />
   } else if (code <= CREATED) {
     text = "Upload your " + (isBeta() ? 'test file' : 'official file')

--- a/src/filing/institutions/helpers.js
+++ b/src/filing/institutions/helpers.js
@@ -1,4 +1,6 @@
 import { splitYearQuarter } from '../api/utils'
+import { UPLOADED } from '../constants/statusCodes'
+import { daysSince } from '../utils/date'
 
 export const getNextAnnualPeriod = (periodOptions = { options: [] }) => {
   let annual = periodOptions.options
@@ -10,3 +12,6 @@ export const getNextAnnualPeriod = (periodOptions = { options: [] }) => {
 
   return (nextAnnual || 2018).toString()
 }
+
+export const isStalledUpload = (code, start) =>
+  code === UPLOADED && daysSince(start) > 2

--- a/src/filing/institutions/helpers.js
+++ b/src/filing/institutions/helpers.js
@@ -1,6 +1,8 @@
 import { splitYearQuarter } from '../api/utils'
 import { UPLOADED } from '../constants/statusCodes'
-import { daysSince } from '../utils/date'
+import { hoursSince } from '../utils/date'
+
+const MAX_UPLOAD_HOURS = 5
 
 export const getNextAnnualPeriod = (periodOptions = { options: [] }) => {
   let annual = periodOptions.options
@@ -14,4 +16,4 @@ export const getNextAnnualPeriod = (periodOptions = { options: [] }) => {
 }
 
 export const isStalledUpload = (code, start) =>
-  code === UPLOADED && daysSince(start) >= 1
+  code === UPLOADED && hoursSince(start) > MAX_UPLOAD_HOURS

--- a/src/filing/institutions/helpers.js
+++ b/src/filing/institutions/helpers.js
@@ -14,4 +14,4 @@ export const getNextAnnualPeriod = (periodOptions = { options: [] }) => {
 }
 
 export const isStalledUpload = (code, start) =>
-  code === UPLOADED && daysSince(start) > 2
+  code === UPLOADED && daysSince(start) >= 1

--- a/src/filing/reducers/latestSubmissions.js
+++ b/src/filing/reducers/latestSubmissions.js
@@ -42,7 +42,8 @@ export default (state = defaultLatestSubmissions, action) => {
             qualityExists: action.qualityExists || defaultSubmission.qualityExists,
             qualityVerified: action.qualityVerified || defaultSubmission.qualityVerified,
             macroExists: action.macroExists || defaultSubmission.macroExists,
-            macroVerified: action.macroVerified || defaultSubmission.macroVerified
+            macroVerified: action.macroVerified || defaultSubmission.macroVerified,
+            isStalled: action.isStalled,
           }
         }
       }

--- a/src/filing/reducers/submission.js
+++ b/src/filing/reducers/submission.js
@@ -20,7 +20,8 @@ export const defaultSubmission = {
   qualityVerified: false,
   macroExists: false,
   macroVerified: false,
-  isFetching: false
+  isFetching: false,
+  isStalled: false,
 }
 
 /*
@@ -41,7 +42,8 @@ export default (state = defaultSubmission, action) => {
           qualityExists: action.qualityExists || false,
           qualityVerified: action.qualityVerified || false,
           macroExists: action.macroExists || false,
-          macroVerified: action.macroVerified || false
+          macroVerified: action.macroVerified || false,
+          isStalled: action.isStalled,
         }
       return state
     case SELECT_FILE:

--- a/src/filing/utils/date.js
+++ b/src/filing/utils/date.js
@@ -41,12 +41,14 @@ export function ordinalHour(d) {
 
 const msToDays = ms => ms / (1000 * 60 * 60 * 24)
 
+const msToHours = ms => ms / (1000 * 60 * 60)
+
 export const numDaysBetween = function(d1, d2) {
   var diff = d1.getTime() - d2.getTime();
   return msToDays(diff)
 }
 
-export const daysSince = timestamp => {
+export const hoursSince = timestamp => {
   const diffTime = Date.now() - timestamp
-  return msToDays(diffTime)
+  return msToHours(diffTime)
 }

--- a/src/filing/utils/date.js
+++ b/src/filing/utils/date.js
@@ -39,8 +39,14 @@ export function ordinalHour(d) {
   return `${ordinal(d)}, ${hour}:${min}:${sec} ${period}`
 }
 
+const msToDays = ms => ms / (1000 * 60 * 60 * 24)
+
 export const numDaysBetween = function(d1, d2) {
   var diff = d1.getTime() - d2.getTime();
-  const daysDiff = diff / (1000 * 60 * 60 * 24)
-  return daysDiff
-};
+  return msToDays(diff)
+}
+
+export const daysSince = timestamp => {
+  const diffTime = Date.now() - timestamp
+  return msToDays(diffTime)
+}


### PR DESCRIPTION
Closes #1115 

## Changes
- Display the `stalled upload` status if an Upload is not processed after 5hrs.
- Improve accuracy of `SubmissionNav` upload status indicator.
- Display `Refile` button, prompting user to re-upload, when `stalled`.

## Manual local testing
1. Paste the following snippet in `src/filing/institutions/Institution.jsx` at line 20
```
   submission = {
    id: {
      lei: 'FRONTENDTESTBANK9999',
      period: { year: 2019, quarter: null },
      sequenceNumber: 1005,
    },
    status: {
      code: 3,
      message: 'Your file has been uploaded.',
      description: 'Your data is ready to be analyzed.',
    },
    start: 1640650476515,
    end: 0,
    fileName: '2019-FRONTENDTESTBANK9999.txt',
    receipt: '',
    signerUsername: null,
    qualityVerified: false,
    macroVerified: false,
    qualityExists: false,
     macroExists: false,
    isStalled: true,
   }
```
2. Visit http://localhost:3000/filing/2019/institutions
3. Observe `After` state from the screenshots below

## Screenshots

Name | Description | Screenshot
---|---|---
Before | <ul><li>Submission nav is not updated</li><li>Messaging is self-contradictory (file is uploaded / View upload progress)</li></ul> |  <img width="741" alt="before" src="https://user-images.githubusercontent.com/2592907/149415380-e7d8c4ba-f4bc-4521-99d7-c766ce0b7509.png">
After | <ul><li>Submission nav shows error </li><li> All messaging indicates user needs to re-upload their file</li></ul> | <img width="747" alt="Screen Shot 2022-01-13 at 12 52 22 PM" src="https://user-images.githubusercontent.com/2592907/149415171-fca64665-7af1-4705-96d7-08af690c6272.png">

