### PR TITLE
[ModifiedLAR][Config] Add 2021 option to MLAR page

### DIFF
--- a/src/common/constants/dev-config.json
+++ b/src/common/constants/dev-config.json
@@ -26,6 +26,13 @@
   },
   "ffvtAnnouncement": null,
   "dataPublicationYears": {
+    "mlar": [
+      "2021",
+      "2020",
+      "2019",
+      "2018",
+      "2017"
+    ],
     "shared": [
       "2020",
       "2019",


### PR DESCRIPTION
Part of #1377 

Adds 2021 as an option on the Modified LAR page in the `DEV` environment.
 
<img width="503" alt="Screen Shot 2022-03-21 at 4 31 28 PM" src="https://user-images.githubusercontent.com/2592907/159373934-cd98fedd-2383-4216-8468-0e2f2437b2f7.png">

