### PR TITLE
[Cypress] Remove logout calls

### DIFF
--- a/cypress/e2e/filing/Filing.spec.js
+++ b/cypress/e2e/filing/Filing.spec.js
@@ -21,9 +21,6 @@ const years = (YEARS && YEARS.toString().split(',')) || getFilingPeriods(config)
 const { filingPeriodStatus } = config
 
 describe("Filing", function() {
-  // Only need to provide an Auth URL when running locally
-  const authUrl = HOST.indexOf('localhost') > -1 ? AUTH_BASE_URL : HOST
-  
   beforeEach(() => {
     cy.get({
       HOST,
@@ -40,7 +37,7 @@ describe("Filing", function() {
     
     // Skip authentication on CI
     if (!isCI(ENVIRONMENT)) {
-      cy.hmdaLogin('filing', authUrl)
+      cy.hmdaLogin('filing')
       cy.url().should('contains', `${AUTH_BASE_URL}filing/`)
       cy.url().should('contains', `/institutions`)
     }

--- a/cypress/e2e/filing/Keycloak.spec.js
+++ b/cypress/e2e/filing/Keycloak.spec.js
@@ -11,7 +11,6 @@ describe('Keycloak', () => {
     beforeEach(() => {
       cy.visit(`${HOST}/filing`)
       cy.get({ HOST, USERNAME, PASSWORD, ENVIRONMENT }).logEnv()
-      cy.logout({ root: authUrl, realm: AUTH_REALM })
     })
   
     describe('Sign In', () => {

--- a/cypress/e2e/filing/Keycloak.spec.js
+++ b/cypress/e2e/filing/Keycloak.spec.js
@@ -1,10 +1,8 @@
 import { isCI } from '../../support/helpers'
 
-const { HOST, USERNAME, PASSWORD, ENVIRONMENT, AUTH_REALM, AUTH_BASE_URL } = Cypress.env()
+const { HOST, USERNAME, PASSWORD, ENVIRONMENT } = Cypress.env()
 
 describe('Keycloak', () => {
-  const authUrl = HOST.indexOf('localhost') > -1 ? AUTH_BASE_URL : HOST
-
   if(isCI(ENVIRONMENT)) 
     it('Does not run on CI')
   else {

--- a/cypress/e2e/hmda-help/institution.spec.js
+++ b/cypress/e2e/hmda-help/institution.spec.js
@@ -36,7 +36,6 @@ describe('HMDA Help - Institutions', () => {
 
     // Log in
     if (!isCI(ENVIRONMENT)) {
-      cy.logout({ root: authUrl, realm: AUTH_REALM })
       cy.hmdaLogin('hmda-help', authUrl)
       cy.url().should('contains', `${AUTH_BASE_URL}hmda-help/`)
     }
@@ -186,7 +185,6 @@ describe('HMDA Help - Institutions', () => {
     
     // Log in
     if (!isCI(ENVIRONMENT)) {
-      cy.logout({ root: authUrl, realm: AUTH_REALM })
       cy.hmdaLogin('hmda-help', authUrl)
       cy.url().should('contains', `${AUTH_BASE_URL}hmda-help/`)
     }

--- a/cypress/e2e/hmda-help/institution.spec.js
+++ b/cypress/e2e/hmda-help/institution.spec.js
@@ -18,7 +18,6 @@ const LOCAL_ACTION_DELAY = 250
 const NOTE_HISTORY_ON_CI_FIXED = false
 
 describe('HMDA Help - Institutions', () => {
-  const authUrl = HOST.indexOf('localhost') > -1 ? AUTH_BASE_URL : HOST
   const years = getFilingYears(getDefaultConfig(HOST))
 
   it('Can update existing Institutions', () => {
@@ -36,7 +35,7 @@ describe('HMDA Help - Institutions', () => {
 
     // Log in
     if (!isCI(ENVIRONMENT)) {
-      cy.hmdaLogin('hmda-help', authUrl)
+      cy.hmdaLogin('hmda-help')
       cy.url().should('contains', `${AUTH_BASE_URL}hmda-help/`)
     }
     
@@ -185,7 +184,7 @@ describe('HMDA Help - Institutions', () => {
     
     // Log in
     if (!isCI(ENVIRONMENT)) {
-      cy.hmdaLogin('hmda-help', authUrl)
+      cy.hmdaLogin('hmda-help')
       cy.url().should('contains', `${AUTH_BASE_URL}hmda-help/`)
     }
 

--- a/cypress/e2e/hmda-help/publication.spec.js
+++ b/cypress/e2e/hmda-help/publication.spec.js
@@ -14,8 +14,6 @@ const {
 const ACTION_DELAY = 250
 
 describe('HMDA Help - Publications', () => {
-  const authUrl = HOST.indexOf('localhost') > -1 ? AUTH_BASE_URL : HOST
-
   it('Can trigger Publication regeneration', () => {
     cy.get({
       HOST,
@@ -33,7 +31,7 @@ describe('HMDA Help - Publications', () => {
     // Log in
     if (!isCI(ENVIRONMENT)) {
       cy.wait(ACTION_DELAY)
-      cy.hmdaLogin('hmda-help', authUrl)
+      cy.hmdaLogin('hmda-help')
       cy.url().should('contains', `${AUTH_BASE_URL}hmda-help/`)
     }
     

--- a/cypress/e2e/hmda-help/publication.spec.js
+++ b/cypress/e2e/hmda-help/publication.spec.js
@@ -32,7 +32,6 @@ describe('HMDA Help - Publications', () => {
 
     // Log in
     if (!isCI(ENVIRONMENT)) {
-      cy.logout({ root: authUrl, realm: AUTH_REALM })
       cy.wait(ACTION_DELAY)
       cy.hmdaLogin('hmda-help', authUrl)
       cy.url().should('contains', `${AUTH_BASE_URL}hmda-help/`)

--- a/cypress/e2e/load/LargeFiler.spec.js
+++ b/cypress/e2e/load/LargeFiler.spec.js
@@ -23,9 +23,6 @@ const getFilename = (filingPeriod, lei) => `${filingPeriod}-${lei}-MAX.txt`
 const { filingPeriodStatus } = config
 
 describe('Large Filer', () => {
-  // Only need to provide an Auth URL when running locally
-  const authUrl = HOST.indexOf('localhost') > -1 ? AUTH_BASE_URL : HOST
-
   beforeEach(() => {
     cy.get({
       HOST,
@@ -42,8 +39,7 @@ describe('Large Filer', () => {
 
     // Skip authentication on CI
     if (!isCI(ENVIRONMENT)) {
-      cy.logout({ root: authUrl, realm: AUTH_REALM })
-      cy.hmdaLogin('filing', authUrl)
+      cy.hmdaLogin('filing')
       cy.url().should('contains', `${AUTH_BASE_URL}filing/`)
     }
 

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -34,7 +34,7 @@ Cypress.Commands.add("logEnv", { prevSubject: true }, vars => {
 })
 
 // Login via UI
-Cypress.Commands.add('hmdaLogin', (app, authUrl) => {
+Cypress.Commands.add('hmdaLogin', (app) => {
   const { USERNAME, PASSWORD, AUTH_BASE_URL } = Cypress.env()
   cy.visit(`${AUTH_BASE_URL}${app}/`)
 

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -35,8 +35,7 @@ Cypress.Commands.add("logEnv", { prevSubject: true }, vars => {
 
 // Login via UI
 Cypress.Commands.add('hmdaLogin', (app, authUrl) => {
-  const { USERNAME, PASSWORD, AUTH_BASE_URL, AUTH_REALM } = Cypress.env()
-  cy.logout({ root: authUrl, realm: AUTH_REALM })
+  const { USERNAME, PASSWORD, AUTH_BASE_URL } = Cypress.env()
   cy.visit(`${AUTH_BASE_URL}${app}/`)
 
   if (app.match('filing')) cy.get('button[title="Login"').click()


### PR DESCRIPTION
Closes #1693 

Logout calls are not interfering with testing via our nightly cronjob but are a blocker when running from localhost.  Cypress has implemented `test isolation` which makes these logout calls redundant.  

## Changes
- Remove calls to cy.logout
- Remove unused param in cy.hmdaLogin
- Remove unused environment variable