### PR TITLE
[Cypress] Pull load file from S3 into running pod

### DIFF
--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -45,6 +45,3 @@ RUN useradd -ms /bin/bash hmda_cypress_user && \
 USER hmda_cypress_user
 
 RUN yarn cypress install
-
-# Copy load-test file from S3 if not already present
-RUN [ ! -f ./cypress/fixtures/2020-FRONTENDTESTBANK9999-MAX.txt ] && aws s3 cp s3://cfpb-hmda-public/cypress/2020-FRONTENDTESTBANK9999-MAX.txt ./cypress/fixtures/ --profile svc_hmda

--- a/cypress/docker-runner.sh
+++ b/cypress/docker-runner.sh
@@ -51,8 +51,12 @@ else
 	post_failure 'Integration testing :handshake:' "output_integration.txt"
 fi
 
-# Load tests
-# TODO: Host load test file on S3, download here
+# Download Submission file for load testing 
+[ ! -f ./cypress/fixtures/2020-FRONTENDTESTBANK9999-MAX.txt ] \
+	&& curl https://s3.amazonaws.com/cfpb-hmda-public/prod/cypress/2020-LargeFiler.zip > ./cypress/fixtures/2020-LargeFiler.zip \
+	&& tar -xvf cypress/fixtures/2020-LargeFiler.zip -C cypress/fixtures/
+
+# Load test
 yarn cypress run --spec "cypress/integration/load/**" > output_load.txt
 if  grep -q "All specs passed!" "output_load.txt" ; then
 	post_success 'Load testing :tractor:' "output_load.txt"


### PR DESCRIPTION
Closes #1395 
 
# Changes
- Removes load test file from `Dockerfile` build
- `curl`s  compressed Submission file for load testing from S3 and unzips
 
# Testing
Changes in this PR are successfully running in our current Cypress test image for Production.  