### PR TITLE
[Keycloak] Use Proof Key for Code Exchange (PKCE)

### DIFF
--- a/cypress/integration/filing/Filing.spec.js
+++ b/cypress/integration/filing/Filing.spec.js
@@ -39,16 +39,10 @@ describe("Filing", function() {
     }).logEnv()
     
     // Skip authentication on CI
-    if(!isCI(ENVIRONMENT)) {
-      cy.logout({ root: authUrl, realm: AUTH_REALM })
-      cy.login({
-        root: authUrl,
-        realm: AUTH_REALM,
-        client_id: AUTH_CLIENT_ID,
-        redirect_uri: HOST,
-        username: USERNAME,
-        password: PASSWORD
-      })
+    if (!isCI(ENVIRONMENT)) {
+      cy.hmdaLogin('filing', authUrl)
+      cy.url().should('contains', `${AUTH_BASE_URL}filing/`)
+      cy.url().should('contains', `/institutions`)
     }
     
     cy.viewport(1600, 900)

--- a/cypress/integration/hmda-help/institution.spec.js
+++ b/cypress/integration/hmda-help/institution.spec.js
@@ -37,15 +37,8 @@ describe('HMDA Help - Institutions', () => {
     // Log in
     if (!isCI(ENVIRONMENT)) {
       cy.logout({ root: authUrl, realm: AUTH_REALM })
-      cy.wait(LOCAL_ACTION_DELAY)
-      cy.login({
-        root: authUrl,
-        realm: AUTH_REALM,
-        client_id: AUTH_CLIENT_ID,
-        redirect_uri: HOST,
-        username: USERNAME,
-        password: PASSWORD,
-      })
+      cy.hmdaLogin('hmda-help', authUrl)
+      cy.url().should('contains', `${AUTH_BASE_URL}hmda-help/`)
     }
     
     // Load site

--- a/cypress/integration/hmda-help/publication.spec.js
+++ b/cypress/integration/hmda-help/publication.spec.js
@@ -34,14 +34,8 @@ describe('HMDA Help - Publications', () => {
     if (!isCI(ENVIRONMENT)) {
       cy.logout({ root: authUrl, realm: AUTH_REALM })
       cy.wait(ACTION_DELAY)
-      cy.login({
-        root: authUrl,
-        realm: AUTH_REALM,
-        client_id: AUTH_CLIENT_ID,
-        redirect_uri: HOST,
-        username: USERNAME,
-        password: PASSWORD
-      })
+      cy.hmdaLogin('hmda-help', authUrl)
+      cy.url().should('contains', `${AUTH_BASE_URL}hmda-help/`)
     }
     
     // Load site

--- a/cypress/integration/load/LargeFiler.spec.js
+++ b/cypress/integration/load/LargeFiler.spec.js
@@ -43,14 +43,8 @@ describe('Large Filer', () => {
     // Skip authentication on CI
     if (!isCI(ENVIRONMENT)) {
       cy.logout({ root: authUrl, realm: AUTH_REALM })
-      cy.login({
-        root: authUrl,
-        realm: AUTH_REALM,
-        client_id: AUTH_CLIENT_ID,
-        redirect_uri: HOST,
-        username: USERNAME,
-        password: PASSWORD,
-      })
+      cy.hmdaLogin('filing', authUrl)
+      cy.url().should('contains', `${AUTH_BASE_URL}filing/`)
     }
 
     cy.viewport(1600, 900)

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -32,3 +32,16 @@ Cypress.Commands.add("dataUrl", { prevSubject: true }, target => {
 Cypress.Commands.add("logEnv", { prevSubject: true }, vars => {
   logEnv(vars[0])
 })
+
+// Login via UI
+Cypress.Commands.add('hmdaLogin', (app, authUrl) => {
+  const { USERNAME, PASSWORD, AUTH_BASE_URL, AUTH_REALM } = Cypress.env()
+  cy.logout({ root: authUrl, realm: AUTH_REALM })
+  cy.visit(`${AUTH_BASE_URL}${app}/`)
+
+  if (app.match('filing')) cy.get('button[title="Login"').click()
+
+  cy.get('#username').type(USERNAME)
+  cy.get('#password').type(PASSWORD)
+  cy.get('#kc-login').click()
+})

--- a/src/filing/App.jsx
+++ b/src/filing/App.jsx
@@ -32,7 +32,7 @@ export class AppContainer extends Component {
       this.redirectToReachablePeriod(filingPeriod)
     
     const keycloak = initKeycloak()
-    keycloak.init().then(authenticated => {
+    keycloak.init({ pkceMethod: 'S256' }).then(authenticated => {
       this.keycloakConfigured = true
       if (authenticated) {
         AccessToken.set(keycloak.token)

--- a/src/hmda-help/index.js
+++ b/src/hmda-help/index.js
@@ -47,7 +47,7 @@ class App extends Component {
   }
 
   componentDidMount() {
-    keycloak.init().then(authenticated => {
+    keycloak.init({ pkceMethod: 'S256' }).then(authenticated => {
       if (authenticated) {
         AccessToken.set(keycloak.token)
         refreshToken(this)


### PR DESCRIPTION
Closes #1621 

This is tested in DEV and looks good.  I don't want it merged yet, in case we need to do any deployments to other environments where PKCE is not yet enabled.  Hence leaving in as `Draft` for now.  

- Incorporates and expands upon PKCE inclusion from https://github.com/cfpb/hmda-frontend/pull/1612
- Update Cypress login flow to use UI instead API due to failures after PKCE implementation