### PR TITLE
[Redirect] /documentation is properly handled and points to Docusaurus

### DIFF
--- a/src/documentation/index.js
+++ b/src/documentation/index.js
@@ -9,13 +9,13 @@ const Documentation = () => {
   // Redirects point to Docusaurus base route
   return (
     <Switch>
-      {/* <Redirect
+      <Redirect
         exact
         path='/documentation'
         to={window.location.assign(
           `${window.location.origin}/documentation/category/frequently-asked-questions`
         )}
-      /> */}
+      />
       <Route component={NotFound} />
     </Switch>
   )


### PR DESCRIPTION
Fixes a redirect issue where `/documentation` route wasn't being handled. PR will now properly redirect the user to Docusaurus when they enter `/documentation`.