### PR TITLE
Update Submission Nav

### DIFF
--- a/src/filing/institutions/Progress.jsx
+++ b/src/filing/institutions/Progress.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import {
   PARSED_WITH_ERRORS,
   SYNTACTICAL_VALIDITY_EDITS,
+  NO_SYNTACTICAL_VALIDITY_EDITS,
   NO_QUALITY_EDITS,
   NO_MACRO_EDITS,
   MACRO_EDITS,
@@ -23,7 +24,7 @@ const navMap = {
   },
   'syntactical & validity edits': {
     isErrored: submission => submission.status.code === SYNTACTICAL_VALIDITY_EDITS,
-    isCompleted: submission => submission.status.code > SYNTACTICAL_VALIDITY_EDITS,
+    isCompleted: submission => submission.status.code >= NO_SYNTACTICAL_VALIDITY_EDITS,
     errorText: 'syntactical & validity edits',
     completedText: 'no syntactical & validity edits'
   },

--- a/src/filing/submission/Nav.jsx
+++ b/src/filing/submission/Nav.jsx
@@ -36,7 +36,8 @@ export default class EditsNav extends Component {
       },
       'syntactical & validity edits': {
         isReachable: () =>
-          this.props.editsFetched && this.navMap.upload.isCompleted(),
+          this.props.editsFetched && this.navMap.upload.isCompleted() ||
+          this.props.code >= NO_SYNTACTICAL_VALIDITY_EDITS,
         isErrored: () => this.props.code === SYNTACTICAL_VALIDITY_EDITS,
         isCompleted: () =>
           (this.navMap['syntactical & validity edits'].isReachable() &&

--- a/src/filing/submission/router.jsx
+++ b/src/filing/submission/router.jsx
@@ -16,7 +16,8 @@ import {
   QUALITY_EDITS,
   NO_MACRO_EDITS,
   MACRO_EDITS,
-  VALIDATED
+  VALIDATED,
+  NO_SYNTACTICAL_VALIDITY_EDITS
 } from '../constants/statusCodes.js'
 
 const editTypes = ['syntacticalvalidity', 'quality', 'macro']
@@ -96,7 +97,12 @@ export class SubmissionRouter extends Component {
     if (code <= VALIDATING || code === NO_QUALITY_EDITS) return 'upload'
     if (code >= VALIDATED || code === NO_MACRO_EDITS) return 'submission'
     if (code === SYNTACTICAL_VALIDITY_EDITS) return 'syntacticalvalidity'
-    if (code >= QUALITY_EDITS && qualityExists && !qualityVerified) return 'quality'
+    if (
+      (code >= QUALITY_EDITS || code === NO_SYNTACTICAL_VALIDITY_EDITS) &&
+      qualityExists &&
+      !qualityVerified
+    )
+      return 'quality'
     return 'macro'
   }
 

--- a/src/filing/submission/upload/DropzoneContent.jsx
+++ b/src/filing/submission/upload/DropzoneContent.jsx
@@ -23,6 +23,11 @@ const DropzoneContent = ({ getRootProps, getInputProps, code, filename, errorFil
         }
         break
       case STATUS.UPLOADING:
+        messageObj = {
+          pre: 'Upload of',
+          post: 'is currently in progress'
+        }
+        break
       case STATUS.UPLOADED:
       case STATUS.PARSING:
       case STATUS.PARSED:
@@ -30,7 +35,7 @@ const DropzoneContent = ({ getRootProps, getInputProps, code, filename, errorFil
       case STATUS.NO_SYNTACTICAL_VALIDITY_EDITS:
       case STATUS.NO_QUALITY_EDITS:
         messageObj = {
-          pre: 'Upload of',
+          pre: 'Analysis of',
           post: 'is currently in progress'
         }
         break


### PR DESCRIPTION
Closes #1320


## Changes
- Updates the UI indicator for `Syntactical & Validity` edits once the Submission's status has reached `8 - No Syntactical or Validity edits`
  - Submission Nav
  - Progress Nav
- More accurate language in the Upload dropzone to indicate when the file is being `Analyzed` instead of `Uploaded`.

## Screenshots
The file is still being analyzed, but we know that it does not have SV edits, so we mark that step as done.

### Progress Nav
  before|after
  ---|---
<img width="930" alt="Screen Shot 2022-01-25 at 4 06 36 PM" src="https://user-images.githubusercontent.com/2592907/151074755-16964d8f-e69f-4481-b96e-01685b1d3cdc.png">|<img width="930" alt="Screen Shot 2022-01-25 at 3 56 27 PM" src="https://user-images.githubusercontent.com/2592907/151074391-0b3f6853-fdcc-4a44-bd2a-19fe9753a700.png">

### Submission Nav
We also indicate `Analysis` in the dropzone text since the file is uploaded but still being checked for Edits.
  before|after
  ---|---
<img width="1139" alt="before1" src="https://user-images.githubusercontent.com/2592907/151074672-6f7614f0-3f75-44e5-bc8a-336de5426c38.png">|<img width="1137" alt="Screen Shot 2022-01-25 at 4 02 04 PM" src="https://user-images.githubusercontent.com/2592907/151074891-ed89ed37-705c-4415-bbed-1af7c60b22ba.png">

