### PR TITLE
[Filing] Account for Daylight Savings Time

### DIFF
--- a/src/deriveConfig.js
+++ b/src/deriveConfig.js
@@ -1,5 +1,6 @@
 import { getFilingPeriods } from './common/constants/configHelpers'
 import { splitYearQuarter } from './filing/api/utils'
+import { easternOffsetHours } from './filing/utils/date'
 
 export const PERIODS = ['Q3', 'Q2', 'Q1', 'annual']
 
@@ -183,14 +184,13 @@ function potentialYears(start = 2017) {
  * Converts a date string into a Date object for deadline calculations
  * @param {String} str mm-dd-yyyy
  * @param {Boolean} isDeadline Use end of day (11:59pm ET) for Date?
- * @returns Date
+ * @returns Date (Eastern time)
  */
 export function parseTimedGuardDate(str, isDeadline = false) {
   let [month, day, year] = str.split('/').map(s => parseInt(s, 10))
   month = month - 1 // JS months are 0 indexed
 
-  // Determine time distance from Eastern Time zone
-  let offset = new Date().getTimezoneOffset() / 60 - 5
+  const offset = easternOffsetHours()
 
   if (isDeadline)
     // End of day
@@ -219,12 +219,11 @@ export function parseTimedGuardDate(str, isDeadline = false) {
  * @param {Date} date 
  * @returns String
  */
- function formatLocalString(date) {
-  const eastern = new Date(date.getTime())
-  eastern.setHours(date.getHours() + (new Date().getTimezoneOffset() / 60 - 5))
-  return eastern.toLocaleString('en-US', {
+ export function formatLocalString(date) {
+  return date.toLocaleString('en-US', {
     year: 'numeric',
     day: 'numeric',
-    month: 'long'
+    month: 'long',
+    timeZone: 'America/New_York'
   })
 }

--- a/src/deriveConfig.test.js
+++ b/src/deriveConfig.test.js
@@ -1,0 +1,30 @@
+import { parseTimedGuardDate, formatLocalString } from './deriveConfig'
+
+describe('parseTimedGuardDate', () => {
+  const timedGuard = '01/01/2022'
+  it('calculates start dates', () => {
+    const date = new Date(
+      parseTimedGuardDate(timedGuard).toLocaleString('en-US', {
+        timeZone: 'America/New_York',
+      })
+    )
+    expect(date === `${timedGuard}, 12:00:00 AM`)
+  })
+
+  it('calculates start dates', () => {
+    const date = new Date(
+      parseTimedGuardDate(timedGuard, true).toLocaleString('en-US', {
+        timeZone: 'America/New_York',
+      })
+    )
+    expect(date === `${timedGuard}, 11:59:59 PM`)
+  })
+})
+
+describe('formatLocalString', () => {
+  it('outputs date string', () => {
+    expect(formatLocalString(new Date(2022, 0, 1)) == 'January 1, 2022')
+    expect(formatLocalString(new Date(2022, 4, 1)) == 'April 1, 2022')
+    expect(formatLocalString(new Date(2022, 11, 16)) == 'December 16, 2022')
+  })
+})

--- a/src/filing/utils/date.js
+++ b/src/filing/utils/date.js
@@ -52,3 +52,20 @@ export const hoursSince = timestamp => {
   const diffTime = Date.now() - timestamp
   return msToHours(diffTime)
 }
+
+export const stdTimezoneOffset = date => {
+  var jan = new Date(date.getFullYear(), 0, 1)
+  var jul = new Date(date.getFullYear(), 6, 1)
+  return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset())
+}
+
+export const isDstObserved = (date = new Date()) => {
+  return date.getTimezoneOffset() < stdTimezoneOffset(date)
+}
+
+// Calculate hour adjustment needed to convert to Eastern timezone
+// Standard = GMT-5, Daylight Savings = GMT-4
+export const easternOffsetHours = (date = new Date()) => {
+  const eastOffset = isDstObserved() ? 4 : 5
+  return date.getTimezoneOffset() / 60 - eastOffset
+}

--- a/src/filing/utils/date.test.js
+++ b/src/filing/utils/date.test.js
@@ -5,6 +5,9 @@ import {
   padZero,
   ordinal,
   ordinalHour,
+  stdTimezoneOffset,
+  isDstObserved,
+  easternOffsetHours,
 } from './date.js'
 
 describe('nth', () => {
@@ -47,5 +50,35 @@ describe('ordinal hour', () => {
     expect(ordinalHour(new Date('2017-07-18T14:14:14'))).toBe(
       'July 18th, 2017, 2:14:14 PM'
     )
+  })
+})
+
+describe('stdTimezoneOffset', () => {
+  it('identifies standard time offset', () => {
+    expect(stdTimezoneOffset(new Date()) === 5)
+  })
+})
+
+describe('isDstObserved', () => {
+  it('recognizes when DST applies', () => {
+    expect(isDstObserved(new Date(2022, 0, 1)) === false)
+    expect(isDstObserved(new Date(2022, 2, 1)) === false)
+    expect(isDstObserved(new Date(2022, 2, 13)) === true)
+    expect(isDstObserved(new Date(2022, 5, 13)) === true)
+    expect(isDstObserved(new Date(2022, 7, 13)) === true)
+    expect(isDstObserved(new Date(2022, 9, 13)) === true)
+    expect(isDstObserved(new Date(2022, 10, 1)) === true)
+    expect(isDstObserved(new Date(2022, 10, 13)) === false)
+    expect(isDstObserved(new Date(2022, 11, 13)) === false)
+  })
+})
+
+describe('easternOffsetHours', () => {
+  it.skip('calculates correct hour adjustment accounting for DST', () => {
+    /* 
+    / This function's output depends on the end user's system settings. 
+    / Users in ET will get a different offset than users in PT.
+    / Needs more thought into how to get consistent test results. 
+    */
   })
 })

--- a/src/filing/utils/date.test.js
+++ b/src/filing/utils/date.test.js
@@ -1,4 +1,3 @@
-jest.unmock('../constants/dates.js')
 jest.unmock('./date.js')
 
 import {
@@ -6,12 +5,7 @@ import {
   padZero,
   ordinal,
   ordinalHour,
-  withinAWeekOfDeadline,
-  withinFilingPeriod,
-  beforeFilingPeriod,
-  afterFilingPeriod
 } from './date.js'
-import * as dates from '../constants/dates.js'
 
 describe('nth', () => {
   it('calculates date ends correctly', () => {
@@ -53,85 +47,5 @@ describe('ordinal hour', () => {
     expect(ordinalHour(new Date('2017-07-18T14:14:14'))).toBe(
       'July 18th, 2017, 2:14:14 PM'
     )
-  })
-})
-
-describe('withinAWeekOfDeadline', () => {
-  it('returns true if within a week', () => {
-    Date.now = () => 1487721600000
-    expect(withinAWeekOfDeadline('2017')).toBe(true)
-  })
-
-  it('returns false if not within a week', () => {
-    Date.now = () => 1387721600000
-    expect(withinAWeekOfDeadline('2017')).toBe(false)
-  })
-
-  it('throws on bad input', () => {
-    try {
-      withinAWeekOfDeadline('qwe')
-    } catch (e) {
-      expect(e).toBeDefined()
-    }
-  })
-})
-
-describe('withinFilingPeriod', () => {
-  it('returns true if within filing period', () => {
-    Date.now = () => 1487721600000
-    expect(withinFilingPeriod('2016')).toBe(true)
-  })
-
-  it('returns false if not within filing period', () => {
-    Date.now = () => 1387721600000
-    expect(withinFilingPeriod('2016')).toBe(false)
-  })
-
-  it('throws on bad input', () => {
-    try {
-      withinFilingPeriod('qwe')
-    } catch (e) {
-      expect(e).toBeDefined()
-    }
-  })
-})
-
-describe('afterFilingPeriod', () => {
-  it('returns true if after filing period', () => {
-    Date.now = () => 1587721600000
-    expect(afterFilingPeriod('2016')).toBe(true)
-  })
-
-  it('returns false if not after filing period', () => {
-    Date.now = () => 1387721600000
-    expect(afterFilingPeriod('2016')).toBe(false)
-  })
-
-  it('throws on bad input', () => {
-    try {
-      afterFilingPeriod('qwe')
-    } catch (e) {
-      expect(e).toBeDefined()
-    }
-  })
-})
-
-describe('beforeFilingPeriod', () => {
-  it('returns true if before filing period', () => {
-    Date.now = () => 1387721600000
-    expect(beforeFilingPeriod('2016')).toBe(true)
-  })
-
-  it('returns false if not before filing period', () => {
-    Date.now = () => 1587721600000
-    expect(beforeFilingPeriod('2016')).toBe(false)
-  })
-
-  it('throws on bad input', () => {
-    try {
-      beforeFilingPeriod('qwe')
-    } catch (e) {
-      expect(e).toBeDefined()
-    }
   })
 })


### PR DESCRIPTION
Closes #1408 
 
## Changes
- Adjusts Timed Guard calculations to account for DST
- Adds `jest` tests for modified functions
- Cleans up some outdated `jests` tests

## Testing
- `yarn run jest src/deriveConfig.test.js`
- `yarn run jest src/filing/utils/date.test.js`