### PR TITLE
[Filing] Block non-UTF8 encoded file uploads with message

### DIFF
--- a/src/filing/utils/checkFileErrors.js
+++ b/src/filing/utils/checkFileErrors.js
@@ -48,7 +48,7 @@ function fileIsEmpty(file) {
 }
 
 function extensionIsNotTxt(file) {
-  let extension = file?.name?.split('.').slice(-1)[0]?.toLowerCase()
+  const extension = file?.name?.split('.').slice(-1)[0]?.toLowerCase()
   if (extension !== 'txt')
     return 'The file you uploaded is not a text file (.txt). Please check your file and re-upload.'
 }

--- a/src/filing/utils/checkFileErrors.js
+++ b/src/filing/utils/checkFileErrors.js
@@ -1,3 +1,5 @@
+import detectFileEncoding from 'detect-file-encoding-and-language'
+
 export default function checkFileErrors(file, cb) {
   const fileSlice = file.slice(0, 2)
   const reader = new window.FileReader()
@@ -5,27 +7,40 @@ export default function checkFileErrors(file, cb) {
   reader.addEventListener('load', () => {
     const firstBytes = reader.result
     const errors = []
-
+    
     if (file && file.size !== undefined && file.name !== undefined) {
-      const notTxt = file.name.split('.').slice(-1)[0].toLowerCase() !== 'txt'
-      if (file.size === 0) {
-        errors.push(
-          'The file you uploaded does not contain any data. Please check your file and re-upload.'
-        )
-      }
-      if (notTxt) {
-        errors.push(
-          'The file you uploaded is not a text file (.txt). Please check your file and re-upload.'
-        )
-      }
-      if(firstBytes !== ('1|') && !notTxt){
-        errors.push('Your file appears to be a text file (.txt) but has invalid content. Please ensure you are uploading a pipe-delimited text file and that your transmittal sheet begins with 1.');
-      }
+      detectFileEncoding(file).then(fileInfo => {
+        if (fileInfo.encoding !== 'UTF-8'){
+          errors.push(
+            'The file you selected is not UTF-8 encoded. Please check your file and re-upload.'
+          )
+          
+          // Skip additional checks to avoid false-positives
+          return cb(errors)
+        }
+
+        const notTxt = file.name.split('.').slice(-1)[0].toLowerCase() !== 'txt'
+        if (file.size === 0) {
+          errors.push(
+            'The file you uploaded does not contain any data. Please check your file and re-upload.'
+          )
+        }
+        if (notTxt) {
+          errors.push(
+            'The file you uploaded is not a text file (.txt). Please check your file and re-upload.'
+          )
+        }
+        if(firstBytes !== ('1|') && !notTxt){
+          errors.push('Your file appears to be a text file (.txt) but has invalid content. Please ensure you are uploading a pipe-delimited text file and that your transmittal sheet begins with 1.');
+        }
+
+        cb(errors)
+      })
     } else {
       errors.push('Your file was not uploaded. Please try again.')
+      cb(errors)
     }
-
-    cb(errors)
   })
+
   reader.readAsText(fileSlice)
 }


### PR DESCRIPTION
Closes #1311

## Changes

- Checks file encoding of uploads `if (fileInfo.encoding !== 'UTF-8')`
- Moves other checks inside of `detectFileEncoding` promise for consistency. 

## Testing

1. I've run 5 1M row submissions through this check and have not found any memory spikes 

## Screenshots
<img width="1099" alt="Screen Shot 2022-01-27 at 12 42 23 PM" src="https://user-images.githubusercontent.com/2592907/151431988-847036a8-f283-4811-a328-9a3f31ce29c3.png">

