### PR TITLE
[Cypress] Update Modified LAR tests to match new UI

### DIFF
--- a/cypress/e2e/data-publication/ModifiedLAR.spec.js
+++ b/cypress/e2e/data-publication/ModifiedLAR.spec.js
@@ -3,6 +3,7 @@ import { isBeta } from "../../support/helpers"
 const { HOST } = Cypress.env()
 
 const testCases = [
+  { year: 2022, name: "cypress", institution: "549300I4IUWMEMGLST06"},
   { year: 2021, name: "cypress", institution: "549300I4IUWMEMGLST06"},
   { year: 2020, name: "cypress", institution: "549300I4IUWMEMGLST06"},
   { year: 2019, name: "cypress", institution: "549300I4IUWMEMGLST06"},
@@ -27,9 +28,9 @@ onlyOn(!isBeta(HOST), () => {
         cy.get("#institution-name").click()
         cy.get("#institution-name").type(name)
   
-        cy.get("#main-content > .SearchList > h4").contains("1 results found")
-        cy.get("#main-content > .SearchList > .Results > li > p").contains(institution)
-        cy.get("#main-content > .SearchList > .Results > li > .font-small").then(
+        cy.get("#main-content .SearchList > h4").contains("1 results found")
+        cy.get("#main-content .SearchList > .Results > li > p").contains(institution)
+        cy.get("#main-content .SearchList > .Results > li > .font-small").then(
           $el => {
             expect($el).to.have.text("Download Modified LAR ")
             expect($el).to.have.attr(
@@ -43,7 +44,7 @@ onlyOn(!isBeta(HOST), () => {
         cy.get("#inclHeader").click()
         cy.get("#inclHeader").check("true")
   
-        cy.get("#main-content > .SearchList > .Results > li > .font-small").should(
+        cy.get("#main-content .SearchList > .Results > li > .font-small").should(
           $el => {
             expect($el).to.have.text("Download Modified LAR with Header")
             expect($el).to.have.attr(


### PR DESCRIPTION
Closes #1753 

- Add 2022 to `testCases`
- Adjusts selectors to account for updated UI