### PR TITLE
[Data Pub] Point pipe-delimited links to PSV files

### DIFF
--- a/src/data-publication/reports/snapshot/index.jsx
+++ b/src/data-publication/reports/snapshot/index.jsx
@@ -27,7 +27,7 @@ function renderDatasets(datasets){
             <ul>
               <S3DatasetLink url={dataset.csv} label='CSV' showLastUpdated />
               <S3DatasetLink
-                url={dataset.csv}
+                url={dataset.txt}
                 label='Pipe Delimited'
                 showLastUpdated
               />


### PR DESCRIPTION
Closes #1443 

## Changes
Currently, links for pipe-delimited files incorrectly point to the CSV version.  This PR directs those links to the .txt (PSV) files. 