### PR TITLE
[Cypress] Avoid negative timezone offsets

### DIFF
--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -39,9 +39,20 @@ WORKDIR /hmda-frontend/
 
 RUN yarn
 
-RUN useradd -ms /bin/bash hmda_cypress_user && \
+RUN rm -rf /usr/local/share/.cache/yarn/v6/npm-public-encrypt-*/node_modules/public-encrypt/test/*
+RUN rm -rf /root/.cache/Cypress/9.5.1/Cypress/resources/app/node_modules/public-encrypt/test/*
+RUN rm -rf /root/.cache/Cypress/9.5.1/Cypress/resources/app/node_modules/http-proxy/test/*
+RUN rm -rf /root/.cache/Cypress/9.5.1/Cypress/resources/app/node_modules/lazystream/secret
+
+RUN useradd -M -d /hmda-frontend -s /bin/bash hmda_cypress_user && \
   chown -R hmda_cypress_user:hmda_cypress_user /hmda-frontend/
 
 USER hmda_cypress_user
+RUN yarn --cache-folder /hmda-frontend cypress install
 
-RUN yarn cypress install
+
+RUN rm -rf /hmda-frontend/node_modules/public-encrypt/test/*
+RUN rm -rf /hmda-frontend/.cache/Cypress/9.5.1/Cypress/resources/app/node_modules/public-encrypt/test/*
+RUN rm -rf /hmda-frontend/.cache/Cypress/9.5.1/Cypress/resources/app/node_modules/http-proxy/test/*
+
+RUN rm -rf /hmda-frontend/.cache/Cypress/9.5.1/Cypress/resources/app/node_modules/lazystream/secret

--- a/cypress/integration/tools/RateSpread.spec.js
+++ b/cypress/integration/tools/RateSpread.spec.js
@@ -54,7 +54,7 @@ describe("Rate Spread Tool", function() {
 
 describe("Rate Spread API", () => {
   
-  if(isProd(HOST) || isCI(ENVIRONMENT)) {
+  if(isCI(ENVIRONMENT) || !isProdBeta(HOST)) {
     it("Generates rates from file", () => {
       cy.get({ HOST, TEST_DELAY, ENVIRONMENT }).logEnv()
       let response

--- a/src/deriveConfig.js
+++ b/src/deriveConfig.js
@@ -190,7 +190,8 @@ export function parseTimedGuardDate(str, isDeadline = false) {
   let [month, day, year] = str.split('/').map(s => parseInt(s, 10))
   month = month - 1 // JS months are 0 indexed
 
-  const offset = easternOffsetHours()
+  // The addition of abs() is a workaround for our Cypress testing pods, which seem to run in UTC
+  const offset = Math.abs(easternOffsetHours())
 
   if (isDeadline)
     // End of day

--- a/src/deriveConfig.test.js
+++ b/src/deriveConfig.test.js
@@ -11,7 +11,7 @@ describe('parseTimedGuardDate', () => {
     expect(date === `${timedGuard}, 12:00:00 AM`)
   })
 
-  it('calculates start dates', () => {
+  it('calculates end dates', () => {
     const date = new Date(
       parseTimedGuardDate(timedGuard, true).toLocaleString('en-US', {
         timeZone: 'America/New_York',


### PR DESCRIPTION
Closes #1430 

Our test pods run in UTC, which means the current method of calculating the adjustment to Eastern Time may incorrectly result in the DateTime moving forward (subtracting a negative `offset`) instead of backwards (subtracting a positive `offset`). 