### PR TITLE
1628 refactor cypress image

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -45,6 +45,8 @@ export CYPRESS_PASSWORD=<password>
 export CYPRESS_INSTITUTION=<target-institution-lei>
 export CYPRESS_TEST_DELAY=1000 # No delay (milliseconds)
 export CYPRESS_ACTION_DELAY=1000 # No delay (milliseconds)
+export CYPRESS_SHOULD_LOAD_TEST=true
+export CYPRESS_TEST_LIST='cypress/integration/data-browser/**,cypress/integration/data-publication/**,cypress/integration/filing/**,cypress/integration/hmda-help/**,cypress/integration/tools/**'
 ```
 
 ## Running Tests
@@ -76,15 +78,23 @@ Note: No videos or snapshots are created when running tests via the Cypress UI, 
 yarn cypress open
 ```
 
-## Building & Cronjob integration
+## Cronjob integration
+Integration testing automatically runs once daily via cronjob. 
 
-### Updating Specs
-Integration testing automatically runs twice daily via cronjob. To update the testing pod with the latest specs we need only update the image `hmda-cypress:latest`.  From the root directory `/hmda-frontend/` run:
+### Updating the test image
 ```
 docker build . -t hmda-cypress -f cypress/Dockerfile &&
 docker tag hmda-cypress <image_repo>/hmda/hmda-cypress &&
 docker push  <image_repo>/hmda/hmda-cypress
 ```
+
+### Updating Specs/Fixtures
+Cronjob specs and fixtures are pulled from AWS S3 on each job run. To update the testing data used, from the root directory `/hmda-frontend/`, run 
+```
+yarn cy-update-s3
+```
+ 
+You will be prompted for an AWS user profile that has `write` access to the S3 bucket.
 
 ### Updating Credentials
 In order to update the login credentials used by the testing pod, please see the `Quick Start` section in `/hmda-devops/kubernetes/cypress/README.md`.

--- a/cypress/docker-runner.sh
+++ b/cypress/docker-runner.sh
@@ -14,7 +14,7 @@ curl https://s3.amazonaws.com/cfpb-hmda-public/prod/cypress/integration.zip > ./
 
 # Run configured Integration tests
 # Example: "cypress/integration/data-browser/**,cypress/integration/data-publication/**"
-if [ $CYPRESS_TEST_LIST ]; 
+if [[ -n "$CYPRESS_TEST_LIST" ]]; 
 then
 	yarn cypress run --spec ${CYPRESS_TEST_LIST} > output_integration.txt
 	if  grep -q "All specs passed!" "output_integration.txt" ; then

--- a/cypress/docker-runner.sh
+++ b/cypress/docker-runner.sh
@@ -1,67 +1,38 @@
 #!/bin/bash
 # Script that will post a message to a predefined webhook when cypress is done
 
-# Args
-# 1 - Test collection label (Integration/Load)
-# 2 - Filename
-post_success() 
-{
-	runtime=$(tail -n 1 ${2} | xargs echo)
-	
-	msg="- [ [${environment}](${CYPRESS_HOST}) ] ${1}\n  - ${runtime} :1up:"
+# Import helper functions
+. ./cypress/support/shell-helpers.sh
 
-	curl -i -X POST -H 'Content-Type: application/json' -d "{\"text\": \"${msg}\"}" $CYPRESS_WEB_HOOK
+# Download Fixtures
+curl https://s3.amazonaws.com/cfpb-hmda-public/prod/cypress/fixtures.zip > ./cypress/downloads/fixtures.zip \
+	&& unzip -o cypress/downloads/fixtures.zip -d cypress/
 
-}
+# Download Integration tests
+curl https://s3.amazonaws.com/cfpb-hmda-public/prod/cypress/integration.zip > ./cypress/downloads/integration.zip \
+	&& unzip -o cypress/downloads/integration.zip -d cypress/  
 
-# Args
-# 1 - Test collection label (Integration/Load)
-# 2 - Filename
-post_failure() 
-{
-	msg="- [ [${environment}](${CYPRESS_HOST}) ] ${1}\n  - Failed. :old-man-yells-at-cloud-simpsons:\n  - Check the logs\n    \`\`\`\n    kubectl logs \$(kubectl get pods -n monitoring --sort-by=.status.startTime | grep 'hmda-cypress-' | tail -n 1 | awk 'NR==1{print \$1}') -n monitoring\n    \`\`\`"
-
-	curl -i -X POST -H 'Content-Type: application/json' -d "{\"text\": \"${msg}\" }"  $CYPRESS_WEB_HOOK
-
-	echo "\n\n--- ${1} output ---"
-	cat $2
-}
-
-cleanup()
-{
-	rm output_load.txt
-	rm output_integration.txt
-}
-
-if [[ "$CYPRESS_HOST" == *"ffiec.cfpb"* ]]; then
-  environment="PROD"
-elif [[ "$CYPRESS_HOST" == *"ffiec.beta"* ]]; then
-  environment="BETA"
-elif [[ "$CYPRESS_HOST" == *"hmda4.demo"* ]]; then
-  environment="DEV"
-else
-  environment="DEV-BETA"
+# Run configured Integration tests
+# Example: "cypress/integration/data-browser/**,cypress/integration/data-publication/**"
+if [ $CYPRESS_TEST_LIST ]; 
+then
+	yarn cypress run --spec ${CYPRESS_TEST_LIST} > output_integration.txt
+	if  grep -q "All specs passed!" "output_integration.txt" ; then
+		post_success 'Integration testing' "output_integration.txt"
+	else
+		post_failure 'Integration testing' "output_integration.txt"
+	fi
 fi
 
