### PR TITLE
[Homepage] Banner cleanup

### DIFF
--- a/src/common/constants/dev-config.json
+++ b/src/common/constants/dev-config.json
@@ -11,33 +11,6 @@
       }
     },
     {
-      "heading": "2023 Filing Guides Released",
-      "message": "On September 6, 2022, the Bureau released the 2023 FIG and the Supplemental Guide for Quarterly Filers for 2023, which are available",
-      "type": "info",
-      "link": {
-        "url": "https://ffiec.cfpb.gov/documentation/2023/fig",
-        "text": "here."
-      }
-    },
-    {
-      "heading": "HMDA Quarterly Graphs Tool Released",
-      "message": "On August 30, 2022, the CFPB released a new FFIEC HMDA Data Browser feature - the Quarterly Graphs tool, which is available ",
-      "type": "info",
-      "link": {
-        "url": "https://ffiec.cfpb.gov/data-browser/graphs/quarterly",
-        "text": "here."
-      }
-    },
-    {
-      "heading": "2021 Data Publication Release",
-      "message": "On June 16, 2022, the 2021 static datasets, Disclosure Reports, and MSA/MD Aggregate reports were released and can be accessed via the ",
-      "type": "info",
-      "link": {
-        "url": "https://ffiec.cfpb.gov/data-publication/",
-        "text": "Data Publications page."
-      }
-    },
-    {
       "message": "The FFIEC has announced a tentative release schedule for the 2022 Census products, which is available ",
       "type": "info",
       "heading": "2022 FFIEC Census Product Release Schedule",

--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -11,33 +11,6 @@
       }
     },
     {
-      "heading": "2023 Filing Guides Released",
-      "message": "On September 6, 2022, the Bureau released the 2023 FIG and the Supplemental Guide for Quarterly Filers for 2023, which are available",
-      "type": "info",
-      "link": {
-        "url": "https://ffiec.cfpb.gov/documentation/2023/fig",
-        "text": "here."
-      }
-    },
-    {
-      "heading": "HMDA Quarterly Graphs Tool Released",
-      "message": "On August 30, 2022, the CFPB released a new FFIEC HMDA Data Browser feature - the Quarterly Graphs tool, which is available ",
-      "type": "info",
-      "link": {
-        "url": "https://ffiec.cfpb.gov/data-browser/graphs/quarterly",
-        "text": "here."
-      }
-    },
-    {
-      "heading": "2021 Data Publication Release",
-      "message": "On June 16, 2022, the 2021 static datasets, Disclosure Reports, and MSA/MD Aggregate reports were released and can be accessed via the ",
-      "type": "info",
-      "link": {
-        "url": "https://ffiec.cfpb.gov/data-publication/",
-        "text": "Data Publications page."
-      }
-    },
-    {
       "message": "The FFIEC has announced a tentative release schedule for the 2022 Census products, which is available ",
       "type": "info",
       "heading": "2022 FFIEC Census Product Release Schedule",

--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -11,33 +11,6 @@
       }
     },
     {
-      "heading": "2023 Filing Guides Released",
-      "message": "On September 6, 2022, the Bureau released the 2023 FIG and the Supplemental Guide for Quarterly Filers for 2023, which are available",
-      "type": "info",
-      "link": {
-        "url": "https://ffiec.cfpb.gov/documentation/2023/fig",
-        "text": "here."
-      }
-    },
-    {
-      "heading": "HMDA Quarterly Graphs Tool Released",
-      "message": "On August 30, 2022, the CFPB released a new FFIEC HMDA Data Browser feature - the Quarterly Graphs tool, which is available ",
-      "type": "info",
-      "link": {
-        "url": "https://ffiec.cfpb.gov/data-browser/graphs/quarterly",
-        "text": "here."
-      }
-    },
-    {
-      "heading": "2021 Data Publication Release",
-      "message": "On June 16, 2022, the 2021 static datasets, Disclosure Reports, and MSA/MD Aggregate reports were released and can be accessed via the ",
-      "type": "info",
-      "link": {
-        "url": "https://ffiec.cfpb.gov/data-publication/",
-        "text": "Data Publications page."
-      }
-    },
-    {
       "message": "The FFIEC has announced a tentative release schedule for the 2022 Census products, which is available ",
       "type": "info",
       "heading": "2022 FFIEC Census Product Release Schedule",


### PR DESCRIPTION
Closes #1582 

Prod: Keeps only the Quarterly Graphs Update, Q3 Open, Census Schedule banners.

Beta: Also keeps the OLARFT banner.
 
NOTE The Q3 open banner is programmatically added so does not show up in the Configuration files. 
