### PR TITLE
Open Frontend but closed Backend

### DIFF
--- a/src/common/constants/platform-messages.js
+++ b/src/common/constants/platform-messages.js
@@ -1,0 +1,5 @@
+const FilingNotAllowed = /^The provided year or quarter is no longer available|^Bad/
+
+export {
+  FilingNotAllowed,
+}

--- a/src/filing/actions/fetchNewFiling.js
+++ b/src/filing/actions/fetchNewFiling.js
@@ -6,6 +6,7 @@ import { createFiling } from '../api/api.js'
 import { error } from '../utils/log.js'
 import receiveLatestSubmission from './receiveLatestSubmission'
 import receiveNonQFiling from './receiveNonQFiling'
+import { FilingNotAllowed } from '../../common/constants/platform-messages.js'
 
 export default function fetchNewFiling(filing) {
   return dispatch => {
@@ -14,10 +15,7 @@ export default function fetchNewFiling(filing) {
       .then(json => {
         return hasHttpError(json).then(hasError => {
           if (hasError) {
-            const ignoreMessage =
-              /^The provided year or quarter is no longer available|^Bad/
-            
-            if (json.status == '400' && json.statusText.match(ignoreMessage)) {
+            if (json.status == '400' && json.statusText.match(FilingNotAllowed)) {
               console.log(
                 'Ignoring that we are unable to create a Filing for this period...',
                 filing.period,


### PR DESCRIPTION
Closes #1344 

## Changes

If the Frontend attempts to create a new Filing for a period that is closed (i.e. When a filer has no Filing nor any submissions), and receives a status message that starts with `The provided year or quarter is no longer available`, we appropriately display that those institutions have no filings. 
 
This scenario should not occur as we already have Timed Guard based checks to avoid attempting to create Filings for closed periods, but this is a fail-safe for the case where the Frontend and Backend are out of sync.

## UI
Local Frontend pointed at Production
<img width="1904" alt="Screen Shot 2022-02-10 at 6 44 36 PM" src="https://user-images.githubusercontent.com/2592907/153525725-d4a9b42f-e135-4cd5-92bf-1a8f7c147fdb.png">

