### PR TITLE
[Config] Never cache environment config

### DIFF
--- a/src/common/configUtils.js
+++ b/src/common/configUtils.js
@@ -7,7 +7,12 @@ import { deriveConfig } from '../deriveConfig'
 const CONFIG_URL_PREFIX = 'https://raw.githubusercontent.com/cfpb/hmda-frontend/master/src/common/constants/'
 
 export function fetchEnvConfig(setFn, host) {
-  return fetch(`${CONFIG_URL_PREFIX}${getDefaultConfig(host).name}-config.json`)
+  const url = `${CONFIG_URL_PREFIX}${getDefaultConfig(host).name}-config.json`
+  const options = {
+    cache: 'reload', // Bypass the cache, always fetching the latest config on app load
+  }
+
+  return fetch(url, options)
     .then(data => data.json())
     .then(config => setFn(deriveConfig(config)))
 }


### PR DESCRIPTION
Closes #1455 
 
 ## Changes
Uses `fetch`'s `cache` option to always fetch the latest configuration from Github, bypassing the cache, in order to ensure that users receive the most up-to-date config in a timely manner. 
 
 https://developer.mozilla.org/en-US/docs/Web/API/Request/cache