### PR TITLE
[Graphs] Numeric formatting

### DIFF
--- a/src/data-browser/graphs/Graph.jsx
+++ b/src/data-browser/graphs/Graph.jsx
@@ -3,7 +3,7 @@ import { useCallback, useRef } from 'react'
 import Highcharts from 'highcharts'
 import HighchartsExport from 'highcharts/modules/exporting'
 import HighchartsExportData from 'highcharts/modules/export-data'
-import HighchartsAccessibility from "highcharts/modules/accessibility";
+import HighchartsAccessibility from 'highcharts/modules/accessibility'
 import HighchartsReact from 'highcharts-react-official'
 import useGraphLoading from './useGraphLoading'
 import { AvoidJumpToDataTable } from './highchartsCustomModules'
@@ -17,14 +17,14 @@ export const Graph = ({ options, loading, seriesForURL }) => {
   const chartRef = useRef()
 
   /**
-   * Note about onLoad: 
-   * 
+   * Note about onLoad:
+   *
    * Highcharts also calls this function when exporting to image.
-   * Be warned that the way in which it generates these images can lead to 
+   * Be warned that the way in which it generates these images can lead to
    * synchronization issues with our custom hooks (particularly useQuery).
-   * 
+   *
    * You can check if exporting via `ref.options.chart.forExport`
-   * 
+   *
    * See the following link for context on how these images are generated.
    * https://github.com/highcharts/highcharts-react/issues/315
    */

--- a/src/data-browser/graphs/Graph.jsx
+++ b/src/data-browser/graphs/Graph.jsx
@@ -13,6 +13,12 @@ HighchartsExportData(Highcharts) // Enable export of underlying data
 HighchartsAccessibility(Highcharts) // Accessibility enhancements
 AvoidJumpToDataTable(Highcharts) // Workaround for Accessibility module bug
 
+Highcharts.setOptions({
+  lang: {
+    thousandsSep: ','
+  }
+})
+
 export const Graph = ({ options, loading, seriesForURL }) => {
   const chartRef = useRef()
 

--- a/src/data-browser/graphs/highchartsConfig.js
+++ b/src/data-browser/graphs/highchartsConfig.js
@@ -118,22 +118,7 @@ export const deriveHighchartsConfig = ({
   Tooltip configuration: forces whole numbers and data points that don't have 3 decimals to include 3 decimals points. (i.e 3 -> 3.00 & 3.5 -> 3.500).
   Only reflected in the tooltip and NOT the data table.
   */
-  // config.tooltip.valueDecimals = decimalPlace
-
-  console.log(config)
-
-  // Code does not do anything feel free to delete.
-  // series.map((v) => v.data.forEach((p) => console.log(p)))
-
-  // Code does not do anything feel free to delete.
-  // config.chart.numberFormat = function () {
-  //   return Highcharts.numberFormat(
-  //     series.map((v) => {
-  //       v.data.map((p) => p)
-  //     }),
-  //     title.includes("interest rates") ? 3 : 0
-  //   )
-  // }
+  config.tooltip.valueDecimals = decimalPlace
 
   // Listener used to remove a series from URL when user de-selects
   config.plotOptions.series.events.hide = event => {

--- a/src/data-browser/graphs/highchartsConfig.js
+++ b/src/data-browser/graphs/highchartsConfig.js
@@ -1,4 +1,4 @@
-import { hmda_charts, seriesColors, yearQuarters } from "./config";
+import { hmda_charts, seriesColors, yearQuarters } from './config'
 import { cloneObject, filterByPeriods } from './utils/utils'
 
 // Highcharts configuration for a line graph
@@ -87,13 +87,14 @@ export const baseConfig = {
 }
 
 export const defaultAxisX = {
-  title: { text: "Year Quarter", y: 10 }, // TODO: Replace with data from API
+  title: { text: 'Year Quarter', y: 10 }, // TODO: Replace with data from API
   categories: yearQuarters,
   crosshair: true, // Highlight xAxis hovered category ie. 2020-Q3
   labels: hmda_charts.styles.axisLabel,
-};
+}
 
 export const deriveHighchartsConfig = ({
+  decimalPlace,
   endpoint,
   title,
   subtitle,
@@ -112,6 +113,27 @@ export const deriveHighchartsConfig = ({
   config.accessibility = { description: 'Graph summary: ' + subtitle }
   config.xAxis = xAxis
   config.legend.title.text = deriveLegendTitle(endpoint)
+
+  /* 
+  Tooltip configuration: forces whole numbers and data points that don't have 3 decimals to include 3 decimals points. (i.e 3 -> 3.00 & 3.5 -> 3.500).
+  Only reflected in the tooltip and NOT the data table.
+  */
+  // config.tooltip.valueDecimals = decimalPlace
+
+  console.log(config)
+
+  // Code does not do anything feel free to delete.
+  // series.map((v) => v.data.forEach((p) => console.log(p)))
+
+  // Code does not do anything feel free to delete.
+  // config.chart.numberFormat = function () {
+  //   return Highcharts.numberFormat(
+  //     series.map((v) => {
+  //       v.data.map((p) => p)
+  //     }),
+  //     title.includes("interest rates") ? 3 : 0
+  //   )
+  // }
 
   // Listener used to remove a series from URL when user de-selects
   config.plotOptions.series.events.hide = event => {
@@ -138,8 +160,10 @@ export const deriveHighchartsConfig = ({
   // Apply filtering based on the selected Filing Period Range
   config.series = loading ? [] : filterByPeriods(series, ...periodRange)
   config.xAxis[0].categories = categories?.slice(...periodRange)
-  config.xAxis[0].accessibility = { description: formatXdescription(loading, xAxis) }
-  
+  config.xAxis[0].accessibility = {
+    description: formatXdescription(loading, xAxis),
+  }
+
   config.yAxis = yAxis.map((yTitle, _yIdx) => ({
     title: { text: yTitle },
     labels: hmda_charts.styles.axisLabel,
@@ -169,7 +193,7 @@ const formatXdescription = (loading, axes) => {
   return `${title} from ${from} to ${to}`
 }
 
-const deriveLegendTitle = (endpoint) => {
+const deriveLegendTitle = endpoint => {
   if (endpoint.match('-re$')) return 'Race / Ethnicity'
   if (endpoint === 'all-applications') return 'Filer Types'
   return 'Loan Types'

--- a/src/data-browser/graphs/quarterly/SectionGraphs.jsx
+++ b/src/data-browser/graphs/quarterly/SectionGraphs.jsx
@@ -159,14 +159,31 @@ export const SectionGraphs = ({
   // https://jsfiddle.net/BlackLabel/5kj9pnfm/
   useEffect(() => {
     Highcharts.addEvent(Highcharts.Chart, "aftergetTableAST", function (e) {
-      e.tree.children[2].children.forEach(function (row) {
+      if (!selectedGraphData?.series?.length) return
+
+      // Determine which column === which Series
+      const columnLabels = [...e.tree.children[1].children[0].children].slice(1).map(x => x.textContent)
+ 
+      e.tree.children[2].children.forEach(function (row,r) {
+        const rowYearQuarter = row.children[0].textContent
         row.children.forEach(function (cell, i) {
           if (i !== 0) {
-            row.children[i].textContent = Highcharts.numberFormat(
-              cell.textContent.replaceAll(",", ""),
-              selectedGraphData?.decimalPrecision
+            // Find the corresponding raw data for this Series + YearQuarter
+            const columnName = columnLabels[i - 1]
+            const columnData = selectedGraphData.series.find(
+              column => column.name === columnName
             )
-          }
+            const cellData = columnData?.coordinates?.find(
+              item => item.x === rowYearQuarter
+            )
+            if (!cellData) return
+
+            // Update the cell with value formatted to the API configured precision
+            cell.textContent = Highcharts.numberFormat(
+              cellData.y,
+              selectedGraphData.decimalPrecision
+            )
+          } 
         })
       })
     })

--- a/src/data-browser/graphs/quarterly/SectionGraphs.jsx
+++ b/src/data-browser/graphs/quarterly/SectionGraphs.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import CopyURLButton from '../../../common/CopyURLButton.jsx'
 import LoadingIcon from '../../../common/LoadingIcon'
@@ -154,6 +154,23 @@ export const SectionGraphs = ({
     setResetSeriesVisability(true)
     setTimeout(() => setResetSeriesVisability(false), 100)
   }, [selectedGraph, dispatch])
+
+  // Reformat data table values to match graph's decimal precision
+  // https://jsfiddle.net/BlackLabel/5kj9pnfm/
+  useEffect(() => {
+    Highcharts.addEvent(Highcharts.Chart, 'aftergetTableAST', function (e) {
+      e.tree.children[2].children.forEach(function (row) {
+        row.children.forEach(function (cell, i) {
+          if (i !== 0) {
+            row.children[i].textContent = Highcharts.numberFormat(
+              cell.textContent.replaceAll(',', ''),
+              selectedGraphData?.decimalPrecision || 0
+            )
+          }
+        })
+      })
+    })
+  }, [selectedGraphData])
 
   const loadingGraphDetails =
     !selectedGraph ||

--- a/src/data-browser/graphs/quarterly/SectionGraphs.jsx
+++ b/src/data-browser/graphs/quarterly/SectionGraphs.jsx
@@ -1,12 +1,12 @@
-import React, { useCallback, useEffect, useState } from "react"
-import { useSelector, useDispatch } from "react-redux"
-import CopyURLButton from "../../../common/CopyURLButton.jsx"
-import LoadingIcon from "../../../common/LoadingIcon"
-import Select from "../../Select.jsx"
-import { BaseURLQuarterly } from "../constants"
-import { Graph } from "../Graph"
-import { deriveHighchartsConfig } from "../highchartsConfig"
-import { PeriodSelectors } from "../PeriodSelectors"
+import React, { useCallback, useEffect, useState } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import CopyURLButton from '../../../common/CopyURLButton.jsx'
+import LoadingIcon from '../../../common/LoadingIcon'
+import Select from '../../Select.jsx'
+import { BaseURLQuarterly } from '../constants'
+import { Graph } from '../Graph'
+import { deriveHighchartsConfig } from '../highchartsConfig'
+import { PeriodSelectors } from '../PeriodSelectors'
 import {
   CATEGORIES,
   DATA,
@@ -21,12 +21,12 @@ import {
   SELECTED_GRAPH,
   SELECTED_GRAPH_DATA,
   SERIES_FOR_URL,
-} from "../slice/graphConfigs.js"
-import { graphs } from "../slice/index.js"
-import { formatGroupLabel } from "../utils/menuHelpers.js"
-import { useFetchGraphList } from "./useFetchGraphList"
-import { useFetchSingleGraph } from "./useFetchSingleGraphs"
-import { useManageGraphSelection } from "./useManageGraphSelection"
+} from '../slice/graphConfigs.js'
+import { graphs } from '../slice/index.js'
+import { formatGroupLabel } from '../utils/menuHelpers.js'
+import { useFetchGraphList } from './useFetchGraphList'
+import { useFetchSingleGraph } from './useFetchSingleGraphs'
+import { useManageGraphSelection } from './useManageGraphSelection'
 
 export const SectionGraphs = ({
   error,
@@ -46,9 +46,9 @@ export const SectionGraphs = ({
   const isFirstLoad = firstLoadState === undefined ? true : firstLoadState
 
   const periodHigh = graphs.getConfig(graphStore, PERIOD_HI) // Period filters
-  const setPeriodHigh = (value) => dispatch(graphs.setConfig(PERIOD_HI, value))
+  const setPeriodHigh = value => dispatch(graphs.setConfig(PERIOD_HI, value))
   const periodLow = graphs.getConfig(graphStore, PERIOD_LO) // Period filters
-  const setPeriodLow = (value) => dispatch(graphs.setConfig(PERIOD_LO, value))
+  const setPeriodLow = value => dispatch(graphs.setConfig(PERIOD_LO, value))
 
   const quarters = graphs.getConfig(graphStore, QUARTERS) // Contains all the quarters from a selected graph and is used for period filtering
   const rawGraphList = graphs.getConfig(graphStore, RAW_GRAPH_LIST) // List of available graphs from API
@@ -56,11 +56,11 @@ export const SectionGraphs = ({
   const selectedGraph = graphs.getConfig(graphStore, SELECTED_GRAPH) // Configuration for the currently selected graph
   const selectedGraphData = graphs.getConfig(graphStore, SELECTED_GRAPH_DATA) // API data of currently selected graph
   const seriesForURL = graphs.getConfig(graphStore, SERIES_FOR_URL) // List of series names to be included in the URL's `visibleSeries` query parameter
-  const setSeriesForURL = (value) =>
+  const setSeriesForURL = value =>
     dispatch(graphs.setConfig(SERIES_FOR_URL, value))
 
   const onGraphFetchError = useCallback(
-    (err) => {
+    err => {
       dispatch(graphs.setConfig(SELECTED_GRAPH_DATA, null))
       setError(err)
     },
@@ -92,11 +92,11 @@ export const SectionGraphs = ({
   })
 
   const handleGraphSelection = useCallback(
-    (event) => {
+    event => {
       dispatch(
         graphs.setConfig(
           SELECTED_GRAPH,
-          rawGraphList.find((opt) => opt.value == event.value)
+          rawGraphList.find(opt => opt.value == event.value)
         )
       )
       fetchSingleGraph(event.value) // value = endpoint for single graph (i.e) -> /applications
@@ -124,11 +124,11 @@ export const SectionGraphs = ({
     }
 
     // Allows direct linking to the different tabs
-    if (props.history.location.pathname.includes("/info/filers")) {
+    if (props.history.location.pathname.includes('/info/filers')) {
       props.history.push({
         pathname: `${BaseURLQuarterly}/info/filers`,
       })
-    } else if (props.history.location.pathname.includes("/info/faq")) {
+    } else if (props.history.location.pathname.includes('/info/faq')) {
       props.history.push({
         pathname: `${BaseURLQuarterly}/info/faq`,
       })
@@ -149,7 +149,7 @@ export const SectionGraphs = ({
 
   // A workaround to force Highcharts to reset series visibility when a new graph is selected
   useEffect(() => {
-    const setResetSeriesVisability = (value) =>
+    const setResetSeriesVisability = value =>
       dispatch(graphs.setConfig(RESET_SERIES_VIS, value))
     setResetSeriesVisability(true)
     setTimeout(() => setResetSeriesVisability(false), 100)
@@ -167,17 +167,17 @@ export const SectionGraphs = ({
 
   return (
     <>
-      <p className="instructions">Select a graph from the menu below</p>
+      <p className='instructions'>Select a graph from the menu below</p>
       <Select
-        classNamePrefix="react-select__graph" // Used for cypress testing
+        classNamePrefix='react-select__graph' // Used for cypress testing
         options={graphMenuOptions}
-        placeholder="Select a Graph"
-        aria-label="Select a Graph."
+        placeholder='Select a Graph'
+        aria-label='Select a Graph.'
         onChange={handleGraphSelection}
         value={
           selectedGraph
             ? { value: selectedGraph.value, label: selectedGraph.label }
-            : ""
+            : ''
         }
         formatGroupLabel={formatGroupLabel}
       />
@@ -195,8 +195,8 @@ export const SectionGraphs = ({
       />
 
       {!error && seriesForURL && (
-        <div className="toolbar">
-          <CopyURLButton text={"Share Graph"} />
+        <div className='toolbar'>
+          <CopyURLButton text={'Share Graph'} />
         </div>
       )}
 
@@ -204,14 +204,15 @@ export const SectionGraphs = ({
         loading={!data[selectedGraph.value]} // Are we waiting for API data for the selected graph?
         seriesForURL={seriesForURL}
         options={deriveHighchartsConfig({
+          decimalPlace: selectedGraphData.decimalPrecision,
           categories, // xAxis values from API
           endpoint: selectedGraph?.value,
           loading: resetSeriesVisability, // Force reset of series' visibility
           periodHigh,
           periodLow,
           periodRange: [
-            quarters?.findIndex((q) => q.value == periodLow.value),
-            quarters?.findIndex((q) => q.value == periodHigh.value) + 1,
+            quarters?.findIndex(q => q.value == periodLow.value),
+            quarters?.findIndex(q => q.value == periodHigh.value) + 1,
           ],
           series: data[selectedGraph?.value],
           seriesForURL,

--- a/src/data-browser/graphs/quarterly/SectionGraphs.jsx
+++ b/src/data-browser/graphs/quarterly/SectionGraphs.jsx
@@ -158,13 +158,13 @@ export const SectionGraphs = ({
   // Reformat data table values to match graph's decimal precision
   // https://jsfiddle.net/BlackLabel/5kj9pnfm/
   useEffect(() => {
-    Highcharts.addEvent(Highcharts.Chart, 'aftergetTableAST', function (e) {
+    Highcharts.addEvent(Highcharts.Chart, "aftergetTableAST", function (e) {
       e.tree.children[2].children.forEach(function (row) {
         row.children.forEach(function (cell, i) {
           if (i !== 0) {
             row.children[i].textContent = Highcharts.numberFormat(
-              cell.textContent.replaceAll(',', ''),
-              selectedGraphData?.decimalPrecision || 0
+              cell.textContent.replaceAll(",", ""),
+              selectedGraphData?.decimalPrecision
             )
           }
         })

--- a/src/data-browser/graphs/quarterly/SectionGraphs.jsx
+++ b/src/data-browser/graphs/quarterly/SectionGraphs.jsx
@@ -1,5 +1,6 @@
+import Highcharts from 'highcharts'
 import React, { useCallback, useEffect } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import CopyURLButton from '../../../common/CopyURLButton.jsx'
 import LoadingIcon from '../../../common/LoadingIcon'
 import Select from '../../Select.jsx'
@@ -20,7 +21,7 @@ import {
   RESET_SERIES_VIS,
   SELECTED_GRAPH,
   SELECTED_GRAPH_DATA,
-  SERIES_FOR_URL,
+  SERIES_FOR_URL
 } from '../slice/graphConfigs.js'
 import { graphs } from '../slice/index.js'
 import { formatGroupLabel } from '../utils/menuHelpers.js'

--- a/src/data-browser/graphs/quarterly/useManageGraphSelection.jsx
+++ b/src/data-browser/graphs/quarterly/useManageGraphSelection.jsx
@@ -1,10 +1,10 @@
-import { produce } from 'immer'
-import { useEffect } from 'react'
-import { useDispatch } from 'react-redux'
-import { useQuery } from '../utils/utils'
-import { graphs } from '../slice'
-import { DATA, PERIOD_HI, PERIOD_LO, QUARTERS } from '../slice/graphConfigs'
-import { useLocation } from 'react-router-dom'
+import { produce } from "immer"
+import { useEffect } from "react"
+import { useDispatch } from "react-redux"
+import { useQuery } from "../utils/utils"
+import { graphs } from "../slice"
+import { DATA, PERIOD_HI, PERIOD_LO, QUARTERS } from "../slice/graphConfigs"
+import { useLocation } from "react-router-dom"
 
 /**
  * On graph selection,
@@ -23,21 +23,24 @@ export const useManageGraphSelection = ({
     if (!selectedGraph) return
 
     if (selectedGraphData) {
-      const nextState = produce(data, draft => {
+      const nextState = produce(data, (draft) => {
         let graphLines = []
 
+        let decimalPlace = selectedGraphData.decimalPrecision
+
         // Generating each line for the graph
-        selectedGraphData.series.map(line => {
+        selectedGraphData.series.map((line) => {
           // Create an Array of zeros, matching the length of the xAxis labels array
           const currentSeries = Array.apply(null, Array(categories.length)).map(
-            _ => null
+            (_) => null
           )
 
           // Match each point in the series to its xAxis index by referencing categories
-          line.coordinates.forEach(point => {
+          line.coordinates.forEach((point) => {
             const idx = categories.indexOf(point.x)
             if (idx < 0) return // Skip unknown filing periods
-            currentSeries[idx] = parseFloat(parseFloat(`${point.y}`).toFixed(2)) || 0
+            currentSeries[idx] =
+              parseFloat(parseFloat(`${point.y}`).toFixed(decimalPlace)) || 0
           })
 
           graphLines.push({
@@ -51,11 +54,11 @@ export const useManageGraphSelection = ({
       })
       dispatch(graphs.setConfig(DATA, nextState))
 
-      let lowPeriod = query.get('periodLow')
-      let highPeriod = query.get('periodHigh')
+      let lowPeriod = query.get("periodLow")
+      let highPeriod = query.get("periodHigh")
 
       // Dynamically generate period selector options
-      let periodOptions = categories.map(yq => ({
+      let periodOptions = categories.map((yq) => ({
         value: yq,
         label: yq,
       }))
@@ -66,14 +69,20 @@ export const useManageGraphSelection = ({
       if (
         location.search.match(/periodLow/) &&
         location.search.match(/periodHigh/) &&
-        periodOptions.some(q => q.value == lowPeriod) &&
-        periodOptions.some(q => q.value == highPeriod)
+        periodOptions.some((q) => q.value == lowPeriod) &&
+        periodOptions.some((q) => q.value == highPeriod)
       ) {
-        dispatch(graphs.setConfig(PERIOD_LO, { value: lowPeriod, label: lowPeriod }))
-        dispatch(graphs.setConfig(PERIOD_HI, { value: highPeriod, label: highPeriod }))
+        dispatch(
+          graphs.setConfig(PERIOD_LO, { value: lowPeriod, label: lowPeriod })
+        )
+        dispatch(
+          graphs.setConfig(PERIOD_HI, { value: highPeriod, label: highPeriod })
+        )
       } else {
         dispatch(graphs.setConfig(PERIOD_LO, periodOptions[0]))
-        dispatch(graphs.setConfig(PERIOD_HI, periodOptions[periodOptions.length - 1]))
+        dispatch(
+          graphs.setConfig(PERIOD_HI, periodOptions[periodOptions.length - 1])
+        )
       }
     }
   }, [selectedGraph, selectedGraphData, categories])


### PR DESCRIPTION
Closes #1530 

- Display data table values with API configured precision
- Switch thousands separator from `space` to `comma`

### Data table precision matches chart 
<img width="1004" alt="Screen Shot 2022-09-20 at 5 21 26 PM" src="https://user-images.githubusercontent.com/2592907/191381847-1f0dfc3c-45c5-403e-bb09-86e6a7756315.png">

### Large Y-Axis values use comma separator 
<img width="108" alt="Screen Shot 2022-09-20 at 5 16 59 PM" src="https://user-images.githubusercontent.com/2592907/191381202-fdbe3f86-8df9-45d8-bbba-51353749aa89.png">


