### PR TITLE
Modified LAR 2021 - Part 2 (Release)

### DIFF
--- a/src/common/constants/dev-config.json
+++ b/src/common/constants/dev-config.json
@@ -2,6 +2,15 @@
   "name": "dev",
   "announcement": [
     {
+      "heading": "2021 Modified LAR Release",
+      "message": "On March XX, 2022, the 2021 Modified LAR data was released and can be accessed via the ",
+      "type": "info",
+      "link": {
+        "url": "https://ffiec.cfpb.gov/data-publication/modified-lar/",
+        "text": "Modified LAR page."
+      }
+    },
+    {
       "message": "On October 20, 2021 the Filing Instructions Guide (FIG) for data collected in 2022 was updated with new guidance for edits V720-2, V721-2, and Q657. ",
       "type": "info",
       "heading": "2022 FIG Update",

--- a/src/common/constants/dev-config.json
+++ b/src/common/constants/dev-config.json
@@ -3,7 +3,7 @@
   "announcement": [
     {
       "heading": "2021 Modified LAR Release",
-      "message": "On March XX, 2022, the 2021 Modified LAR data was released and can be accessed via the ",
+      "message": "On March 23, 2022, the 2021 Modified LAR data was released and can be accessed via the ",
       "type": "info",
       "link": {
         "url": "https://ffiec.cfpb.gov/data-publication/modified-lar/",

--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -2,6 +2,15 @@
   "name": "prod-beta",
   "announcement": [
     {
+      "heading": "2021 Modified LAR Release",
+      "message": "On March XX, 2022, the 2021 Modified LAR data was released and can be accessed via the ",
+      "type": "info",
+      "link": {
+        "url": "https://ffiec.cfpb.gov/data-publication/modified-lar/",
+        "text": "Modified LAR page."
+      }
+    },
+    {
       "message": "The LAR Formatting tool, previously Excel-based, is being redeveloped as a web application. You can now easily import/input your LAR data, search to filter, make edits, and create a HMDA Platform compatible file right from your browser. Updates will be made to this tool iteratively, with the latest version now available on the ",
       "type": "warning",
       "heading": "[Preview] Create and edit LAR files online",

--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -3,7 +3,7 @@
   "announcement": [
     {
       "heading": "2021 Modified LAR Release",
-      "message": "On March XX, 2022, the 2021 Modified LAR data was released and can be accessed via the ",
+      "message": "On March 23, 2022, the 2021 Modified LAR data was released and can be accessed via the ",
       "type": "info",
       "link": {
         "url": "https://ffiec.cfpb.gov/data-publication/modified-lar/",

--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -2,6 +2,15 @@
   "name": "prod",
   "announcement": [
     {
+      "heading": "2021 Modified LAR Release",
+      "message": "On March XX, 2022, the 2021 Modified LAR data was released and can be accessed via the ",
+      "type": "info",
+      "link": {
+        "url": "https://ffiec.cfpb.gov/data-publication/modified-lar/",
+        "text": "Modified LAR page."
+      }
+    },
+    {
       "message": "On October 20, 2021 the Filing Instructions Guide (FIG) for data collected in 2022 was updated with new guidance for edits V720-2, V721-2, and Q657. ",
       "type": "info",
       "heading": "2022 FIG Update",
@@ -26,6 +35,13 @@
   },
   "ffvtAnnouncement": null,
   "dataPublicationYears": {
+    "mlar": [
+      "2021",
+      "2020",
+      "2019",
+      "2018",
+      "2017"
+    ],
     "shared": [
       "2020",
       "2019",

--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -3,7 +3,7 @@
   "announcement": [
     {
       "heading": "2021 Modified LAR Release",
-      "message": "On March XX, 2022, the 2021 Modified LAR data was released and can be accessed via the ",
+      "message": "On March 23, 2022, the 2021 Modified LAR data was released and can be accessed via the ",
       "type": "info",
       "link": {
         "url": "https://ffiec.cfpb.gov/data-publication/modified-lar/",

--- a/src/data-publication/ChangeLog/change-log-data.json
+++ b/src/data-publication/ChangeLog/change-log-data.json
@@ -4,7 +4,7 @@
       "date": "03/31/22",
       "type": "release",
       "product": "mlar",
-      "description": "On March XX, 2022, the 2021 Modified LAR data was released.",
+      "description": "On March 23, 2022, the 2021 Modified LAR data was released.",
       "links": [
         {
           "text": "View the press release.",

--- a/src/data-publication/ChangeLog/change-log-data.json
+++ b/src/data-publication/ChangeLog/change-log-data.json
@@ -1,6 +1,18 @@
 {
   "log": [
     {
+      "date": "03/31/22",
+      "type": "release",
+      "product": "mlar",
+      "description": "On March XX, 2022, the 2021 Modified LAR data was released.",
+      "links": [
+        {
+          "text": "View the press release.",
+          "url": "https://www.consumerfinance.gov/about-us/newsroom/2021-hmda-data-on-mortgage-lending-now-available"
+        }
+      ]
+    },
+    {
       "date": "02/10/22",
       "type": "correction",
       "product": "filing",


### PR DESCRIPTION
Closes #1377 

## TODO
- [ ] Add specific release date

## Changes

- Adds banner announcing release
- Add Updates/Notes entry for release
- Adds `2021` option to the UI via `prod-config.json`

## Screenshots
- Homepage banner
  <img width="1003" alt="Screen Shot 2022-03-22 at 2 05 44 PM" src="https://user-images.githubusercontent.com/2592907/159566896-1c86170e-b391-4bda-b4d3-7a6394408c11.png">
 
- Release notes
  <img width="1035" alt="Screen Shot 2022-03-22 at 2 09 28 PM" src="https://user-images.githubusercontent.com/2592907/159567246-b91026ad-33d9-409b-82b8-f23c6c3a123b.png">

