### PR TITLE
[Docs] Fix broken links to Platform hosted documentation

### DIFF
--- a/src/documentation/publications/ModifiedLar.jsx
+++ b/src/documentation/publications/ModifiedLar.jsx
@@ -5,30 +5,30 @@ import { Link } from 'react-router-dom'
 const links = {
   permanent: [
     <li key="0"><a target="_blank" rel="noopener noreferrer" href="/data-publication/documents#modified-lar">Supporting Documentation</a></li>,
-    <li key="1"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/ModifiedLarWithExcel.md">How to Open a Modified LAR Text Files with Excel</a></li>
+    <li key="1"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/ModifiedLarWithExcel.md">How to Open a Modified LAR Text Files with Excel</a></li>
   ],
   2017: [],
   2018: [
-    <li key="18-1"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
+    <li key="18-1"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
     <li key="18-2"><a target="_blank" rel="noopener noreferrer" href="https://s3.amazonaws.com/cfpb-hmda-public/prod/help/2018-public-LAR-code-sheet.pdf">2018 Public LAR Code Sheet PDF</a></li>,
     <li key="18-3"><Link to="/documentation/2018/modified-lar-header/">Modified LAR Header</Link></li>,
     <li key="18-4"><Link to="/documentation/2018/modified-lar-schema/">Modified LAR Schema</Link></li>,
   ],
   2019: [
-    <li key="3"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
+    <li key="3"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
     <li key="19-2"><Link to="/documentation/2019/modified-lar-header/">Modified LAR Header</Link></li>,
     <li key="19-3"><Link to="/documentation/2019/modified-lar-schema/">Modified LAR Schema</Link></li>,
   ],
   2020: [
-    <li key="4"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
+    <li key="4"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
     <li key="20-2"><Link to="/documentation/2020/modified-lar-schema/">Modified LAR Schema</Link></li>,
   ],
   2021: [
-    <li key="21-1"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
+    <li key="21-1"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
     <li key="21-2"><Link to="/documentation/2021/modified-lar-schema/">Modified LAR Schema</Link></li>,
   ],
   2022: [
-    <li key="2022-1"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/v2/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
+    <li key="2022-1"><a target="_blank" rel="noopener noreferrer" href="https://github.com/cfpb/hmda-platform/blob/master/docs/UsingModifiedLar.md">Using Modified LAR Data</a></li>,
     <li key="2022-2"><Link to="/documentation/2022/modified-lar-schema/">Modified LAR Schema</Link></li>,
   ]
 }


### PR DESCRIPTION
Closes #1504 

## Changes

- Updates URLs of documentation hosted in the HMDA Platform repo

