### PR TITLE
[Charts] Usable on mobile

### DIFF
--- a/src/data-browser/graphs/graphs.css
+++ b/src/data-browser/graphs/graphs.css
@@ -88,3 +88,7 @@
 .Graphs .Markdown-Wrapper h2 {
   font-size: 1.25em;
 }
+
+.Graphs .highcharts-data-table {
+  overflow: auto;
+}

--- a/src/data-browser/graphs/highchartsConfig.js
+++ b/src/data-browser/graphs/highchartsConfig.js
@@ -8,7 +8,7 @@ export const baseConfig = {
   },
   subtitle: {
     text: "Subtitle",
-    style: { fontSize: "15px" },
+    style: { fontSize: "14px" },
   },
   caption: {
     text: "",
@@ -82,6 +82,16 @@ export const baseConfig = {
           },
         },
       },
+      {
+        condition: {
+          maxWidth: 800
+        },
+        chartOptions: {
+          chart: {
+            height: 600,
+          }
+        }
+      }
     ],
   },
 }


### PR DESCRIPTION
Closes #1614

## Changes

- Adds responsive rules to display chart at a height of 600px on mobile/tablet devices
- Adds scrolling to chart data tables


## Testing
http://localhost:3000/data-browser/graphs/quarterly/ltv-fha-re?periodLow=2019-Q1&periodHigh=2022-Q2&visibleSeries=Asian,Black,Hispanic,White

1. Proxy to Dev
1. View chart on mobile device
2. (OR) Use browser responsive tools to view chart at smaller device widths
3. Verify that the chart content is visible
4. Verify that you can interact with the chart
5. Verify that you can view all table content without it affecting the overall width of the page

 
|before|after|
|---|---|
|<img width="972" alt="Screen Shot 2022-10-15 at 12 45 53 AM" src="https://user-images.githubusercontent.com/2592907/195975808-3aa56ef4-59aa-4c9b-a1c4-161b4cae53dc.png">|<img width="972" alt="Screen Shot 2022-10-15 at 12 46 04 AM" src="https://user-images.githubusercontent.com/2592907/195975814-d0197a0d-12b3-41b9-bbc7-618dda568015.png">|


