### PR TITLE
[Homepage] Banner for 2023 FIG release

### DIFF
--- a/src/common/constants/dev-config.json
+++ b/src/common/constants/dev-config.json
@@ -2,6 +2,15 @@
   "name": "dev",
   "announcement": [
     {
+      "heading": "2023 Filing Guides Released",
+      "message": "On September 6, 2022, the Bureau released the 2023 FIG and the Supplemental Guide for Quarterly Filers for 2023, which are available",
+      "type": "info",
+      "link": {
+        "url": "https://ffiec.cfpb.gov/documentation/2023/fig",
+        "text": "here."
+      }
+    },
+    {
       "heading": "HMDA Quarterly Graphs Tool Released",
       "message": "On August 30, 2022, the CFPB released a new FFIEC HMDA Data Browser feature - the Quarterly Graphs tool, which is available ",
       "type": "info",

--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -2,6 +2,15 @@
   "name": "prod-beta",
   "announcement": [
     {
+      "heading": "2023 Filing Guides Released",
+      "message": "On September 6, 2022, the Bureau released the 2023 FIG and the Supplemental Guide for Quarterly Filers for 2023, which are available",
+      "type": "info",
+      "link": {
+        "url": "https://ffiec.cfpb.gov/documentation/2023/fig",
+        "text": "here."
+      }
+    },
+    {
       "heading": "HMDA Quarterly Graphs Tool Released",
       "message": "On August 30, 2022, the CFPB released a new FFIEC HMDA Data Browser feature - the Quarterly Graphs tool, which is available ",
       "type": "info",

--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -2,6 +2,15 @@
   "name": "prod",
   "announcement": [
     {
+      "heading": "2023 Filing Guides Released",
+      "message": "On September 6, 2022, the Bureau released the 2023 FIG and the Supplemental Guide for Quarterly Filers for 2023, which are available",
+      "type": "info",
+      "link": {
+        "url": "https://ffiec.cfpb.gov/documentation/2023/fig",
+        "text": "here."
+      }
+    },
+    {
       "heading": "HMDA Quarterly Graphs Tool Released",
       "message": "On August 30, 2022, the CFPB released a new FFIEC HMDA Data Browser feature - the Quarterly Graphs tool, which is available ",
       "type": "info",


### PR DESCRIPTION
Closes #1545 

Displays banner in Prod and ProdBeta announcing FIG / Supplemental Quarterly Filers Guide for 2023.
 
`here` links to https://ffiec.cfpb.gov/documentation/2023/fig

<img width="997" alt="Screen Shot 2022-09-06 at 10 06 42 PM" src="https://user-images.githubusercontent.com/2592907/188786622-201f5408-352e-4eae-baf0-2a51ab724a92.png">
