### PR TITLE
[Docs] Add 2023 tools docs

### DIFF
--- a/src/documentation/tools/DataBrowser.jsx
+++ b/src/documentation/tools/DataBrowser.jsx
@@ -41,6 +41,13 @@ const links = {
     <li key="2022-3"><Link to="/documentation/2022/derived-data-fields/">Derived Data Fields</Link></li>,
     <li key="2022-4"><Link to="/documentation/2022/lar-data-fields/">Public HMDA Data Fields with Values and Definitions</Link></li>,
     <li key="2022-5"><Link to="/documentation/2022/data-browser-maps-faq/">Maps - Frequently Asked Questions</Link></li>,
+  ],
+  2023: [
+    <li key="2023-1"><Link to="/documentation/2023/data-browser-faq/">Frequently Asked Questions</Link></li>,
+    <li key="2023-2"><Link to="/documentation/2023/data-browser-filters/">Available Filters</Link></li>,
+    <li key="2023-3"><Link to="/documentation/2023/derived-data-fields/">Derived Data Fields</Link></li>,
+    <li key="2023-4"><Link to="/documentation/2023/lar-data-fields/">Public HMDA Data Fields with Values and Definitions</Link></li>,
+    <li key="2023-5"><Link to="/documentation/2023/data-browser-maps-faq/">Maps - Frequently Asked Questions</Link></li>,
   ]
 }
 

--- a/src/documentation/tools/FFVT.jsx
+++ b/src/documentation/tools/FFVT.jsx
@@ -18,6 +18,9 @@ const links = {
   ],
   2022: [
     <li key="2022-0"><Link to="/documentation/2022/file-format-verification/">File Format Verification Tool Instructions</Link></li>,
+  ],
+  2023: [
+    <li key="2023-0"><Link to="/documentation/2023/file-format-verification/">File Format Verification Tool Instructions</Link></li>,
   ]
 }
 

--- a/src/documentation/tools/LARFT.jsx
+++ b/src/documentation/tools/LARFT.jsx
@@ -18,6 +18,9 @@ const links = {
   ],
   2022: [    
     <li key="2022-0"><Link to="/documentation/2022/lar-formatting/">LAR Formatting Tool Instructions</Link></li>,
+  ],
+  2023: [    
+    <li key="2023-0"><Link to="/documentation/2023/lar-formatting/">LAR Formatting Tool Instructions</Link></li>,
   ]
 }
 

--- a/src/documentation/tools/RateSpread.jsx
+++ b/src/documentation/tools/RateSpread.jsx
@@ -22,6 +22,10 @@ const links = {
   2022: [
     <li key="2022-0"><a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread/requirements">Data Requirements</a></li>,
     <li key="2022-1"><a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread/methodology">Methodology for Determining Average Prime Offer Rates</a></li>
+  ],
+  2023: [
+    <li key="2023-0"><a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread/requirements">Data Requirements</a></li>,
+    <li key="2023-1"><a target="_blank" rel="noopener noreferrer" href="https://ffiec.cfpb.gov/tools/rate-spread/methodology">Methodology for Determining Average Prime Offer Rates</a></li>
   ]
 }
 


### PR DESCRIPTION
Part 2 of #1517 

Adds the entries needed to display the Tools docs in https://ffiec.cfpb.gov/documentation/