### PR TITLE
Redirect from base urls

### DIFF
--- a/src/common/redirectIfNoYearProvided.js
+++ b/src/common/redirectIfNoYearProvided.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Redirect } from 'react-router-dom'
+
+/**
+ * Redirects users from the base URL, with no year provided, to a year focused URL
+ * @param {Object} render_props React Router props
+ * @param {String} targetYear Latest available year of Publication data
+ * @returns
+ */
+export const redirectIfNoYearProvided = (render_props, targetYear) => {
+  const year = render_props.match.params.year
+  let { pathname, search } = render_props.location
+
+  if (!year) {
+    if (pathname.substr(-1) !== '/') pathname = pathname + '/'
+
+    return <Redirect to={`${pathname}${targetYear}${search}`} />
+  }
+
+  return null
+}

--- a/src/data-browser/index.js
+++ b/src/data-browser/index.js
@@ -1,39 +1,30 @@
 import React from 'react'
-import { Switch, Route, Redirect } from 'react-router-dom'
+import { Switch, Route } from 'react-router-dom'
 import Home from './Home'
 import Geography from './datasets/Geography.jsx'
 import MapsGraphs from './maps/MapsGraphs.jsx'
 import NotFound from '../common/NotFound'
 import { withAppContext } from '../common/appContextHOC'
+import { redirectIfNoYearProvided } from '../common/redirectIfNoYearProvided'
 
 const DataBrowser = props => {
   const { publicationReleaseYear } = props.config
 
   return (
-    <div className="DataBrowser App">
+    <div className='DataBrowser App'>
       <Switch>
-        <Route exact path="/data-browser" component={Home} />
+        <Route exact path='/data-browser' component={Home} />
         <Route
-          path="/data-browser/data/:year?"
-          render={(r_props) => <Geography {...r_props} {...props} /> }
+          path='/data-browser/data/:year?'
+          render={r_props =>
+            redirectIfNoYearProvided(r_props, publicationReleaseYear) || <Geography {...r_props} {...props} />
+          }
         />
         <Route
           path={['/data-browser/maps/:year?', '/data-browser/maps']}
-          render={r_props => {
-            const year = r_props.match.params.year
-            let { pathname, search } = r_props.location
-
-            if (!year) {
-              if (pathname.substr(-1) !== '/') pathname = pathname + '/'
-              return (
-                <Redirect
-                  to={`${pathname}${publicationReleaseYear}${search}`}
-                />
-              )
-            }
-
-            return <MapsGraphs {...r_props} {...props} />
-          }}
+          render={r_props =>
+            redirectIfNoYearProvided(r_props, publicationReleaseYear) || <MapsGraphs {...r_props} {...props} />
+          }
         />
         <Route component={NotFound} />
       </Switch>

--- a/src/data-publication/index.js
+++ b/src/data-publication/index.js
@@ -16,6 +16,7 @@ import { withAppContext } from '../common/appContextHOC.jsx'
 import PublicationChanges from './ChangeLog/'
 
 import './index.css'
+import { redirectIfNoYearProvided } from '../common/redirectIfNoYearProvided'
 
 const DataPublication = ({ config }) => {
   const { dynamic, oneYear, snapshot, shared, threeYear } = config.dataPublicationYears
@@ -34,15 +35,21 @@ const DataPublication = ({ config }) => {
         <Route path="/data-publication/modified-lar/:year" component={ModifiedLar} />
         <Route
           path="/data-publication/disclosure-reports/:year?/:institutionId?/:msaMdId?/:reportId?"
-          component={Disclosure}
+          render={props => {
+            return redirectIfNoYearProvided(props, shared[0]) || <Disclosure {...props} />
+          }}
         />
         <Route
           path="/data-publication/aggregate-reports/:year?/:stateId?/:msaMdId?/:reportId?"
-          component={Aggregate}
+          render={props => {
+            return redirectIfNoYearProvided(props, shared[0]) || <Aggregate {...props} />
+          }}
         />
         <Route
           path="/data-publication/national-aggregate-reports/:year?/:reportId?"
-          component={NationalAggregate}
+          render={props => {
+            return redirectIfNoYearProvided(props, 2017) || <NationalAggregate {...props} />
+          }}
         />
         <Route
           path="/data-publication/snapshot-national-loan-level-dataset/:year?"
@@ -51,7 +58,8 @@ const DataPublication = ({ config }) => {
             if(year && snapshotYears.indexOf(year) === -1){
               return <NotFound/>
             }
-            return <Snapshot {...props}/>
+            
+            return redirectIfNoYearProvided(props, snapshotYears[0]) || <Snapshot {...props}/>
           }}
         />
         <Route
@@ -59,7 +67,7 @@ const DataPublication = ({ config }) => {
           render={ props => {
             const { year } = props.match.params
             if(year && threeYearYears.indexOf(year) === -1) return <NotFound/>
-            return <ThreeYearDataset {...props}/>
+            return redirectIfNoYearProvided(props, threeYearYears[0]) || <ThreeYearDataset {...props}/>
           }}
         />
         <Route
@@ -67,7 +75,7 @@ const DataPublication = ({ config }) => {
           render={ props => {
             const { year } = props.match.params
             if(year && oneYearYears.indexOf(year) === -1) return <NotFound/>
-            return <OneYearDataset {...props}/>
+            return redirectIfNoYearProvided(props, oneYearYears[0]) || <OneYearDataset {...props}/>
           }}
         />
         <Route
@@ -75,7 +83,7 @@ const DataPublication = ({ config }) => {
           render={ props => {
             const { year } = props.match.params
             if(year && dynamicYears.indexOf(year) === -1) return <NotFound/>
-            return <DynamicDataset {...props}/>
+            return redirectIfNoYearProvided(props, dynamicYears[0]) || <DynamicDataset {...props}/>
           }}
         />
         <Route path="/data-publication/:year" component={Home} />


### PR DESCRIPTION
Closes #1466 

## Changes

When visiting Data Browser or Data Publications root urls, users will now be automatically redirected to the latest year

ex. https://ffiec.cfpb.gov/data-browser/data/ -> https://ffiec.cfpb.gov/data-browser/data/2021
 
ex https://ffiec.cfpb.gov/data-publication/one-year-national-loan-level-dataset/ -> https://ffiec.cfpb.gov/data-publication/one-year-national-loan-level-dataset/2021