### PR TITLE
[Graphs] Adds table of contents sidebar to the 'faq' page

### DIFF
--- a/src/common/TableOfContents.jsx
+++ b/src/common/TableOfContents.jsx
@@ -69,7 +69,7 @@ const TableOfContents = ({
   return (
     <div>
       <div className='toc-container'>
-        {displayTOCBackLink == true ? <BackLink year={year} /> : ''}
+        <BackLink year={year} hide={!displayTOCBackLink} />
         <ul>
           {markdownHeaders.map((header, index) => (
             <TOCHeader {...{ header, index, active: activeContent }} />

--- a/src/common/TableOfContents.jsx
+++ b/src/common/TableOfContents.jsx
@@ -19,7 +19,8 @@ const REGEX_H2s_H3s = /#{2}.+(?=\n)/g
  * @param {year} String Tells the backlink what year the documentation comes from
  * @param {id} String id comes from DynamicRenderer and is specifically used on developer documentation. It is a continuation of direct linking to a specific developer Field.
  * @param {props} Object Required to get access to location.hash string
- * @param {setTOCSideBarDisplay} Boolean Helps trigger `back to documentation` link appear if table of contents sidebar isn't present
+ * @param {setTOCSideBarDisplay} Boolean Helps hide `back to documentation` link that appears when there is no table of contents sidebar to display
+ * @param {displayTOCBackLink} Boolean Shows/Hides backlink that is at the top of the TOC sidebar
  */
 
 const TableOfContents = ({
@@ -28,6 +29,7 @@ const TableOfContents = ({
   id,
   props,
   setTOCSideBarDisplay,
+  displayTOCBackLink,
 }) => {
   const [markdownHeaders, setMarkdownHeaders] = useState()
   const [activeContent, setActiveContent] = useState()
@@ -67,7 +69,7 @@ const TableOfContents = ({
   return (
     <div>
       <div className='toc-container'>
-        <BackLink year={year} />
+        {displayTOCBackLink == true ? <BackLink year={year} /> : ''}
         <ul>
           {markdownHeaders.map((header, index) => (
             <TOCHeader {...{ header, index, active: activeContent }} />

--- a/src/data-browser/graphs/graphs.css
+++ b/src/data-browser/graphs/graphs.css
@@ -77,6 +77,10 @@
 }
 
 /* Section - FAQ */
+.Graphs .dynamic-renderer {
+  margin-top: -2em;
+}
+
 .Graphs .Markdown-Wrapper img {
   max-width: 100%;
 }

--- a/src/data-browser/graphs/quarterly/index.jsx
+++ b/src/data-browser/graphs/quarterly/index.jsx
@@ -21,12 +21,15 @@ export const QuarterlyGraphs = (props) => {
   const showGraphs = ![PATH_FILERS_INFO, PATH_FAQ].includes(location.pathname)
 
   return (
-    <div className="Graphs">
+    <div className='Graphs'>
       <HomeLink />
       <GraphsHeader overview={graphHeaderOverview} />
       <Error error={error} />
       <SectionSelector props={props} />
-      <div className="section-wrapper">
+      <div
+        className='section-wrapper'
+        style={location.pathname.includes('/faq') ? { marginTop: '-.6em' } : {}}
+      >
         <SectionGraphs
           {...{
             error,
@@ -49,8 +52,9 @@ export const QuarterlyGraphs = (props) => {
             render={() => (
               <DynamicRenderer
                 year={CURRENT_YEAR}
-                slug={"data-browser-graphs-faq"}
-                showBackLink={false}
+                slug={'data-browser-graphs-faq'}
+                props={props}
+                displayTOCBackLink={false}
               />
             )}
           />

--- a/src/data-browser/graphs/quarterly/index.jsx
+++ b/src/data-browser/graphs/quarterly/index.jsx
@@ -26,10 +26,7 @@ export const QuarterlyGraphs = (props) => {
       <GraphsHeader overview={graphHeaderOverview} />
       <Error error={error} />
       <SectionSelector props={props} />
-      <div
-        className='section-wrapper'
-        style={location.pathname.includes('/faq') ? { marginTop: '-.6em' } : {}}
-      >
+      <div className='section-wrapper'>
         <SectionGraphs
           {...{
             error,

--- a/src/documentation/DynamicRenderer.jsx
+++ b/src/documentation/DynamicRenderer.jsx
@@ -14,7 +14,7 @@ const DynamicRenderer = props => {
   const [error, setError] = useState(null)
   const [idToScrollTo, setIdToScrollTo] = useState()
   const [TOCSideBarDisplay, setTOCSideBarDisplay] = useState(false)
-  const { year, slug } = props
+  const { year, slug, displayTOCBackLink } = props
 
   const scrollToElement = useCallback(
     id => {
@@ -74,6 +74,7 @@ const DynamicRenderer = props => {
         id={idToScrollTo}
         props={props}
         setTOCSideBarDisplay={setTOCSideBarDisplay}
+        displayTOCBackLink={displayTOCBackLink}
       />
       <div className='Markdown-Wrapper'>
         <BackLink year={year} hide={TOCSideBarDisplay} />

--- a/src/documentation/DynamicRenderer.jsx
+++ b/src/documentation/DynamicRenderer.jsx
@@ -67,7 +67,7 @@ const DynamicRenderer = props => {
   if (error) return <NotFound />
 
   return (
-    <div style={{ display: 'flex' }}>
+    <div className='dynamic-renderer'>
       <TableOfContents
         markdown={data}
         year={year}

--- a/src/documentation/index.css
+++ b/src/documentation/index.css
@@ -2,6 +2,10 @@ html {
   scroll-behavior: smooth !important;
 }
 
+.dynamic-renderer {
+  display: flex;
+}
+
 .Markdown-Wrapper {
   max-width: 1040px;
   margin: 10px auto;

--- a/src/documentation/index.js
+++ b/src/documentation/index.js
@@ -115,7 +115,12 @@ const Documentation = ({ config }) => {
 
             return (
               <div className='App Documentation'>
-                <DynamicRenderer year={year} slug={collection} props={props} />
+                <DynamicRenderer
+                  year={year}
+                  slug={collection}
+                  props={props}
+                  displayTOCBackLink={true}
+                />
               </div>
             )
           }}


### PR DESCRIPTION
Closes #1620

Graphs FAQ page now displays table of contents side bar.

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/60801873/201997543-59cdb12f-e6ae-4c0c-9afd-55ee9dc8e4d1.png">

