### PR TITLE
Guard destructuring

### DIFF
--- a/src/filing/actions/receiveFiling.js
+++ b/src/filing/actions/receiveFiling.js
@@ -1,20 +1,25 @@
 import * as types from '../constants'
+import { UNINITIALIZED } from '../constants/statusCodes'
 import { isStalledUpload } from '../institutions/helpers'
 
 
 export default function receiveFiling(data) {
   // Check for stalled uploads
-  data.submissions = data.submissions?.map((sub) => {
-    const { status: { code }, start } = sub
-    
-    return {
-      ...sub,
-      isStalled: isStalledUpload(code, start),
-    }
-  })
+  const filing = {
+    ...data,
+    submissions: data.submissions?.map((sub) => {
+      const { start } = sub
+      const code = sub.status?.code || UNINITIALIZED
+      
+      return {
+        ...sub,
+        isStalled: isStalledUpload(code, start),
+      }
+    })
+  } 
   
   return {
     type: types.RECEIVE_FILING,
-    filing: data
+    filing
   }
 }

--- a/src/filing/actions/receiveFiling.js
+++ b/src/filing/actions/receiveFiling.js
@@ -4,7 +4,7 @@ import { isStalledUpload } from '../institutions/helpers'
 
 export default function receiveFiling(data) {
   // Check for stalled uploads
-  data.submissions = data.submissions.map((sub) => {
+  data.submissions = data.submissions?.map((sub) => {
     const { status: { code }, start } = sub
     
     return {

--- a/src/filing/actions/receiveLatestSubmission.js
+++ b/src/filing/actions/receiveLatestSubmission.js
@@ -6,7 +6,6 @@ export default function receiveLatestSubmission(action) {
   const { start } = action
   const code = action.status?.code || UNINITIALIZED
   
-  // Check for stalled uploads
   action.isStalled = isStalledUpload(code, start)
   
   return {

--- a/src/filing/actions/receiveLatestSubmission.js
+++ b/src/filing/actions/receiveLatestSubmission.js
@@ -1,9 +1,10 @@
 import { RECEIVE_LATEST_SUBMISSION } from '../constants/index'
+import { UNINITIALIZED } from '../constants/statusCodes'
 import { isStalledUpload } from '../institutions/helpers'
 
 export default function receiveLatestSubmission(action) {
   const { start } = action
-  let code = action.status?.code || -1
+  const code = action.status?.code || UNINITIALIZED
   
   // Check for stalled uploads
   action.isStalled = isStalledUpload(code, start)

--- a/src/filing/actions/receiveLatestSubmission.js
+++ b/src/filing/actions/receiveLatestSubmission.js
@@ -2,7 +2,8 @@ import { RECEIVE_LATEST_SUBMISSION } from '../constants/index'
 import { isStalledUpload } from '../institutions/helpers'
 
 export default function receiveLatestSubmission(action) {
-  const { status: { code }, start } = action
+  const { start } = action
+  let code = action.status?.code || -1
   
   // Check for stalled uploads
   action.isStalled = isStalledUpload(code, start)

--- a/src/filing/institutions/Institution.jsx
+++ b/src/filing/institutions/Institution.jsx
@@ -33,7 +33,7 @@ const Institution = ({
             <InstitutionNameAndId
               name={institution.name}
               lei={institution.lei}
-              filingPeriod={filing.period}
+              filingPeriod={filing.period || selectedPeriod.period}
             />
 
             <SubmissionNav submission={submission} />
@@ -72,6 +72,7 @@ const Institution = ({
             <InstitutionNameAndId
               name={institution.name}
               lei={institution.lei}
+              filingPeriod={selectedPeriod.period}
             />
             <Alert type='error' heading='Sorry, there was a problem.'>
               <p>


### PR DESCRIPTION
Closes #1326 

## Changes
- Stalled Upload check - guard destructuring to avoid error
- Institutions: Add Filing Period and fallback where appropriate

## Testing
- Start HMDA Platform / Institutions API locally
- Frontend on `master`: `yarn ci-data && yarn ci`
- Visit http://localhost:3000/filing and observe that institutions are stuck in loading status for all periods
- Frontend: `git checkout 1326-bad-destructure`
- Visit http://localhost:3000/filing and observe that institutions are loading for all periods