### PR TITLE
[Docs] Update and correct Panel Data Fields - values/definitions

### DIFF
--- a/src/documentation/markdown/2018/panel-data-fields.md
+++ b/src/documentation/markdown/2018/panel-data-fields.md
@@ -33,11 +33,6 @@
 - **Values:**
   - Varying values
 
-### [arid\_2017](#arid_2017)
-- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, use the _ARID2017 to LEI Reference Table_ available on the <a href='/data-publication/snapshot-national-loan-level-dataset/2020'>Snapshot National Loan Level Dataset</a> page. For 2018 and forward, LEI will be the primary key.
-- **Values:**
-  - Varying values
-
 ### [respondent\_rssd](#respondent_rssd)
 - **Description:** The National Information Center RSSD of the institution
 - **Values:**
@@ -60,10 +55,10 @@
   - Varying values
 
 ### [assets](#assets)
-- **Description:** The assets of the institution in the 4th quarter of the HMDA collection year
+- **Description:** The count of assets of the institution in the 4th quarter of the HMDA collection year
 - **Values:**
   - -1: NULL/blank
-- Varying values
+  - Varying values
 
 ### [other\_lender\_code](#other_lender_code)
 - **Description:** Derived assignment of an institution's status as, or relationship to, a depository institution

--- a/src/documentation/markdown/2019/panel-data-fields.md
+++ b/src/documentation/markdown/2019/panel-data-fields.md
@@ -33,11 +33,6 @@
 - **Values:**
   - Varying values
 
-### [arid\_2017](#arid_2017)
-- **Description:** The concatenation of an institution's 2017 Agency Code and Respondent ID. In order to match between 2017 and 2018, use the _ARID2017 to LEI Reference Table_ available on the <a href='/data-publication/snapshot-national-loan-level-dataset/2020'>Snapshot National Loan Level Dataset</a> page. For 2018 and forward, LEI will be the primary key.
-- **Values:**
-  - Varying values
-
 ### [respondent\_rssd](#respondent_rssd)
 - **Description:** The National Information Center RSSD of the institution
 - **Values:**
@@ -60,7 +55,7 @@
   - Varying values
 
 ### [assets](#assets)
-- **Description:** The assets of the institution in the 4th quarter of the HMDA collection year
+- **Description:** The count of assets of the institution in the 4th quarter of the HMDA collection year
 - **Values:**
   - -1: NULL/blank
   - Varying values

--- a/src/documentation/markdown/2020/panel-data-fields.md
+++ b/src/documentation/markdown/2020/panel-data-fields.md
@@ -8,12 +8,12 @@
 ### [lei](#lei)
 - **Description:** A financial institution’s Legal Entity Identifier
 - **Values:**
-- Varying values
+  - Varying values
 
 ### [tax\_id](#tax_id)
 - **Description:** The federal tax ID of the institution
 - **Values:**
-- Varying values
+  - Varying values
 
 ### [agency\_code](#agency_code)
 - **Description:** The integer code corresponding to an institution's regulatory agency
@@ -55,7 +55,7 @@
   - Varying values
 
 ### [assets](#assets)
-- **Description:** The assets of the institution in the 4th quarter of the HMDA collection year
+- **Description:** The count of assets of the institution in the 4th quarter of the HMDA collection year
 - **Values:**
   - -1: NULL/blank
   - Varying values

--- a/src/documentation/markdown/2021/panel-data-fields.md
+++ b/src/documentation/markdown/2021/panel-data-fields.md
@@ -55,7 +55,7 @@
   - Varying values
 
 ### [assets](#assets)
-- **Description:** The assets of the institution in the 4th quarter of the HMDA collection year
+- **Description:** The count of assets of the institution in the 4th quarter of the HMDA collection year
 - **Values:**
   - -1: NULL/blank
   - Varying values

--- a/src/documentation/markdown/2022/panel-data-fields.md
+++ b/src/documentation/markdown/2022/panel-data-fields.md
@@ -55,7 +55,7 @@
   - Varying values
 
 ### [assets](#assets)
-- **Description:** The assets of the institution in the 4th quarter of the HMDA collection year
+- **Description:** The count of assets of the institution in the 4th quarter of the HMDA collection year
 - **Values:**
   - -1: NULL/blank
   - Varying values

--- a/src/documentation/markdown/2023/panel-data-fields.md
+++ b/src/documentation/markdown/2023/panel-data-fields.md
@@ -55,7 +55,7 @@
   - Varying values
 
 ### [assets](#assets)
-- **Description:** The assets of the institution in the 4th quarter of the HMDA collection year
+- **Description:** The count of assets of the institution in the 4th quarter of the HMDA collection year
 - **Values:**
   - -1: NULL/blank
   - Varying values


### PR DESCRIPTION
Closes #1554 

- Extends `Assets` definition per #1554
- Removes incorrect inclusion of `arid_2017` in some years, as verified against the [Panel - Schema](https://ffiec.cfpb.gov/documentation/2022/public-panel-schema/)