### PR TITLE
[Graphs] Users can download filer loan info from filer tab in Graphs

### DIFF
--- a/src/common/SimpleSortTable.jsx
+++ b/src/common/SimpleSortTable.jsx
@@ -1,94 +1,162 @@
-import { flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from '@tanstack/react-table';
-import { useState } from 'react';
-import Pills from './Pills';
-import './SimpleSortTable.css';
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table"
+import fileSaver from "file-saver"
+import { useState, useRef } from "react"
+import Pills from "./Pills"
+import "./SimpleSortTable.css"
+import { buildCSVRows } from "../data-publication/reports/tables/AggregateUtils"
 
-const SimpleSortTable = props => {
-  const { data, columns, customFooter, initialSort: { sort, setSort } } = props;
+const SimpleSortTable = (props) => {
+  const {
+    data,
+    columns,
+    customFooter,
+    initialSort: { sort, setSort },
+    year,
+  } = props
 
-  const [sorting, setSorting] = useState(sort || []);
+  const [sorting, setSorting] = useState(sort || [])
 
-  const onSortingChange = changeFn => {
-    setSorting(changeFn);
-    setSort?.call(undefined, changeFn);
-  };
+  const tableRef = useRef()
+
+  // Generates a CSV file from the table on the page
+  const generateCSV = () => {
+    let theCSV = ""
+
+    if (!tableRef.current) return
+
+    // Extracting table header innerHTML because the table headers contained sorting icons
+    const tHeadRows = tableRef.current.tHead.rows.item("0").cells
+    const rowArray = Array.from(tHeadRows)
+    const rowHeaders = rowArray.map(
+      (header) => header.children.item("0").children.item("0").innerHTML
+    )
+
+    theCSV = theCSV + rowHeaders.join(",") + "\n"
+
+    // Extracting table body rows
+    const tBodyRows = tableRef.current.tBodies[0].rows
+    theCSV = theCSV + buildCSVRows(tBodyRows, "body")
+
+    // Extracting table footer rows
+    const tFootRows = tableRef.current.tFoot.rows
+    theCSV = theCSV + buildCSVRows(tFootRows, "foot")
+
+    // Downloads CSV file
+    fileSaver.saveAs(
+      new Blob([theCSV], { type: "text/csv;charset=utf-16" }),
+      `${year} Quarterly Filer Loan and Application Counts.csv`
+    )
+  }
+
+  const onSortingChange = (changeFn) => {
+    setSorting(changeFn)
+    setSort?.call(undefined, changeFn)
+  }
 
   const table = useReactTable({
     data,
     columns,
     state: {
-      sorting
+      sorting,
     },
     enableSortingRemoval: false,
     onSortingChange,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
-  });
+  })
 
-  const updateSortSelection = updatedSelection => onSortingChange(old => updatedSelection);
+  const updateSortSelection = (updatedSelection) =>
+    onSortingChange((old) => updatedSelection)
 
-  const getSortArrow = sorted => {
-    if (sorted === 'asc') return '\u2191';
-    if (sorted === 'desc') return '\u2193';
-    return '\u2195';
-  };
+  const getSortArrow = (sorted) => {
+    if (sorted === "asc") return "\u2191"
+    if (sorted === "desc") return "\u2193"
+    return "\u2195"
+  }
 
-  const pills = sort.map(s => {
-    const label = columns.find(({ accessorKey }) => accessorKey === s.id)?.header.concat(s.desc ? ' \u2193' : ' \u2191');
+  const pills = sort.map((s) => {
+    const label = columns
+      .find(({ accessorKey }) => accessorKey === s.id)
+      ?.header.concat(s.desc ? " \u2193" : " \u2191")
     return { ...s, label }
-  });
+  })
 
-  return <div className="simple-sort-table-container">
-    <div>
-      <ul>
-        <li>Table is sortable by selecting the column headers.</li>
-        <li>Hold Shift and select multiple column headers to sort by multiple fields.</li>
-      </ul>
+  return (
+    <div className="simple-sort-table-container">
       <div>
-        <Pills values={pills} onChange={updateSortSelection} />
+        <ul>
+          <li>Table is sortable by selecting the column headers.</li>
+          <li>
+            Hold Shift and select multiple column headers to sort by multiple
+            fields.
+          </li>
+        </ul>
+
+        {data && (
+          <button
+            onClick={() => generateCSV()}
+            style={{ margin: "5px 0px 15px 0px" }}
+          >
+            Save as CSV
+          </button>
+        )}
+
+        <div>
+          <Pills values={pills} onChange={updateSortSelection} />
+        </div>
       </div>
-    </div>
-    <table className="simple-sort-table">
-      <thead>
-        {
-          table.getHeaderGroups().map(headerGroup => (
+      <table className="simple-sort-table" ref={tableRef}>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>
-              {headerGroup.headers.map(header => {
-                const clickableHeader = header.column.getCanSort() ? 'cursor-pointer select-none' : null;
+              {headerGroup.headers.map((header) => {
+                const clickableHeader = header.column.getCanSort()
+                  ? "cursor-pointer select-none"
+                  : null
                 return (
                   <th key={header.id} colSpan={header.colSpan}>
                     {header.isPlaceholder ? null : (
-                      <div className={clickableHeader}
-                        onClick={header.column.getToggleSortingHandler()}>
+                      <div
+                        className={clickableHeader}
+                        onClick={header.column.getToggleSortingHandler()}
+                      >
                         <span>
-                          {flexRender(header.column.columnDef.header, header.getContext())}
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
                         </span>
-                        <span className="sort-icon">{getSortArrow(header.column.getIsSorted())}</span>
+                        <span className="sort-icon">
+                          {getSortArrow(header.column.getIsSorted())}
+                        </span>
                       </div>
                     )}
                   </th>
                 )
               })}
             </tr>
-          ))
-        }
-      </thead>
-      <tbody>
-        {table.getRowModel().rows.map(row => (
-          <tr key={row.id}>
-            {row.getVisibleCells().map(cell => (
-              <td key={cell.id}>
-                {cell.getContext().getValue()?.toLocaleString()}
-              </td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-      <tfoot>
-        {customFooter}
-      </tfoot>
-    </table>
-  </div>;
-};
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>
+                  {cell.getContext().getValue()?.toLocaleString()}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>{customFooter}</tfoot>
+      </table>
+    </div>
+  )
+}
 
-export default SimpleSortTable;
+export default SimpleSortTable

--- a/src/data-browser/graphs/quarterly/QuarterlyFilersTable.jsx
+++ b/src/data-browser/graphs/quarterly/QuarterlyFilersTable.jsx
@@ -1,98 +1,131 @@
-import { useEffect, useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import LoadingIcon from '../../../common/LoadingIcon';
-import SimpleSortTable from '../../../common/SimpleSortTable';
-import { institutions } from '../slice';
-import './QuarterlyFilersTable.css';
+import { useEffect, useMemo, useRef } from "react"
+import { useDispatch, useSelector } from "react-redux"
+import LoadingIcon from "../../../common/LoadingIcon"
+import SimpleSortTable from "../../../common/SimpleSortTable"
+import { institutions } from "../slice"
+import "./QuarterlyFilersTable.css"
 
-const QuarterlyFilersTable = props => {
-  const dispatch = useDispatch();
-  const [year, past] = [new Date().getFullYear(), 3];
-  const { data, loading, sort } = useSelector(state => state.institutions);
-  const pastYears = [...Array(past).keys()].map(i => `${year - i - 1}`);
+const QuarterlyFilersTable = (props) => {
+  const dispatch = useDispatch()
+  const [year, past] = [new Date().getFullYear(), 3]
+  const { data, loading, sort } = useSelector((state) => state.institutions)
+  const pastYears = [...Array(past).keys()].map((i) => `${year - i - 1}`)
 
   useEffect(() => {
     if (!data) {
-      dispatch(institutions.fetchInstitutionLars({ year, past }));
-      dispatch(institutions.updateSort([{ id: 'agency', desc: false }, { id: 'name', desc: false }]));
+      dispatch(institutions.fetchInstitutionLars({ year, past }))
+      dispatch(
+        institutions.updateSort([
+          { id: "agency", desc: false },
+          { id: "name", desc: false },
+        ])
+      )
     }
-  }, [dispatch, data]);
+  }, [dispatch, data])
 
-  const setSort = sortUpdateFn => dispatch(institutions.updateSort(sortUpdateFn(sort)));
+  const setSort = (sortUpdateFn) =>
+    dispatch(institutions.updateSort(sortUpdateFn(sort)))
 
-  let content = <LoadingIcon />;
+  let content = <LoadingIcon />
 
   const tableColumns = useMemo(() => {
-    const countsColumns = pastYears.map(accessorKey => {
+    const countsColumns = pastYears.map((accessorKey) => {
       return {
         header: accessorKey,
         accessorKey,
-        sortingFn: 'alphanumeric',
-      };
-    });
+        sortingFn: "alphanumeric",
+      }
+    })
 
-    return [{
-      header: 'Institution',
-      accessorKey: 'name',
-      sortingFn: 'text',
-    }, {
-      header: 'LEI',
-      accessorKey: 'lei',
-      sortingFn: 'text',
-    }, {
-      header: 'Agency',
-      accessorKey: 'agency',
-      sortingFn: 'text',
-    }, ...countsColumns];
-  });
+    return [
+      {
+        header: "Institution",
+        accessorKey: "name",
+        sortingFn: "text",
+      },
+      {
+        header: "LEI",
+        accessorKey: "lei",
+        sortingFn: "text",
+      },
+      {
+        header: "Agency",
+        accessorKey: "agency",
+        sortingFn: "text",
+      },
+      ...countsColumns,
+    ]
+  })
 
-  if (loading === 'succeeded' && data) {
+  if (loading === "succeeded" && data) {
     const tableData = data.quarterly.map(({ name, lei, agency, larCounts }) => {
-      let counts = {};
-      larCounts.forEach(ts => {
-        counts[ts.year] = ts.count;
-      });
+      let counts = {}
+      larCounts.forEach((ts) => {
+        counts[ts.year] = ts.count
+      })
       return {
         name: name.toUpperCase(),
         lei,
         agency,
-        ...counts
+        ...counts,
       }
-    });
+    })
 
-    const quarterlySums = {};
-    pastYears.forEach(yr => {
+    const quarterlySums = {}
+    pastYears.forEach((yr) => {
       quarterlySums[yr] = data.quarterly.reduce((prev, curr) => {
-        const tsLar = curr.larCounts.find(ts => ts.year === yr);
-        return tsLar ? prev + tsLar.count : prev;
-      }, 0);
-    });
+        const tsLar = curr.larCounts.find((ts) => ts.year === yr)
+        return tsLar ? prev + tsLar.count : prev
+      }, 0)
+    })
 
-    const customFooter = <>
-      <tr>
-        <th colSpan="3" style={{ textAlign: 'right' }}>Total of Quarterly Filers</th>
-        {pastYears.map(yr => {
-          return <td key={yr}>{quarterlySums[yr].toLocaleString()}</td>
-        })}
-      </tr>
-      <tr>
-        <th colSpan="3" style={{ textAlign: 'right' }}>Total of All Filers</th>
-        {pastYears.map(yr => {
-          return <td key={yr}>{(data.yearly.find(yearlyCount => yearlyCount.year === yr) || { count: 0 }).count.toLocaleString()}</td>
-        })}
-      </tr>
-    </>;
-    content = <SimpleSortTable columns={tableColumns} data={tableData} customFooter={customFooter} initialSort={{ sort, setSort }} />;
+    const customFooter = (
+      <>
+        <tr>
+          <th colSpan="3" style={{ textAlign: "right" }}>
+            Total of Quarterly Filers
+          </th>
+          {pastYears.map((yr) => {
+            return <td key={yr}>{quarterlySums[yr].toLocaleString()}</td>
+          })}
+        </tr>
+        <tr>
+          <th colSpan="3" style={{ textAlign: "right" }}>
+            Total of All Filers
+          </th>
+          {pastYears.map((yr) => {
+            return (
+              <td key={yr}>
+                {(
+                  data.yearly.find(
+                    (yearlyCount) => yearlyCount.year === yr
+                  ) || { count: 0 }
+                ).count.toLocaleString()}
+              </td>
+            )
+          })}
+        </tr>
+      </>
+    )
+    content = (
+      <SimpleSortTable
+        columns={tableColumns}
+        data={tableData}
+        customFooter={customFooter}
+        initialSort={{ sort, setSort }}
+        year={year}
+      />
+    )
   }
 
   return (
     <div className="quarterly-filers-table">
-      <h2 className="table-heading">{year} Quarterly Filer Loan and Application Counts</h2>
-      <div className="table-container">
-        {content}
-      </div>
+      <h2 className="table-heading">
+        {year} Quarterly Filer Loan and Application Counts
+      </h2>
+      <div className="table-container">{content}</div>
     </div>
-  );
-};
+  )
+}
 
