### PR TITLE
Use HMDA file proxy for MLAR and IRS download

### DIFF
--- a/src/common/s3/fileProxy.js
+++ b/src/common/s3/fileProxy.js
@@ -1,0 +1,14 @@
+export const IRS = {
+  buildURL: (year, lei) => {
+    return '/file/reports/irs/year/' + year + '/institution/' + lei
+  },
+}
+
+export const MLAR = {
+ buildURL: (year, lei, withHeader) => {
+   let fileType = '/txt'
+   if (withHeader) fileType += '/header'
+
+   return `/file/modifiedLar/year/` + year + `/institution/` + lei + fileType
+ }
+}

--- a/src/data-publication/reports/Results.jsx
+++ b/src/data-publication/reports/Results.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { MLAR } from '../../common/s3/fileProxy'
 
 import './Results.css'
 
@@ -97,11 +98,12 @@ class Results extends React.Component {
           }
         : { title: 'LEI', id: institution.lei }
 
-    const headeredFile = this.state.withHeader
-      ? { dir: 'header/', fname: '_header' }
-      : { dir: '', fname: '' }
+    const href = MLAR.buildURL(
+      this.props.year,
+      normalizedInstitution.id,
+      this.state.withHeader
+    )
 
-    const href = `https://s3.amazonaws.com/cfpb-hmda-public/prod/modified-lar/${this.props.year}/${headeredFile.dir}${normalizedInstitution.id}${headeredFile.fname}.txt`
     return (
       <li key={index}>
         <h4>{institution.name}</h4>

--- a/src/filing/api/fetch.js
+++ b/src/filing/api/fetch.js
@@ -27,7 +27,7 @@ export function fetchData(options = { method: 'GET' }) {
     options.querystring = createQueryString(options.params)
   }
 
-  const url = makeUrl(options)
+  const url = options.url || makeUrl(options)
   if (typeof options.body === 'object' && !isFormData)
     options.body = JSON.stringify(options.body)
 

--- a/src/filing/submission/irs/DownloadIRS.jsx
+++ b/src/filing/submission/irs/DownloadIRS.jsx
@@ -1,0 +1,77 @@
+import FileSaver from 'file-saver'
+import React, { useState } from 'react'
+import { IRS } from '../../../common/s3/fileProxy.js'
+import { fetchData } from '../../api/fetch.js'
+import { useCallback } from 'react'
+import { error } from '../../utils/log.js'
+import { DownloadStatus } from './DownloadStatus'
+
+const noOp = () => null
+
+/**
+ * Download an Institution's IRS file (CSV)
+ * @param {String} period YearQuarter
+ * @param {String} lei Institution identifier
+ * @param {Object} opts Additional options
+ */
+const download = (period, lei, opts) => {
+  const onResult = opts.onResult || noOp
+
+  onResult(null) // Reset status on each download request
+
+  const fetchOptions = {
+    url: IRS.buildURL(period, lei),
+    params: {
+      format: 'csv',
+    },
+  }
+
+  // IRS proxy endpoint requires Authentication and the fetchData method encapsulates that
+  fetchData(fetchOptions)
+    .then(data => {
+      // Successful will be a string with content
+      if (typeof data !== 'string' || !data.length) {
+        onResult(false)
+        return
+      }
+
+      FileSaver.saveAs(
+        new Blob([data], { type: 'text/csv;charset=utf-16' }),
+        `${period}-${lei}-nationwide-irs.csv`
+      )
+
+      onResult(true)
+    })
+    .catch(_ => {
+      error(`Error fetching ${period} IRS for ${lei}`)
+      onResult(false)
+    })
+}
+
+
+/**
+ * Encapsulates IRS downloading
+ * @param {Object} props
+ * @param {String} props.period YearQuarter
+ * @param {String} props.lei Institution ID
+ */
+export const DownloadIRS = ({ period, lei }) => {
+  const [irsReady, setIrsReady] = useState(null)
+
+  const clickHandler = useCallback(() => {
+    download(period, lei, { onResult: setIrsReady })
+  }, [period, lei, setIrsReady])
+
+  return (
+    <p className='flex-inline'>
+      When ready, the IRS will be available for{' '}
+      <button className='download-irs' onClick={clickHandler}>
+        download here
+      </button>
+      .
+      <DownloadStatus success={irsReady} />
+    </p>
+  )
+}
+
+export default DownloadIRS

--- a/src/filing/submission/irs/DownloadStatus.jsx
+++ b/src/filing/submission/irs/DownloadStatus.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { BsCheckCircle, BsExclamationTriangleFill } from 'react-icons/bs'
+
+/**
+ * Display a message after attempting to download an IRS
+ * @param {Object} props
+ * @param {boolean|null} props.success
+ * @returns
+ */
+export const DownloadStatus = ({ success }) => {
+  if (success === null) return success
+
+  if (success)
+    return (
+      <span className='flex-inline status success '>
+        <BsCheckCircle />
+        IRS downloaded!
+      </span>
+    )
+
+  return (
+    <span className='flex-inline status'>
+      <BsExclamationTriangleFill />
+      IRS not found
+    </span>
+  )
+}

--- a/src/filing/submission/irs/IRSReport.css
+++ b/src/filing/submission/irs/IRSReport.css
@@ -50,3 +50,32 @@
 .IRSReport button:hover {
   color: #205493;
 }
+
+.IRSReport .download-irs {
+  display: inline;
+  margin-left: 5px;
+}
+
+.IRSReport .status {
+  display: inline;
+  margin-left: .5em;
+  /* border: 1px solid #e48a34; */
+  border-radius: 5px;
+  padding: 0 5px;
+}
+.IRSReport .status svg {
+  margin-right: .3em;
+  fill: #e48a34;
+}
+
+.IRSReport .status.success,
+.IRSReport .status.success svg {
+  border-color: #0071bc;
+  fill: #0071bc;
+}
+
+.IRSReport .flex-inline {
+  display:flex;
+  flex-direction: row;
+  align-items: center;
+}

--- a/src/filing/submission/irs/index.jsx
+++ b/src/filing/submission/irs/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { isBeta } from '../../../common/Beta.jsx'
+import DownloadIRS from './DownloadIRS.jsx'
 
 import './IRSReport.css'
 
-const IRSReport = props => {
-  const filingPeriod=props.filingPeriod
+const IRSReport = ({ filingPeriod, lei }) => {
   if(isBeta()) return null
   return (
     <section className="IRSReport">
@@ -17,18 +17,7 @@ const IRSReport = props => {
           will not be available immediately. Please check back shortly after
           submitting your data to access your IRS.
         </p>
-        <p>
-          When ready, the IRS will be available for{' '}
-          <a
-            href={`https://s3.amazonaws.com/cfpb-hmda-public/prod/reports/disclosure/${filingPeriod}/${
-              props.lei
-            }/nationwide/IRS.csv`}
-            download={true}
-          >
-            download here
-          </a>
-          .
-        </p>
+        <DownloadIRS period={filingPeriod} lei={lei} />
         <p className="text-small">
           Loan amounts in the IRS are binned and disclosed in accordance
           with the 2018 HMDA data publication policy guidance. An overview
@@ -42,6 +31,7 @@ const IRSReport = props => {
 }
 
 IRSReport.propTypes = {
+  filingPeriod: PropTypes.string,
   lei: PropTypes.string
 }
 


### PR DESCRIPTION
Closes #1547
## Changes
- Updates `fetchData` to accept a specific URL
- Fetches IRS reports via HMDA File Proxy instead of from S3
  - Displays a success/not-found message for each download attempt.
- Fetches MLAR reports via HMDA File Proxy instead of from S3 
## Screenshots
|Status|Visual|
|---|---|
|null => No click yet|<img width="560" alt="null" src="https://user-images.githubusercontent.com/2592907/193162180-916a123e-fb01-48c8-8a98-cf177b3497d1.png">|
|false => No IRS found | <img width="558" alt="false" src="https://user-images.githubusercontent.com/2592907/193162228-61960eb5-ddb4-4a98-a0c5-a4e2d66f51f2.png"> |
|true => IRS found | <img width="595" alt="true" src="https://user-images.githubusercontent.com/2592907/193162274-b7989153-283c-46ab-81dc-fde32bc49b98.png">|

## Testing

### Missing IRS
- Visit https://\<DEV>/filing/2020/B90YWS6AFX2LGWOXJ1LD/submission
- Click `download here`
- Observe status updated with `IRS not found`


### Has IRS
 - Visit https://\<DEV>/filing/2019/FRONTENDTESTBANK9999/submission
- Click `download here`
- Observe status update with `IRS downloaded!`

### Modified LAR
- Visit https://\<DEV>/data-publication/modified-lar/2020
- Enter `cypress` 
- Click `Download Modified LAR`
- Click checkbox  `Include File Header `
- Click `Download Modified LAR w/ header`
- Open both files.  Confirm that headered version has the header row while the other version does not.
