### PR TITLE
[Beta][Filing] Match the defaultPeriod to Production

### DIFF
--- a/src/common/configUtils.js
+++ b/src/common/configUtils.js
@@ -22,8 +22,15 @@ export function getDefaultConfig(str) {
     : isBeta(host)
       ? devBeta
       : dev
+
+  const derivedConfig = deriveConfig(baseConfig)
+
+  if (isBeta(host)) {
+    const prodConfig = getDefaultConfig('ffiec')
+    derivedConfig.defaultPeriod = prodConfig?.defaultPeriod
+  }
   
-  return deriveConfig(baseConfig)
+  return derivedConfig
 }
 
 export function isProd(host) {


### PR DESCRIPTION
Closes #1328 

## Changes

- Set the Beta config's `defaultPeriod` to match Production's `defaultPeriod`

## Testing

https://user-images.githubusercontent.com/2592907/151609339-60c1fb35-c765-42bf-8b99-b2b301edf1e4.mov



1. Change [App](https://github.com/cfpb/hmda-frontend/blob/master/src/App.jsx#L30) to use Beta config:
  ```
const config = useEnvironmentConfig('beta')
```
2. Visit http://localhost:3000/filing
3. Observe that you are redirected to `2021` like in Prod vs `2022` like in Beta



## Notes

- This redirection happens based on the in-build configurations, before the fetched config can have any effect. Once I realized that, I was able to figured out the right place to make the adjustment. 
