### PR TITLE
[Filer Info] Heading content change

### DIFF
--- a/src/data-browser/graphs/quarterly/QuarterlyFilersTable.jsx
+++ b/src/data-browser/graphs/quarterly/QuarterlyFilersTable.jsx
@@ -119,7 +119,7 @@ const QuarterlyFilersTable = props => {
   return (
     <div className='quarterly-filers-table'>
       <h2 className='table-heading'>
-        {year} Quarterly Filer Loan and Application Counts
+        Quarterly Filer Loan and Application Counts
       </h2>
       <div className='table-container'>{content}</div>
     </div>


### PR DESCRIPTION
Removes the yearly specific year from the header on the [filer info tab](https://ffiec.cfpb.gov/data-browser/graphs/quarterly/info/filers) on graphs.