### PR TITLE
[Homepage] Make banner a consistent height to avoid controls shifting…

### DIFF
--- a/src/common/OptionCarousel.css
+++ b/src/common/OptionCarousel.css
@@ -7,6 +7,15 @@
   align-items: center;
 }
 
+/* Prevent shifting height on homepage banner  */
+#oc-homepage-banner .alert-text {
+  max-height: 3em;
+}
+
+#oc-homepage-banner .alert {
+  height: 120px;
+}
+
 .oc .alert {
   margin: 0;
   padding-top: 3rem;

--- a/src/common/OptionCarousel.jsx
+++ b/src/common/OptionCarousel.jsx
@@ -15,10 +15,12 @@ import "./OptionCarousel.css"
  * @param {Boolean} showControls Display the navigation controls
  */
 export const OptionCarousel = ({
+  autoAdvance = true,
   className = "",
   cycleTime = 2,
   fixedHeight = null,
   hideIcon = false,
+  id,
   options = [],
   showControls = true,
 }) => {
@@ -40,10 +42,10 @@ export const OptionCarousel = ({
   useDynamicHeight({ setCurrHeight, maxLength, fixedHeight })
 
   /* Navigation logic */
-  const navControls = useAutoAdvance({ cycleTime, totalCount, autoAdvance: false })
+  const navControls = useAutoAdvance({ cycleTime, totalCount, autoAdvance })
 
   return (
-    <div className="oc" style={styles}>
+    <div id={id} className="oc" style={styles}>
       <span className={classname}>
         {showNavigator && (
           <OptionNavigator {...{ ...navControls, totalCount }} />

--- a/src/homepage/AnnouncementBanner.jsx
+++ b/src/homepage/AnnouncementBanner.jsx
@@ -167,6 +167,7 @@ export const AnnouncementBanner = ({
       cycleTime={5}
       hideIcon
       showControls
+      fixedHeight='7em'
     />
   )
 }


### PR DESCRIPTION
Closes #1583 

Issues
- [x] Scroll bars always show even without overflow
  - Chrome 105.0.5195.102
  - Chrome 105.0.5195.125 (looks good)
  - RESOLUTION: Removed the `overflow: scroll`.  
    - This does mean that we're restricted to 2 rows of text per banner message. 