### PR TITLE
[Docs] Panel - Add enumeration -1

### DIFF
--- a/src/documentation/markdown/2017/panel-data-fields.md
+++ b/src/documentation/markdown/2017/panel-data-fields.md
@@ -76,6 +76,7 @@
   - 2: MBS of bank holding company
   - 3: Independent mortgage banking subsidiary
   - 5: Affiliate of a depository institution
+  - -1: NULL/blank
 
 ### [parent\_rssd](#parent_rssd)
 - **Description:** The National Information Center's RSSD for the parent of the institution

--- a/src/documentation/markdown/2018/panel-data-fields.md
+++ b/src/documentation/markdown/2018/panel-data-fields.md
@@ -73,6 +73,7 @@
   - 2: MBS of bank holding company
   - 3: Independent mortgage banking subsidiary
   - 5: Affiliate of a depository institution
+  - -1: NULL/blank
 
 ### [parent\_rssd](#parent_rssd)
 - **Description:** The National Information Center's RSSD for the parent of the institution

--- a/src/documentation/markdown/2019/panel-data-fields.md
+++ b/src/documentation/markdown/2019/panel-data-fields.md
@@ -73,6 +73,7 @@
   - 2: MBS of bank holding company
   - 3: Independent mortgage banking subsidiary
   - 5: Affiliate of a depository institution
+  - -1: NULL/blank
 
 ### [parent\_rssd](#parent_rssd)
 - **Description:** The National Information Center's RSSD for the parent of the institution

--- a/src/documentation/markdown/2020/panel-data-fields.md
+++ b/src/documentation/markdown/2020/panel-data-fields.md
@@ -68,6 +68,7 @@
   - 2: MBS of bank holding company
   - 3: Independent mortgage banking subsidiary
   - 5: Affiliate of a depository institution
+  - -1: NULL/blank
 
 ### [parent\_rssd](#parent_rssd)
 - **Description:** The National Information Center's RSSD for the parent of the institution

--- a/src/documentation/markdown/2021/panel-data-fields.md
+++ b/src/documentation/markdown/2021/panel-data-fields.md
@@ -68,6 +68,7 @@
   - 2: MBS of bank holding company
   - 3: Independent mortgage banking subsidiary
   - 5: Affiliate of a depository institution
+  - -1: NULL/blank
 
 ### [parent\_rssd](#parent_rssd)
 - **Description:** The National Information Center's RSSD for the parent of the institution

--- a/src/documentation/markdown/2022/panel-data-fields.md
+++ b/src/documentation/markdown/2022/panel-data-fields.md
@@ -68,6 +68,7 @@
   - 2: MBS of bank holding company
   - 3: Independent mortgage banking subsidiary
   - 5: Affiliate of a depository institution
+  - -1: NULL/blank
 
 ### [parent\_rssd](#parent_rssd)
 - **Description:** The National Information Center's RSSD for the parent of the institution


### PR DESCRIPTION
Closes #1482 

Add the missing -1 enumeration for `other_lender_code` in the `Public Panel - Data Fields with Values and Definitions` documentation. 
 
## Screenshot
<img width="889" alt="other-lender-code-neg-1" src="https://user-images.githubusercontent.com/2592907/177838859-27e6ca4d-a878-4c4e-a53f-1150981a360f.png">

