### PR TITLE
Fix Disclosure/Aggregate Report year switching

### DIFF
--- a/cypress/integration/common-features/redirection.spec.js
+++ b/cypress/integration/common-features/redirection.spec.js
@@ -1,26 +1,25 @@
 import config from '../../../src/common/constants/prod-config.json'
-const latestRelease = config.publicationReleaseYear
 const years = config.dataPublicationYears
 
 const { HOST } = Cypress.env()
 
 const FromTo = [
+  // Reports that will break if auto-redirect is enabled
   {
-    from: '/data-publication/modified-lar',
-    to: `/data-publication/modified-lar/${years.mlar[0]}`,
-  },
-  {
-    from: '/data-publication/modified-lar/20',
-    to: `/data-publication/modified-lar/${years.mlar[0]}`,
-    desc: 'From invalid year for Data pub',
+    from: '/data-publication/aggregate-reports',
+    to: `/data-publication/aggregate-reports`,
+    description: 'Aggregate should not auto-redirect',
   },
   {
     from: '/data-publication/disclosure-reports',
-    to: `/data-publication/disclosure-reports/${years.shared[0]}`,
+    to: `/data-publication/disclosure-reports`,
+    description: 'Disclosure should not auto-redirect',
   },
+
+  // Test redirect from base URLs
   {
-    from: '/data-publication/aggregate-reports',
-    to: `/data-publication/aggregate-reports/${years.shared[0]}`,
+    from: '/data-publication/modified-lar',
+    to: `/data-publication/modified-lar/${years.mlar[0]}`,
   },
   {
     from: '/data-publication/national-aggregate-reports',
@@ -42,21 +41,64 @@ const FromTo = [
     from: '/data-publication/dynamic-national-loan-level-dataset',
     to: `/data-publication/dynamic-national-loan-level-dataset/${years.shared[0]}`,
   },
-  { from: '/data-publication', to: `/data-publication/${latestRelease}` },
-  { from: '/data-browser/maps', to: `/data-browser/maps/${latestRelease}` },
-  { from: '/data-browser/data/', to: `/data-browser/data/${latestRelease}` },
+  { from: '/data-publication', to: `/data-publication/${years.shared[0]}` },
+  { from: '/data-browser/maps', to: `/data-browser/maps/${years.shared[0]}` },
+  { from: '/data-browser/data/', to: `/data-browser/data/${years.shared[0]}` },  
+  
+  // Test redirect from invalid years
+  {
+    from: '/data-publication/aggregate-reports/20',
+    to: `/data-publication/aggregate-reports/${years.shared[0]}`,
+    description: 'Aggregate redirects from invalid year',
+  },
+  {
+    from: '/data-publication/modified-lar/20',
+    to: `/data-publication/modified-lar/${years.mlar[0]}`,
+    description: 'Modified LAR redirects correctly from invalid year',
+  },
+  {
+    from: '/data-publication/disclosure-reports/20',
+    to: `/data-publication/disclosure-reports/${years.shared[0]}`,
+    description: 'Disclosure redirects from invalid year',
+  },
+  {
+    from: '/data-publication/dynamic-national-loan-level-dataset/20',
+    to: `/data-publication/dynamic-national-loan-level-dataset/${years.shared[0]}`,
+    description: 'Dynamic redirects correctly from invalid year',
+  },
+  {
+    from: '/data-publication/snapshot-national-loan-level-dataset/20',
+    to: `/data-publication/snapshot-national-loan-level-dataset/${years.mlar[0]}`,
+    description: 'Snapshot redirects correctly from invalid year',
+  },
+  {
+    from: '/data-publication/one-year-national-loan-level-dataset/20',
+    to: `/data-publication/one-year-national-loan-level-dataset/${years.oneYear[0]}`,
+    description: 'One Year redirects correctly from invalid year',
+  },
+  {
+    from: '/data-publication/three-year-national-loan-level-dataset/20',
+    to: `/data-publication/three-year-national-loan-level-dataset/${years.threeYear[0]}`,
+    description: 'Three Year redirects correctly from invalid year',
+  },
   {
     from: '/data-browser/data/20',
-    to: `/data-browser/data/${latestRelease}`,
-    desc: 'From invalid year for Data Browser',
+    to: `/data-browser/data/${years.shared[0]}`,
+    description: 'Data Browser redirects correctly from invalid year',
+  },
+  {
+    from: '/data-browser/maps/20',
+    to: `/data-browser/maps/${years.shared[0]}`,
+    description: 'Maps redirects correctly from invalid year',
   },
 ]
 
 describe('withYearValidation', () => {
-  FromTo.forEach(({ from, to, desc }) => {
-    it(`Redirects correctly from ${desc || from}`, () => {
+  FromTo.forEach(({ from, to, description }) => {
+    const testDescription = description || `Auto-redirects from ${from}`
+    it(testDescription, () => {
       cy.visit(`${HOST}${from}`)
       cy.url().should('include', to)
-    }) 
+    })
   })
 })

--- a/src/data-publication/index.js
+++ b/src/data-publication/index.js
@@ -40,11 +40,11 @@ const DataPublication = ({ config }) => {
         />
         <Route
           path='/data-publication/disclosure-reports/:year?/:institutionId?/:msaMdId?/:reportId?'
-          render={props => <Disclosure {...props} />}
+          render={props => <Disclosure {...props} targetYearKey='disclosure'/>}
         />
         <Route
           path='/data-publication/aggregate-reports/:year?/:stateId?/:msaMdId?/:reportId?'
-          render={props => <Aggregate {...props} />}
+          render={props => <Aggregate {...props} targetYearKey='aggregate'/>}
         />
         <Route
           path='/data-publication/national-aggregate-reports/:year?/:reportId?'

--- a/src/data-publication/reports/DynamicDataset.jsx
+++ b/src/data-publication/reports/DynamicDataset.jsx
@@ -10,22 +10,14 @@ import { withYearValidation } from '../../common/withYearValidation.js'
 import './DynamicDataset.css'
 
 const linkToDocs2017 = ({ lar_spec, ts_spec }) => [
-  <S3DatasetLink url={lar_spec} label='Loan/Application Records (LAR)' />,
-  <S3DatasetLink url={ts_spec} label='Transmittal Sheet Records (TS)' />
+  <S3DatasetLink url={lar_spec} label='Loan/Application Records (LAR)' key='lar-docs' />,
+  <S3DatasetLink url={ts_spec} label='Transmittal Sheet Records (TS)' key='ts-docs' />
 ]
 
 const BaseIconStyles = {
   className: 'icon',
   width: '1.2em',
   height: '1.2em',
-}
-
-function makeListLink(href, val) {
-  return (
-    <li>
-      <a href={href}>{val}</a>
-    </li>
-  )
 }
 
 function linkToDocs(year = '2018') {


### PR DESCRIPTION
Closes #1478 

## Changes

- Avoids auto-redirect from base URL in Disclosure/Aggregate Reports, which prevents users from being able to switch the selected reporting year
- Updates Cypress tests
