### PR TITLE
[Cypress] Test access to Rate Spread from an external referrer

### DIFF
--- a/cypress/e2e/tools/RateSpread.spec.js
+++ b/cypress/e2e/tools/RateSpread.spec.js
@@ -1,4 +1,4 @@
-import { withFormData, isProd, isCI, isProdBeta } from "../../support/helpers"
+import { withFormData, isProdDefault, isCI, isProdBeta } from "../../support/helpers"
 
 const { HOST, TEST_DELAY, ENVIRONMENT } = Cypress.env()
 
@@ -92,5 +92,30 @@ describe("Rate Spread API", () => {
   }
   else {
     it(`Does not run on ${HOST}`, () => cy.get({ HOST, TEST_DELAY, ENVIRONMENT }).logEnv())
+  }
+})
+
+describe('Rate Spread - External Referrer', function () {
+  if (isProdDefault(HOST)) {
+    it('Is accessible from Google search', function () {
+      cy.viewport(1680, 916)
+      cy.visit(`https://www.google.com/search?q=hmda+rate+spread`)
+      cy.get('div#search a').contains('rate-spread').click()
+
+      cy.wait(TEST_DELAY)
+
+      cy.get('.item > div > .Form > div > #rateSetDate')
+        .clear()
+        .click()
+        .type('12/16/2019')
+      cy.get('.item > div > .Form > div > #APR').type('3.2')
+      cy.get('.item > div > .Form > div > #loanTerm').click().type('45')
+      cy.get('.grid > .item > div > .Form > input').click()
+
+      // Validate
+      cy.get('.item  .alert').contains('-0.590')
+
+      cy.wait(TEST_DELAY)
+    })
   }
 })


### PR DESCRIPTION
Closes #1746 

## Changes

**Note: Test only runs when testing against Prod default (ffiec.cfpb.gov)**

Adds a Cypress test that will
- search Google for "hmda rate spread"
- Click on the HMDA link 
- Verify ability to access page from an external referrer by generating a rate spread


## Testing
- `yarn cypress open --env HOST="https://ffiec.cfpb.gov"`
- Run `RateSpread.spec.js`