### PR TITLE
[Graphs] Focus Graph selection menu on current selection

### DIFF
--- a/src/data-browser/graphs/quarterly/SectionGraphs.jsx
+++ b/src/data-browser/graphs/quarterly/SectionGraphs.jsx
@@ -24,7 +24,7 @@ import {
   SERIES_FOR_URL
 } from '../slice/graphConfigs.js'
 import { graphs } from '../slice'
-import { formatGroupLabel } from '../utils/menuHelpers.js'
+import { formatGroupLabel, onMenuOpen } from '../utils/menuHelpers.js'
 import { useFetchGraphList } from './useFetchGraphList'
 import { useFetchSingleGraph } from './useFetchSingleGraphs'
 import { useManageGraphSelection } from './useManageGraphSelection'
@@ -215,6 +215,7 @@ export const SectionGraphs = ({
             : ''
         }
         formatGroupLabel={formatGroupLabel}
+        onMenuOpen={onMenuOpen}
       />
       <PeriodSelectors
         {...{

--- a/src/data-browser/graphs/utils/menuHelpers.js
+++ b/src/data-browser/graphs/utils/menuHelpers.js
@@ -9,4 +9,23 @@ export const formatGroupLabel = (data) => (
     <span>{data.label}</span>
     <span className='badge'>{data.options.length}</span>
   </div>
-);
+)
+
+/**
+ * When opened, focus the Graph selection menu on the currently selected
+ * graph so that users can easily continue exploring options without having
+ * to manually scroll to their last selection. 
+ */
+export const onMenuOpen = () => {
+  setTimeout(() => {
+    const cname = 'react-select__graph__option--is-selected'
+    const selectedEl = document.getElementsByClassName(cname)[0]
+    if (selectedEl) {
+      selectedEl.scrollIntoView({
+        behavior: 'auto',
+        block: 'nearest',
+        inline: 'start',
+      })
+    }
+  }, 15)
+}


### PR DESCRIPTION
Closes #1723 

## Changes
- Allows users to quickly continue exploring the list of available graphs without having to manually scroll