### PR TITLE
[Announcement] 2022 FFIC Census Products schedule - fix spacing

### DIFF
--- a/src/common/constants/dev-config.json
+++ b/src/common/constants/dev-config.json
@@ -2,7 +2,7 @@
   "name": "dev",
   "announcement": [
     {
-      "message": "The FFIEC has announced a tentative release schedule for the 2022 Census products, which is available",
+      "message": "The FFIEC has announced a tentative release schedule for the 2022 Census products, which is available ",
       "type": "info",
       "heading": "2022 FFIEC Census Product Release Schedule",
       "link": {

--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -2,7 +2,7 @@
   "name": "prod-beta",
   "announcement": [
     {
-      "message": "The FFIEC has announced a tentative release schedule for the 2022 Census products, which is available",
+      "message": "The FFIEC has announced a tentative release schedule for the 2022 Census products, which is available ",
       "type": "info",
       "heading": "2022 FFIEC Census Product Release Schedule",
       "link": {

--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -2,7 +2,7 @@
   "name": "prod",
   "announcement": [
     {
-      "message": "The FFIEC has announced a tentative release schedule for the 2022 Census products, which is available",
+      "message": "The FFIEC has announced a tentative release schedule for the 2022 Census products, which is available ",
       "type": "info",
       "heading": "2022 FFIEC Census Product Release Schedule",
       "link": {


### PR DESCRIPTION
Adds a missing space between the main message and the link to the product schedule