### PR TITLE
[Cypress] Skip Rate Spread API test in Beta

### DIFF
--- a/cypress/integration/tools/RateSpread.spec.js
+++ b/cypress/integration/tools/RateSpread.spec.js
@@ -54,7 +54,7 @@ describe("Rate Spread Tool", function() {
 
 describe("Rate Spread API", () => {
   
-  if(isProd(HOST) || isCI(ENVIRONMENT)) {
+  if(isCI(ENVIRONMENT) || !isProdBeta(HOST)) {
     it("Generates rates from file", () => {
       cy.get({ HOST, TEST_DELAY, ENVIRONMENT }).logEnv()
       let response


### PR DESCRIPTION
Closes #1429 

This API does not run in our Beta environment, hence we're updating the conditional logic to correctly skip this test.