-# Integration tests
-yarn cypress run --spec "cypress/integration/data-browser/**,cypress/integration/data-publication/**,cypress/integration/filing/**,cypress/integration/hmda-help/**,cypress/integration/tools/**" > output_integration.txt
-if  grep -q "All specs passed!" "output_integration.txt" ; then
-	post_success 'Integration testing :handshake:' "output_integration.txt"
-else
-	post_failure 'Integration testing :handshake:' "output_integration.txt"
-fi
-
-# Download Submission file for load testing 
-[ ! -f ./cypress/fixtures/2020-FRONTENDTESTBANK9999-MAX.txt ] \
-	&& curl https://s3.amazonaws.com/cfpb-hmda-public/prod/cypress/2020-LargeFiler.zip > ./cypress/fixtures/2020-LargeFiler.zip \
-	&& unzip -o cypress/fixtures/2020-LargeFiler.zip -d cypress/fixtures
-
-# Load test
-yarn cypress run --spec "cypress/integration/load/**" > output_load.txt
-if  grep -q "All specs passed!" "output_load.txt" ; then
-	post_success 'Load testing :tractor:' "output_load.txt"
-else
-	post_failure 'Load testing :tractor:' "output_load.txt"
+# Run Load tests, if enabled
+if [ "$CYPRESS_SHOULD_LOAD_TEST" = true ];
+then 
+	yarn cypress run --spec "cypress/integration/load/**" > output_load.txt
+	if  grep -q "All specs passed!" "output_load.txt" ; then
+		post_success 'Load testing' "output_load.txt"
+	else
+		post_failure 'Load testing' "output_load.txt"
+	fi
 fi
 
 

--- a/cypress/support/shell-helpers.sh
+++ b/cypress/support/shell-helpers.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Args
+# 1 - Test collection label (Integration/Load)
+# 2 - Filename
+post_success() 
+{
+	runtime=$(tail -n 1 ${2} | xargs echo)
+	
+	msg="- [ [${environment}](${CYPRESS_HOST}) ] ${1}\n  - ${runtime} :1up:"
+
+	curl -i -X POST -H 'Content-Type: application/json' -d "{\"text\": \"${msg}\"}" $CYPRESS_WEB_HOOK
+
+}
+
+# Args
+# 1 - Test collection label (Integration/Load)
+# 2 - Filename
+post_failure() 
+{
+	msg="- [ [${environment}](${CYPRESS_HOST}) ] ${1}\n  - Failed. :old-man-yells-at-cloud-simpsons:\n  - Check the logs\n    \`\`\`\n    kubectl logs \$(kubectl get pods -n monitoring --sort-by=.status.startTime | grep 'hmda-cypress-' | tail -n 1 | awk 'NR==1{print \$1}') -n monitoring\n    \`\`\`"
+
+	curl -i -X POST -H 'Content-Type: application/json' -d "{\"text\": \"${msg}\" }"  $CYPRESS_WEB_HOOK
+
+	echo "\n\n--- ${1} output ---"
+	cat $2
+}
+
+cleanup()
+{
+	rm output_load.txt
+	rm output_integration.txt
+}
+
+if [[ "$CYPRESS_HOST" == *"ffiec.cfpb"* ]]; then
+  environment="PROD"
+elif [[ "$CYPRESS_HOST" == *"ffiec.beta"* ]]; then
+  environment="BETA"
+elif [[ "$CYPRESS_HOST" == *"hmda4.demo"* ]]; then
+  environment="DEV"
+else
+  environment="DEV-BETA"
+fi

--- a/cypress/update-s3-files.sh
+++ b/cypress/update-s3-files.sh
@@ -1,0 +1,21 @@
+cd ./cypress
+echo $PWD
+echo "1) Creating zip files: fixtures.zip, integration.zip"
+zip -r -X fixtures.zip fixtures/
+zip -r -X integration.zip integration/
+echo "- Done"
+echo ""
+echo "2) Ready to upload files to S3"
+echo ""
+read -p "  Enter the S3 profile name: " s3_profile
+echo ""
+echo "3) Uploading S3 files..."
+aws s3 cp integration.zip s3://cfpb-hmda-public/prod/cypress/ --profile=${s3_profile}
+aws s3 cp fixtures.zip s3://cfpb-hmda-public/prod/cypress/ --profile=${s3_profile}
+echo "- Done"
+
+# Cleanup
+rm -f fixtures.zip
+rm -f integration.zip
+
+cd ..

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "ci": "REACT_APP_ENVIRONMENT=CI yarn start -p 3000",
     "ci-data": "yarn newman run cypress/ci/tests/CREATE_INSTITUTIONS.postman_collection.json -e cypress/ci/config/PLATFORM_ENV.postman_environment.json -d cypress/ci/config/institutions.json",
     "dev-docs": "cp -R ./src/documentation/markdown ./public/",
-    "make-lar": "node ./scripts/lar/generate_lar_file.mjs"
+    "make-lar": "node ./scripts/lar/generate_lar_file.mjs",
+    "cy-update-s3": "./cypress/update-s3-files.sh"
   },
   "keywords": [
     "HMDA"


### PR DESCRIPTION
Closes #1628 
Closes #1627 

Changes to support new process of hosting specs/fixtures on S3 and pulling those files into the Cypress test pod at runtime in order to enable dynamic updates to test data without image rebuild.

Also adds new ENV variables to control which tests are run. 
 
New process:
1) Run cypress/update-s3-files.sh to upload test data and specs from the current local branch to S3.
2) Define ENV vars as outlined in cypress/README.md to configure which tests will run
3) Build and push Cypress test image (only needed for Cypress version updates or security fixes)