-export default QuarterlyFilersTable;
+export default QuarterlyFilersTable

--- a/src/data-browser/graphs/quarterly/QuarterlyFilersTable.jsx
+++ b/src/data-browser/graphs/quarterly/QuarterlyFilersTable.jsx
@@ -1,15 +1,15 @@
-import { useEffect, useMemo, useRef } from "react"
+import { useEffect, useMemo } from "react"
 import { useDispatch, useSelector } from "react-redux"
 import LoadingIcon from "../../../common/LoadingIcon"
 import SimpleSortTable from "../../../common/SimpleSortTable"
 import { institutions } from "../slice"
 import "./QuarterlyFilersTable.css"
 
-const QuarterlyFilersTable = (props) => {
+const QuarterlyFilersTable = props => {
   const dispatch = useDispatch()
   const [year, past] = [new Date().getFullYear(), 3]
-  const { data, loading, sort } = useSelector((state) => state.institutions)
-  const pastYears = [...Array(past).keys()].map((i) => `${year - i - 1}`)
+  const { data, loading, sort } = useSelector(state => state.institutions)
+  const pastYears = [...Array(past).keys()].map(i => `${year - i - 1}`)
 
   useEffect(() => {
     if (!data) {
@@ -23,13 +23,13 @@ const QuarterlyFilersTable = (props) => {
     }
   }, [dispatch, data])
 
-  const setSort = (sortUpdateFn) =>
+  const setSort = sortUpdateFn =>
     dispatch(institutions.updateSort(sortUpdateFn(sort)))
 
   let content = <LoadingIcon />
 
   const tableColumns = useMemo(() => {
-    const countsColumns = pastYears.map((accessorKey) => {
+    const countsColumns = pastYears.map(accessorKey => {
       return {
         header: accessorKey,
         accessorKey,
@@ -60,7 +60,7 @@ const QuarterlyFilersTable = (props) => {
   if (loading === "succeeded" && data) {
     const tableData = data.quarterly.map(({ name, lei, agency, larCounts }) => {
       let counts = {}
-      larCounts.forEach((ts) => {
+      larCounts.forEach(ts => {
         counts[ts.year] = ts.count
       })
       return {
@@ -72,9 +72,9 @@ const QuarterlyFilersTable = (props) => {
     })
 
     const quarterlySums = {}
-    pastYears.forEach((yr) => {
+    pastYears.forEach(yr => {
       quarterlySums[yr] = data.quarterly.reduce((prev, curr) => {
-        const tsLar = curr.larCounts.find((ts) => ts.year === yr)
+        const tsLar = curr.larCounts.find(ts => ts.year === yr)
         return tsLar ? prev + tsLar.count : prev
       }, 0)
     })
@@ -82,24 +82,24 @@ const QuarterlyFilersTable = (props) => {
     const customFooter = (
       <>
         <tr>
-          <th colSpan="3" style={{ textAlign: "right" }}>
+          <th colSpan='3' style={{ textAlign: "right" }}>
             Total of Quarterly Filers
           </th>
-          {pastYears.map((yr) => {
+          {pastYears.map(yr => {
             return <td key={yr}>{quarterlySums[yr].toLocaleString()}</td>
           })}
         </tr>
         <tr>
-          <th colSpan="3" style={{ textAlign: "right" }}>
+          <th colSpan='3' style={{ textAlign: "right" }}>
             Total of All Filers
           </th>
-          {pastYears.map((yr) => {
+          {pastYears.map(yr => {
             return (
               <td key={yr}>
                 {(
-                  data.yearly.find(
-                    (yearlyCount) => yearlyCount.year === yr
-                  ) || { count: 0 }
+                  data.yearly.find(yearlyCount => yearlyCount.year === yr) || {
+                    count: 0,
+                  }
                 ).count.toLocaleString()}
               </td>
             )
@@ -119,11 +119,11 @@ const QuarterlyFilersTable = (props) => {
   }
 
   return (
-    <div className="quarterly-filers-table">
-      <h2 className="table-heading">
+    <div className='quarterly-filers-table'>
+      <h2 className='table-heading'>
         {year} Quarterly Filer Loan and Application Counts
       </h2>
-      <div className="table-container">{content}</div>
+      <div className='table-container'>{content}</div>
     </div>
   )
 }

--- a/src/data-publication/reports/tables/AggregateUtils.js
+++ b/src/data-publication/reports/tables/AggregateUtils.js
@@ -22,15 +22,15 @@ export const sortAndFix = (report, fix) => {
  * Temporary Fix: Identifies unaggregated Disposition entries and aggregates them
  * @param {Array} data
  */
-export const fixAgg2 = data => {
+export const fixAgg2 = (data) => {
   const idxsNeedAggregation = []
 
   data.forEach((x, idx) => x.values.length > 7 && idxsNeedAggregation.push(idx))
 
   // Aggregate un-aggregated value data
-  idxsNeedAggregation.forEach(i => {
+  idxsNeedAggregation.forEach((i) => {
     const obj = data[i].values.reduce(valueReducer, {})
-    data[i].values = Object.keys(obj).map(k => obj[k])
+    data[i].values = Object.keys(obj).map((k) => obj[k])
   })
 
   return data
@@ -40,20 +40,20 @@ export const fixAgg2 = data => {
  * Temporary Fix: Identifies unaggregated Disposition entries and aggregates them
  * @param {Array} data
  */
- export const fixAgg1 = data => {
+export const fixAgg1 = (data) => {
   const idxsNeedAggregation = []
 
   data.forEach(
     (x, idx) =>
-      x.dispositions.some(dispo => dispo.values.length > 7) &&
+      x.dispositions.some((dispo) => dispo.values.length > 7) &&
       idxsNeedAggregation.push(idx)
   )
 
   // Aggregate un-aggregated disposition data
-  idxsNeedAggregation.forEach(i => {
-    data[i].dispositions.forEach(d => {
+  idxsNeedAggregation.forEach((i) => {
+    data[i].dispositions.forEach((d) => {
       const obj = d.values.reduce(valueReducer, {})
-      d.values = Object.keys(obj).map(k => obj[k])
+      d.values = Object.keys(obj).map((k) => obj[k])
     })
   })
 
@@ -82,20 +82,20 @@ const valueReducer = (prev, curr) => {
 }
 
 // Pagination label formatter to show first/last Tracts for a page
-export const pageLabelTracts = items => {
+export const pageLabelTracts = (items) => {
   if (!items || !items.length) return null
-  return items[0].tract + ' - ' + items[items.length - 1].tract
+  return items[0].tract + " - " + items[items.length - 1].tract
 }
 
 // Generate Aggregate1 report body for CSV download
-export const buildCSVRowsAggregate1 = report => {
-  let theCSVRows = ''
+export const buildCSVRowsAggregate1 = (report) => {
+  let theCSVRows = ""
 
   const _data = sortAndFix(report, fixUnaggregatedDispositions)
 
-  _data.forEach(tract => {
+  _data.forEach((tract) => {
     // Tract header
-    theCSVRows += tract.tract + '\n'
+    theCSVRows += tract.tract + "\n"
 
     // Disposition rows
     tract.dispositions
@@ -104,7 +104,7 @@ export const buildCSVRowsAggregate1 = report => {
         var yp = y.titleForSorting.substring(y.titleForSorting.length - 3)
         return xp == yp ? 0 : xp < yp ? -1 : 1
       })
-      .forEach(dispo => {
+      .forEach((dispo) => {
         const _rowLabel = dispo.title
         const _cols = dispo.values
           .sort(function (x, y) {
@@ -112,11 +112,11 @@ export const buildCSVRowsAggregate1 = report => {
             var yp = y.dispositionName.substring(y.dispositionName.length - 3)
             return xp == yp ? 0 : xp < yp ? -1 : 1
           })
-          .map(dispo => [dispo.count, dispo.value])
+          .map((dispo) => [dispo.count, dispo.value])
           .flat()
-          .join(',')
+          .join(",")
 
-        theCSVRows += _rowLabel + ',' + _cols + '\n'
+        theCSVRows += _rowLabel + "," + _cols + "\n"
       })
   })
 
@@ -124,23 +124,54 @@ export const buildCSVRowsAggregate1 = report => {
 }
 
 // Generate Aggregate2 report body for CSV download
-export const buildCSVRowsAggregate2 = report => {
-  let theCSVRows = ''
+export const buildCSVRowsAggregate2 = (report) => {
+  let theCSVRows = ""
 
   const _data = sortAndFix(report)
 
-  _data.forEach(tract => {
+  _data.forEach((tract) => {
     const _columns = tract.values
       .sort(function (x, y) {
         var xp = x.dispositionName.substring(x.dispositionName.length - 3)
         var yp = y.dispositionName.substring(y.dispositionName.length - 3)
         return xp == yp ? 0 : xp < yp ? -1 : 1
       })
-      .map(val => [val.count, val.value])
+      .map((val) => [val.count, val.value])
       .flat()
-      .join(',')
+      .join(",")
 
-    theCSVRows += tract.tract + ',' + _columns + '\n'
+    theCSVRows += tract.tract + "," + _columns + "\n"
+  })
+
+  return theCSVRows
+}
+
+// Function used to help build html table elements into CSV files
+export const buildCSVRows = (rows, rowType) => {
+  let theCSVRows = ""
+  Array.prototype.forEach.call(rows, (row, rowIndex) => {
+    // in a thead, account for the rowSpan by adding an empty cell
+    if (rowType === "head") {
+      if (rowIndex !== 0) theCSVRows = theCSVRows + ","
+    }
+    // loop through the cells
+    Array.prototype.forEach.call(row.cells, (cell, cellIndex) => {
+      // add the content
+      theCSVRows = theCSVRows + '"' + cell.innerHTML + '"'
+      if (cell.hasAttribute("colspan")) {
+        const spanCount = parseInt(cell.getAttribute("colspan"), 10)
+        let i = 0
+        for (i; i < spanCount - 1; i++) {
+          theCSVRows = theCSVRows + ","
+        }
+      }
+      // last child
+      if (row.cells.length - 1 === cellIndex) {
+        theCSVRows = theCSVRows + "\n"
+      } else {
+        theCSVRows = theCSVRows + ","
+      }
+    })
   })
 
   return theCSVRows


### PR DESCRIPTION
Closes #1579

New button has been added to `/filers`. This allows users to be able to download filer loan and application counts table as a CSV file. Any filtering/sorting on the table will be reflected in the CSV file.

<img width="584" alt="image" src="https://user-images.githubusercontent.com/60801873/194647766-6b1ce538-b14f-4bc4-8697-72dcfae1c565.png">
