### PR TITLE
Sets reasonable defaults for rate-spread

### DIFF
--- a/src/tools/rate-spread/Form.jsx
+++ b/src/tools/rate-spread/Form.jsx
@@ -13,7 +13,7 @@ const defaultState = {
   reverse: '2',
   rateSetDate: (new Date()).toLocaleDateString(),
   APR: '',
-  loanTerm: '30',
+  loanTerm: '',
   validationErrors: {},
   isFetching: false,
   error: false,


### PR DESCRIPTION

## Changes

- Sets default loan term to 30 years
- Sets default rate set/lock in date to the current day

These are just my best guesses, I'd recommend a quick analysis of data submitted to `/public/rateSpread` to find out whether these defaults are the most sensible (I'm fairly confident on 30 years, not super confident on rate set date.