### PR TITLE
Graphs: Derive year for Filers from graph data

### DIFF
--- a/src/data-browser/graphs/quarterly/QuarterlyFilersTable.jsx
+++ b/src/data-browser/graphs/quarterly/QuarterlyFilersTable.jsx
@@ -4,19 +4,23 @@ import LoadingIcon from '../../../common/LoadingIcon';
 import SimpleSortTable from '../../../common/SimpleSortTable';
 import { institutions } from '../slice';
 import './QuarterlyFilersTable.css';
+import { useLatestAvailableYear } from './useLatestAvailableYear'
 
 const QuarterlyFilersTable = props => {
   const dispatch = useDispatch();
-  const [year, past] = [2022, 3];
   const { sort } = useSelector(state => state.institutionsConfig);
+  const year = useLatestAvailableYear()
+  const past = 3
+  
   const pastYears = [...Array(past).keys()].map(i => `${year - i - 1}`);
-
-  const { data, isSuccess } = institutions.useGetQuarterliesWithLarsQuery({ year, past });
+  
+  const { data, isSuccess } = institutions.useGetQuarterliesWithLarsQuery(
+    { year, past },
+    { skip: !year }
+  )
 
   const setSort = sortUpdateFn =>
     dispatch(institutions.updateSort(sortUpdateFn(sort)))
-
-  let content = <LoadingIcon />
 
   const tableColumns = useMemo(() => {
     const countsColumns = pastYears.map(accessorKey => {
@@ -46,6 +50,8 @@ const QuarterlyFilersTable = props => {
       ...countsColumns,
     ]
   })
+
+  let content
 
   if (isSuccess && data) {
     const tableData = data.quarterly.map(({ name, lei, agency, larCounts }) => {
@@ -107,6 +113,8 @@ const QuarterlyFilersTable = props => {
       />
     )
   }
+
+  if (!year || !content) return <LoadingIcon />
 
   return (
     <div className='quarterly-filers-table'>

--- a/src/data-browser/graphs/quarterly/QuarterlyFilersTable.jsx
+++ b/src/data-browser/graphs/quarterly/QuarterlyFilersTable.jsx
@@ -7,7 +7,7 @@ import './QuarterlyFilersTable.css';
 
 const QuarterlyFilersTable = props => {
   const dispatch = useDispatch();
-  const [year, past] = [new Date().getFullYear(), 3];
+  const [year, past] = [2022, 3];
   const { sort } = useSelector(state => state.institutionsConfig);
   const pastYears = [...Array(past).keys()].map(i => `${year - i - 1}`);
 

--- a/src/data-browser/graphs/quarterly/useLatestAvailableYear.jsx
+++ b/src/data-browser/graphs/quarterly/useLatestAvailableYear.jsx
@@ -1,0 +1,18 @@
+import { useSelector } from 'react-redux'
+import { graphs } from '../slice'
+import { QUARTERS } from '../slice/graphConfigs'
+
+/**
+ * Derive the latest year for which data is available based on
+ * the period options included in the graph data.
+ * @returns Int
+ */
+export const useLatestAvailableYear = () => {
+  const config = useSelector(({ graphsConfig }) => graphsConfig)
+  const quarters = graphs.getConfig(config, QUARTERS)
+  
+  if (!quarters || !quarters.length) return 0
+
+  const year = quarters[quarters.length - 1]?.value.split('-')[0]
+  return (year && parseInt(year, 10)) || 0
+}


### PR DESCRIPTION
Closes #1711 

## Changes
Derive year for Filers from graph data.

If the Graphs API says 2023-Q1 data is the latest available, then filer info for 2023 should also be ready. 
When latest is 2022-Q3 or 2022 annual, we use 2022.  
 
