### PR TITLE
[Filing] Fix display of Maintenance messaging on the Filing app

### DIFF
--- a/src/filing/home/container.jsx
+++ b/src/filing/home/container.jsx
@@ -9,7 +9,6 @@ export class HomeContainer extends Component {
     if (this.props.user === null || this.props.maintenanceMode) return (
       <Home
         maintenanceMode={this.props.maintenanceMode}
-        filingAnnouncement={this.props.filingAnnouncement}
       />
     )
     return <InstitutionsContainer />

--- a/src/filing/home/index.jsx
+++ b/src/filing/home/index.jsx
@@ -5,7 +5,7 @@ import { MailingSignupLarge } from '../../common/MailingListSignup'
 
 import './Home.css'
 
-const Home = ({ maintenanceMode, filingAnnouncement }) => {
+const Home = ({ maintenanceMode }) => {
   const maintenanceTitle = maintenanceMode && 'Unavailable during maintenance'
   const buttonsDisabled = !!maintenanceMode
   const cname = 'FilingHome' + (maintenanceMode ? ' maintenance' : '')
@@ -15,11 +15,6 @@ const Home = ({ maintenanceMode, filingAnnouncement }) => {
     <main className={cname} id="main-content">
       <section className="hero">
         <div className="full-width">
-          {!!maintenanceMode && !!filingAnnouncement && (
-            <Alert type='error' heading='System Temporarily Unavailable'>
-              <p>{filingAnnouncement.message}</p>
-            </Alert>
-          )}
           {sessionExpired && (
             <Alert type="success" heading="Session Expired">
               <p>Please log in. If you are having trouble accessing the Filing application please contact <a href="mailto:hmdahelp@cfpb.gov">HMDA Help</a>.</p>


### PR DESCRIPTION
Closes #1376 
 
The original goal was to add display of Maintenance announcements on the Filing page.  I found that this functionality was already in place but had some bugs.  This PR, in conjunction with a DevOps PR to fix the Maintenance PR generation script, will enable the desired message display. 

## Changes

We had multiple areas where we would display the `config.filingAnnouncement` message, but there was an error in the way this configuration was being passed down to the target component, so one of those areas would never actually display the message.  When I fixed the error with prop-passing I found that a `Maintenance` message could wind up being shown multiple times on the Filing homepage.  So this PR eliminates that duplication. 
 
Observing this duplication led me to investigate the Maintenance PR generator script where I found that it does not account for the `config.filingAnnouncement.endDate` field, so Maintenance messages on Frontend where being filtered out due to an incorrect `config.filingAnnouncement.endDate` being applied. A fix for that issue is being tracked in the DevOps repo.
 
## Screenshots

| Maint. Announcement | Maint. in progress |
|--|--|
|<img width="877" alt="maintenance-announcement-filing" src="https://user-images.githubusercontent.com/2592907/163056625-13e23331-1234-43fc-b288-17b1566503e5.png">|<img width="881" alt="maintenance-inprogress-filing" src="https://user-images.githubusercontent.com/2592907/163058248-7476133d-9646-4b16-ad55-5a03166ac4e5.png">|


## Testing
- To test the display of Maintenance announcements, use [this test configuration](https://github.com/cfpb/hmda-frontend/blob/4ebe2109eef3e68c74cd47a4d56d355538514d94/src/common/constants/prod-config.json) from the [PR](https://github.com/cfpb/hmda-frontend/pull/1404/files) generated using the DevOps script. You should a display similar to the first screenshot above. 
- To test UI that is displayed during Maintenance, use [this test configuration](https://github.com/cfpb/hmda-frontend/blob/99d4f6d2a71de495c2b653e84909aec375705056/src/common/constants/prod-config.json) from the `Maintenance In-Progress` [PR](https://github.com/cfpb/hmda-frontend/pull/1405/files) generated using the DevOps script. You should a display similar to the second screenshot above. 
 