### PR TITLE
[Cypress] Update test files for Beta

### DIFF
--- a/cypress/e2e/common-features/redirection.spec.js
+++ b/cypress/e2e/common-features/redirection.spec.js
@@ -1,4 +1,6 @@
 import config from '../../../src/common/constants/prod-config.json'
+import { isBeta } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
 const years = config.dataPublicationYears
 
 const { HOST } = Cypress.env()
@@ -43,8 +45,8 @@ const FromTo = [
   },
   { from: '/data-publication', to: `/data-publication/${years.shared[0]}` },
   { from: '/data-browser/maps', to: `/data-browser/maps/${years.shared[0]}` },
-  { from: '/data-browser/data/', to: `/data-browser/data/${years.shared[0]}` },  
-  
+  { from: '/data-browser/data/', to: `/data-browser/data/${years.shared[0]}` },
+
   // Test redirect from invalid years
   {
     from: '/data-publication/aggregate-reports/20',
@@ -93,12 +95,20 @@ const FromTo = [
   },
 ]
 
-describe('withYearValidation', () => {
-  FromTo.forEach(({ from, to, description }) => {
-    const testDescription = description || `Auto-redirects from ${from}`
-    it(testDescription, () => {
-      cy.visit(`${HOST}${from}`)
-      cy.url().should('include', to)
+onlyOn(isBeta(HOST), () => {
+  describe('National Aggregate Reports', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
+
+onlyOn(!isBeta(HOST), () => {
+  describe('withYearValidation', () => {
+    FromTo.forEach(({ from, to, description }) => {
+      const testDescription = description || `Auto-redirects from ${from}`
+      it(testDescription, () => {
+        cy.visit(`${HOST}${from}`)
+        cy.url().should('include', to)
+      })
     })
   })
 })

--- a/cypress/e2e/data-browser/graphs.spec.js
+++ b/cypress/e2e/data-browser/graphs.spec.js
@@ -1,14 +1,16 @@
-import { isCI, isProd, isBeta } from "../../support/helpers"
-
+import { isCI, isProd, isBeta } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
 const { HOST, ENVIRONMENT } = Cypress.env()
 
-let baseURLToVisit = isCI(ENVIRONMENT) ? "http://localhost:3000" : HOST
+let baseURLToVisit = isCI(ENVIRONMENT) ? 'http://localhost:3000' : HOST
 
-if (isBeta(HOST)) {
-  describe('HMDA Graphs', () => {
-    it('API does not run in Beta', () => null)
+onlyOn(isBeta(HOST), () => {
+  describe('HMDA Graphs', function () {
+    it('API does not run in Beta environments', () => {})
   })
-} else {
+})
+
+onlyOn(!isBeta(HOST), () => {
   describe('General Tests', () => {
     it('Checks <GraphsHeader/> component if overview props was not sent to the component', () => {
       cy.visit(`${baseURLToVisit}/data-browser/graphs/quarterly`).contains(
@@ -16,7 +18,7 @@ if (isBeta(HOST)) {
       )
     })
 
-    it('Checks <GraphsHeader/> component if data from API succeedes then it checks if numbered financial institutions show in the header', () => {
+    it.skip('Checks <GraphsHeader/> component if data from API succeedes then it checks if numbered financial institutions show in the header', () => {
       // In Dev only an alphanumeric approximation is provided (ex. 5x).
       // In Prod we want to ensure that the count is numeric.
       let institutionCountRx = isProd(HOST) ? '[0-9]{1,3}' : '[0-9x]{1,3}'
@@ -131,4 +133,4 @@ if (isBeta(HOST)) {
       })
     })
   })
-}
+})

--- a/cypress/e2e/data-browser/maps.spec.js
+++ b/cypress/e2e/data-browser/maps.spec.js
@@ -1,204 +1,308 @@
 import { isBeta, mapsURL, openSelector } from '../../support/helpers'
-
+import { onlyOn } from '@cypress/skip-test'
 const { HOST, ENVIRONMENT } = Cypress.env()
 const ACTION_DELAY = 8000 // milliseconds
 
-describe('Maps', () => {
-    it("State 2022", () => {
-      cy.get({ HOST, ENVIRONMENT }).logEnv()
-      cy.viewport(1000, 940)
-      cy.visit(mapsURL(HOST, "2022?geography=state"))
-      deleteBetaBanner(HOST)
-
-      openSelector("#map-filter-1").type("denied{enter}")
-      openSelector("#map-filter-2").type("age 55{enter}")
-
-      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
-      cy.get(".mapboxgl-canvas").click()
-
-      cy.get(".maps-nav-bar .left .count").should("contain", "2,430")
-      cy.get(".maps-nav-bar .right .count").should("contain", "0.83")
-      cy.get(".maps-nav-bar .feature").should("contain", "KANSAS")
-
-      cy.get(".summary-page .featureName > .colorTextWithBias").should(
-        "contain",
-        "KANSAS"
-      )
-      cy.get(".summary-page .count").should("contain", "2,430")
-
-      cy.get(
-        ".filter-report-1 > table > tbody > tr.highlight > :nth-child(1)"
-      ).should("contain", "Application denied")
-      cy.get(
-        ".filter-report-1 > table > tbody > tr.highlight > :nth-child(2)"
-      ).should("contain", "14,689")
-      cy.get(
-        ".filter-report-1 > table > tbody > tr.highlight > :nth-child(3)"
-      ).should("contain", "13.38%")
-      cy.get(
-        ".filter-report-1 > table > tbody > tr.highlight > :nth-child(4)"
-      ).should("contain", "2,430")
-      cy.get(
-        ".filter-report-1 > table > tbody > tr.highlight > :nth-child(5)"
-      ).should("contain", "16.77%")
-
-      cy.get(
-        ".filter-report-2 > table > tbody > tr.highlight > :nth-child(1)"
-      ).should("contain", "55-64")
-      cy.get(
-        ".filter-report-2 > table > tbody > tr.highlight > :nth-child(2)"
-      ).should("contain", "14,486")
-      cy.get(
-        ".filter-report-2 > table > tbody > tr.highlight > :nth-child(3)"
-      ).should("contain", "13.19%")
-      cy.get(
-        ".filter-report-2 > table > tbody > tr.highlight > :nth-child(4)"
-      ).should("contain", "2,430")
-      cy.get(
-        ".filter-report-2 > table > tbody > tr.highlight > :nth-child(5)"
-      ).should("contain", "16.54%")
-    })
-
-  it('State 2021', () => {
-    cy.get({ HOST, ENVIRONMENT }).logEnv()
-    cy.viewport(1000, 940)
-    cy.visit(mapsURL(HOST, '2021?geography=state'))
-    deleteBetaBanner(HOST)
-
-    openSelector('#map-filter-1').type('denied{enter}');
-    openSelector('#map-filter-2').type('age 55{enter}');
-
-    cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
-    cy.get('.mapboxgl-canvas').click();
-
-    cy.get('.maps-nav-bar .left .count').should('contain', '3,032')
-    cy.get('.maps-nav-bar .right .count').should('contain', '1.03')
-    cy.get('.maps-nav-bar .feature').should('contain', 'KANSAS')
-    
-    cy.get('.summary-page .featureName > .colorTextWithBias').should('contain', 'KANSAS')
-    cy.get('.summary-page .count').should('contain', '3,032')
-
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)').should('contain', 'Application denied')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)').should('contain', '16,609')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)').should('contain', '9.61%')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)').should('contain', '3,032')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)').should('contain', '12.46%')
-    
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)').should('contain', '55-64')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)').should('contain', '24,225')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)').should('contain', '14.02%')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)').should('contain', '3,032')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)').should('contain', '18.24%')
-  })
-
-  it('County 2020', () => {
-    cy.get({ HOST, ENVIRONMENT }).logEnv()
-    cy.viewport(1000, 940)
-    cy.visit(mapsURL(HOST, '2020?geography=county'))
-    deleteBetaBanner(HOST)
-
-    openSelector('#map-filter-1').type('denied{enter}');
-    openSelector('#map-filter-2').type('age 55{enter}');
-
-    cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
-    cy.get('.mapboxgl-canvas').click();
-
-    cy.get('.maps-nav-bar .feature').should('contain', 'GREENWOOD COUNTY, KS')
-    cy.get('.maps-nav-bar .left .count').should('contain', '10')
-    cy.get('.maps-nav-bar .right .count').should('contain', '1.67')
-    
-    cy.get('.summary-page .featureName > .colorTextWithBias').should('contain', 'GREENWOOD COUNTY, KS')
-    cy.get('.summary-page .count').should('contain', '10')
-
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)').should('contain', 'Application denied')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)').should('contain', '31')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)').should('contain', '16.49%')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)').should('contain', '10')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)').should('contain', '22.22%')
-    
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)').should('contain', '55-64')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)').should('contain', '45')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)').should('contain', '23.94%')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)').should('contain', '10')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)').should('contain', '32.26%')
-  })
-  
-  it('State 2019', () => {
-    cy.get({ HOST, ENVIRONMENT }).logEnv()
-    cy.viewport(1000, 940)
-    cy.visit(mapsURL(HOST, '2019?geography=state'))
-    deleteBetaBanner(HOST)
-
-    openSelector('#map-filter-1').type('denied{enter}');
-    openSelector('#map-filter-2').type('age 55{enter}');
-
-    cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
-    cy.get('.mapboxgl-canvas').click();
-
-    cy.get('.maps-nav-bar .left .count').should('contain', '2,686')
-    cy.get('.maps-nav-bar .right .count').should('contain', '0.91')
-    cy.get('.maps-nav-bar .feature').should('contain', 'KANSAS')
-    
-    cy.get('.summary-page .featureName > .colorTextWithBias').should('contain', 'KANSAS')
-    cy.get('.summary-page .count').should('contain', '2,686')
-
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)').should('contain', 'Application denied')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)').should('contain', '14,571')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)').should('contain', '12.14%')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)').should('contain', '2,686')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)').should('contain', '15.45%')
-    
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)').should('contain', '55-64')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)').should('contain', '17,385')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)').should('contain', '14.48%')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)').should('contain', '2,686')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)').should('contain', '18.43%')
-  })
-
-  it('County 2018', () => {
-    cy.get({ HOST, ENVIRONMENT }).logEnv()
-    cy.viewport(1000, 940)
-    cy.visit(mapsURL(HOST, '2018?geography=county'))
-    deleteBetaBanner(HOST)
-
-    openSelector('#map-filter-1').type('denied{enter}');
-    openSelector('#map-filter-2').type('age 55{enter}');
-
-    cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
-    cy.get('.mapboxgl-canvas').click();
-
-    cy.get('.maps-nav-bar .feature').should('contain', 'GREENWOOD COUNTY, KS')
-    cy.get('.maps-nav-bar .left .count').should('contain', '6')
-    cy.get('.maps-nav-bar .right .count').should('contain', '1')
-    
-    cy.get('.summary-page .featureName > .colorTextWithBias').should('contain', 'GREENWOOD COUNTY, KS')
-    cy.get('.summary-page .count').should('contain', '6')
-
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)').should('contain', 'Application denied')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)').should('contain', '32')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)').should('contain', '18.93%')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)').should('contain', '6')
-    cy.get('.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)').should('contain', '21.43%')
-    
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)').should('contain', '55-64')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)').should('contain', '28')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)').should('contain', '16.57%')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)').should('contain', '6')
-    cy.get('.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)').should('contain', '18.75%')
-  })
-
-  it('Renders empty state', () => {
-    cy.visit(mapsURL(HOST, "2018?geography=county&variable=actionTaken&value=1&feature=31005&mapCenter=-101.6959558503813,41.568961419127554"))
-    deleteBetaBanner(HOST)
-    cy.get('.maps-nav-bar .left .count').should('contain', '0')
-    cy.contains("No LAR data for this region in 2018")
+onlyOn(isBeta(HOST), () => {
+  describe('Maps', function () {
+    it('Does not run in Beta environments', () => {})
   })
 })
 
+onlyOn(!isBeta(HOST), () => {
+  describe('Maps', () => {
+    it('State 2022', () => {
+      cy.get({ HOST, ENVIRONMENT }).logEnv()
+      cy.viewport(1000, 940)
+      cy.visit(mapsURL(HOST, '2022?geography=state'))
+      deleteBetaBanner(HOST)
 
-const deleteBetaBanner = (env) => {
-  if (!isBeta(env)) return
-  cy.get('div.Beta').then(el => {
-    el.remove()
+      openSelector('#map-filter-1').type('denied{enter}')
+      openSelector('#map-filter-2').type('age 55{enter}')
+
+      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
+      cy.get('.mapboxgl-canvas').click()
+
+      cy.get('.maps-nav-bar .left .count').should('contain', '2,430')
+      cy.get('.maps-nav-bar .right .count').should('contain', '0.83')
+      cy.get('.maps-nav-bar .feature').should('contain', 'KANSAS')
+
+      cy.get('.summary-page .featureName > .colorTextWithBias').should(
+        'contain',
+        'KANSAS'
+      )
+      cy.get('.summary-page .count').should('contain', '2,430')
+
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)'
+      ).should('contain', 'Application denied')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)'
+      ).should('contain', '14,689')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)'
+      ).should('contain', '13.38%')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)'
+      ).should('contain', '2,430')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)'
+      ).should('contain', '16.77%')
+
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)'
+      ).should('contain', '55-64')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)'
+      ).should('contain', '14,486')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)'
+      ).should('contain', '13.19%')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)'
+      ).should('contain', '2,430')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)'
+      ).should('contain', '16.54%')
+    })
+
+    it('State 2021', () => {
+      cy.get({ HOST, ENVIRONMENT }).logEnv()
+      cy.viewport(1000, 940)
+      cy.visit(mapsURL(HOST, '2021?geography=state'))
+      deleteBetaBanner(HOST)
+
+      openSelector('#map-filter-1').type('denied{enter}')
+      openSelector('#map-filter-2').type('age 55{enter}')
+
+      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
+      cy.get('.mapboxgl-canvas').click()
+
+      cy.get('.maps-nav-bar .left .count').should('contain', '3,032')
+      cy.get('.maps-nav-bar .right .count').should('contain', '1.03')
+      cy.get('.maps-nav-bar .feature').should('contain', 'KANSAS')
+
+      cy.get('.summary-page .featureName > .colorTextWithBias').should(
+        'contain',
+        'KANSAS'
+      )
+      cy.get('.summary-page .count').should('contain', '3,032')
+
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)'
+      ).should('contain', 'Application denied')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)'
+      ).should('contain', '16,609')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)'
+      ).should('contain', '9.61%')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)'
+      ).should('contain', '3,032')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)'
+      ).should('contain', '12.46%')
+
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)'
+      ).should('contain', '55-64')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)'
+      ).should('contain', '24,225')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)'
+      ).should('contain', '14.02%')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)'
+      ).should('contain', '3,032')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)'
+      ).should('contain', '18.24%')
+    })
+
+    it('County 2020', () => {
+      cy.get({ HOST, ENVIRONMENT }).logEnv()
+      cy.viewport(1000, 940)
+      cy.visit(mapsURL(HOST, '2020?geography=county'))
+      deleteBetaBanner(HOST)
+
+      openSelector('#map-filter-1').type('denied{enter}')
+      openSelector('#map-filter-2').type('age 55{enter}')
+
+      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
+      cy.get('.mapboxgl-canvas').click()
+
+      cy.get('.maps-nav-bar .feature').should('contain', 'GREENWOOD COUNTY, KS')
+      cy.get('.maps-nav-bar .left .count').should('contain', '10')
+      cy.get('.maps-nav-bar .right .count').should('contain', '1.67')
+
+      cy.get('.summary-page .featureName > .colorTextWithBias').should(
+        'contain',
+        'GREENWOOD COUNTY, KS'
+      )
+      cy.get('.summary-page .count').should('contain', '10')
+
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)'
+      ).should('contain', 'Application denied')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)'
+      ).should('contain', '31')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)'
+      ).should('contain', '16.49%')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)'
+      ).should('contain', '10')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)'
+      ).should('contain', '22.22%')
+
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)'
+      ).should('contain', '55-64')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)'
+      ).should('contain', '45')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)'
+      ).should('contain', '23.94%')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)'
+      ).should('contain', '10')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)'
+      ).should('contain', '32.26%')
+    })
+
+    it('State 2019', () => {
+      cy.get({ HOST, ENVIRONMENT }).logEnv()
+      cy.viewport(1000, 940)
+      cy.visit(mapsURL(HOST, '2019?geography=state'))
+      deleteBetaBanner(HOST)
+
+      openSelector('#map-filter-1').type('denied{enter}')
+      openSelector('#map-filter-2').type('age 55{enter}')
+
+      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
+      cy.get('.mapboxgl-canvas').click()
+
+      cy.get('.maps-nav-bar .left .count').should('contain', '2,686')
+      cy.get('.maps-nav-bar .right .count').should('contain', '0.91')
+      cy.get('.maps-nav-bar .feature').should('contain', 'KANSAS')
+
+      cy.get('.summary-page .featureName > .colorTextWithBias').should(
+        'contain',
+        'KANSAS'
+      )
+      cy.get('.summary-page .count').should('contain', '2,686')
+
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)'
+      ).should('contain', 'Application denied')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)'
+      ).should('contain', '14,571')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)'
+      ).should('contain', '12.14%')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)'
+      ).should('contain', '2,686')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)'
+      ).should('contain', '15.45%')
+
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)'
+      ).should('contain', '55-64')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)'
+      ).should('contain', '17,385')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)'
+      ).should('contain', '14.48%')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)'
+      ).should('contain', '2,686')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)'
+      ).should('contain', '18.43%')
+    })
+
+    it('County 2018', () => {
+      cy.get({ HOST, ENVIRONMENT }).logEnv()
+      cy.viewport(1000, 940)
+      cy.visit(mapsURL(HOST, '2018?geography=county'))
+      deleteBetaBanner(HOST)
+
+      openSelector('#map-filter-1').type('denied{enter}')
+      openSelector('#map-filter-2').type('age 55{enter}')
+
+      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
+      cy.get('.mapboxgl-canvas').click()
+
+      cy.get('.maps-nav-bar .feature').should('contain', 'GREENWOOD COUNTY, KS')
+      cy.get('.maps-nav-bar .left .count').should('contain', '6')
+      cy.get('.maps-nav-bar .right .count').should('contain', '1')
+
+      cy.get('.summary-page .featureName > .colorTextWithBias').should(
+        'contain',
+        'GREENWOOD COUNTY, KS'
+      )
+      cy.get('.summary-page .count').should('contain', '6')
+
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)'
+      ).should('contain', 'Application denied')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)'
+      ).should('contain', '32')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)'
+      ).should('contain', '18.93%')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)'
+      ).should('contain', '6')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)'
+      ).should('contain', '21.43%')
+
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)'
+      ).should('contain', '55-64')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)'
+      ).should('contain', '28')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)'
+      ).should('contain', '16.57%')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)'
+      ).should('contain', '6')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)'
+      ).should('contain', '18.75%')
+    })
+
+    it('Renders empty state', () => {
+      cy.visit(
+        mapsURL(
+          HOST,
+          '2018?geography=county&variable=actionTaken&value=1&feature=31005&mapCenter=-101.6959558503813,41.568961419127554'
+        )
+      )
+      deleteBetaBanner(HOST)
+      cy.get('.maps-nav-bar .left .count').should('contain', '0')
+      cy.contains('No LAR data for this region in 2018')
+    })
   })
-}
+
+  const deleteBetaBanner = env => {
+    if (!isBeta(env)) return
+    cy.get('div.Beta').then(el => {
+      el.remove()
+    })
+  }
+})

--- a/cypress/e2e/data-publication/AggregateReports.spec.js
+++ b/cypress/e2e/data-publication/AggregateReports.spec.js
@@ -1,307 +1,389 @@
-import { openSelector } from "../../support/helpers"
+import { isBeta, openSelector } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
 const { HOST } = Cypress.env()
 
 // TODO: Test CSV Download
-describe("Aggregate Reports", () => {
-  it("2022", () => {
-    cy.get({ HOST }).logEnv()
-    cy.viewport(1680, 867)
-    cy.visit(`${HOST}/data-publication/aggregate-reports/2022`)
 
-    // Select geography and report
-    cy.findByText("Select a state...").type("Arizona{enter}")
-    cy.findByText("Select MSA/MD...").type("Phoenix{enter}")
-    cy.findByText("Select report...").type(
-      "Applications by Ethnicity and Sex{enter}"
-    )
-
-    // Report Content
-    cy.get("tbody > :nth-child(3) > :nth-child(2)").should("have.text", "12308")
-    cy.get("tbody > :nth-child(3) > :nth-child(3)").should(
-      "have.text",
-      "3402910000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(4)").should("have.text", "790")
-    cy.get("tbody > :nth-child(3) > :nth-child(5)").should(
-      "have.text",
-      "160160000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(6)").should("have.text", "5107")
-    cy.get("tbody > :nth-child(3) > :nth-child(7)").should(
-      "have.text",
-      "962115000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(8)").should("have.text", "4032")
-    cy.get("tbody > :nth-child(3) > :nth-child(9)").should(
-      "have.text",
-      "1184710000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(10)").should("have.text", "1442")
-    cy.get("tbody > :nth-child(3) > :nth-child(11)").should(
-      "have.text",
-      "339530000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(12)").should("have.text", "351")
-    cy.get("tbody > :nth-child(3) > :nth-child(13)").should(
-      "have.text",
-      "112775000"
-    )
+onlyOn(isBeta(HOST), () => {
+  describe('Aggregate Reports', function () {
+    it('Does not run in Beta environments', () => {})
   })
+})
 
-  it("2021", () => {
-    cy.get({ HOST }).logEnv()
-    cy.viewport(1680, 867)
-    cy.visit(`${HOST}/data-publication/aggregate-reports/2021`)
+onlyOn(!isBeta(HOST), () => {
+  describe('Aggregate Reports', () => {
+    it('2022', () => {
+      cy.get({ HOST }).logEnv()
+      cy.viewport(1680, 867)
+      cy.visit(`${HOST}/data-publication/aggregate-reports/2022`)
 
-    // Select geography and report
-    cy.findByText("Select a state...").type("Arizona{enter}")
-    cy.findByText("Select MSA/MD...").type("Phoenix{enter}")
-    cy.findByText("Select report...").type(
-      "Applications by Ethnicity and Sex{enter}"
-    )
+      // Select geography and report
+      cy.findByText('Select a state...').type('Arizona{enter}')
+      cy.findByText('Select MSA/MD...').type('Phoenix{enter}')
+      cy.findByText('Select report...').type(
+        'Applications by Ethnicity and Sex{enter}'
+      )
 
-    // Report Content
-    cy.get("tbody > :nth-child(3) > :nth-child(2)").should("have.text", "22816")
-    cy.get("tbody > :nth-child(3) > :nth-child(3)").should(
-      "have.text",
-      "5681840000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(4)").should("have.text", "1123")
-    cy.get("tbody > :nth-child(3) > :nth-child(5)").should(
-      "have.text",
-      "238805000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(6)").should("have.text", "5077")
-    cy.get("tbody > :nth-child(3) > :nth-child(7)").should(
-      "have.text",
-      "1005605000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(8)").should("have.text", "5398")
-    cy.get("tbody > :nth-child(3) > :nth-child(9)").should(
-      "have.text",
-      "1341620000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(10)").should("have.text", "2155")
-    cy.get("tbody > :nth-child(3) > :nth-child(11)").should(
-      "have.text",
-      "466095000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(12)").should("have.text", "1373")
-    cy.get("tbody > :nth-child(3) > :nth-child(13)").should(
-      "have.text",
-      "318245000"
-    )
-  })
+      // Report Content
+      cy.get('tbody > :nth-child(3) > :nth-child(2)').should(
+        'have.text',
+        '12308'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(3)').should(
+        'have.text',
+        '3402910000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(4)').should('have.text', '790')
+      cy.get('tbody > :nth-child(3) > :nth-child(5)').should(
+        'have.text',
+        '160160000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(6)').should(
+        'have.text',
+        '5107'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(7)').should(
+        'have.text',
+        '962115000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(8)').should(
+        'have.text',
+        '4032'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(9)').should(
+        'have.text',
+        '1184710000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(10)').should(
+        'have.text',
+        '1442'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(11)').should(
+        'have.text',
+        '339530000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(12)').should(
+        'have.text',
+        '351'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(13)').should(
+        'have.text',
+        '112775000'
+      )
+    })
 
-  it("2020", () => {
-    cy.get({ HOST }).logEnv()
-    // Report: Applications by Ethnicity and Sex
-    cy.viewport(1680, 867)
-    cy.visit(`${HOST}/data-publication/aggregate-reports/2020`)
-    
-    // Select geography and report
-    cy.findByText("Select a state...").type("Arizona{enter}")
-    cy.findByText("Select MSA/MD...").type("Phoenix{enter}")
-    cy.findByText("Select report...").type(
-      "Applications by Ethnicity and Sex{enter}"
-    )
+    it('2021', () => {
+      cy.get({ HOST }).logEnv()
+      cy.viewport(1680, 867)
+      cy.visit(`${HOST}/data-publication/aggregate-reports/2021`)
 
-    // Report Content
-    cy.get("tbody > :nth-child(3) > :nth-child(2)").should("have.text", "20367")
-    cy.get("tbody > :nth-child(3) > :nth-child(3)").should(
-      "have.text",
-      "4558205000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(4)").should("have.text", "999")
-    cy.get("tbody > :nth-child(3) > :nth-child(5)").should(
-      "have.text",
-      "198315000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(6)").should("have.text", "4726")
-    cy.get("tbody > :nth-child(3) > :nth-child(7)").should(
-      "have.text",
-      "861490000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(8)").should("have.text", "5432")
-    cy.get("tbody > :nth-child(3) > :nth-child(9)").should(
-      "have.text",
-      "1201990000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(10)").should("have.text", "1946")
-    cy.get("tbody > :nth-child(3) > :nth-child(11)").should(
-      "have.text",
-      "403290000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(12)").should("have.text", "1953")
-    cy.get("tbody > :nth-child(3) > :nth-child(13)").should(
-      "have.text",
-      "376535000"
-    )
-  })
+      // Select geography and report
+      cy.findByText('Select a state...').type('Arizona{enter}')
+      cy.findByText('Select MSA/MD...').type('Phoenix{enter}')
+      cy.findByText('Select report...').type(
+        'Applications by Ethnicity and Sex{enter}'
+      )
 
-  it("2019", () => {
-    cy.get({ HOST }).logEnv()
-    // Report: Applications by Ethnicity and Sex
-    cy.viewport(1680, 867)
-    cy.visit(`${HOST}/data-publication/aggregate-reports/2019`)
+      // Report Content
+      cy.get('tbody > :nth-child(3) > :nth-child(2)').should(
+        'have.text',
+        '22816'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(3)').should(
+        'have.text',
+        '5681840000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(4)').should(
+        'have.text',
+        '1123'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(5)').should(
+        'have.text',
+        '238805000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(6)').should(
+        'have.text',
+        '5077'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(7)').should(
+        'have.text',
+        '1005605000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(8)').should(
+        'have.text',
+        '5398'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(9)').should(
+        'have.text',
+        '1341620000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(10)').should(
+        'have.text',
+        '2155'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(11)').should(
+        'have.text',
+        '466095000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(12)').should(
+        'have.text',
+        '1373'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(13)').should(
+        'have.text',
+        '318245000'
+      )
+    })
 
-    // Select geography and report
-    cy.findByText("Select a state...").type("Arizona{enter}")
-    cy.findByText("Select MSA/MD...").type("Phoenix{enter}")
-    cy.findByText("Select report...").type(
-      "Applications by Ethnicity and Sex{enter}"
-    )
+    it('2020', () => {
+      cy.get({ HOST }).logEnv()
+      // Report: Applications by Ethnicity and Sex
+      cy.viewport(1680, 867)
+      cy.visit(`${HOST}/data-publication/aggregate-reports/2020`)
 
-    // Report Content
-    cy.get("tbody > :nth-child(3) > :nth-child(2)").should("have.text", "13409")
-    cy.get("tbody > :nth-child(3) > :nth-child(3)").should(
-      "have.text",
-      "2710055000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(4)").should("have.text", "608")
-    cy.get("tbody > :nth-child(3) > :nth-child(5)").should(
-      "have.text",
-      "108090000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(6)").should("have.text", "4384")
-    cy.get("tbody > :nth-child(3) > :nth-child(7)").should(
-      "have.text",
-      "610090000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(8)").should("have.text", "3634")
-    cy.get("tbody > :nth-child(3) > :nth-child(9)").should(
-      "have.text",
-      "734050000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(10)").should("have.text", "1210")
-    cy.get("tbody > :nth-child(3) > :nth-child(11)").should(
-      "have.text",
-      "235550000"
-    )
-    cy.get("tbody > :nth-child(3) > :nth-child(12)").should("have.text", "2089")
-    cy.get("tbody > :nth-child(3) > :nth-child(13)").should(
-      "have.text",
-      "462355000"
-    )
-  })
+      // Select geography and report
+      cy.findByText('Select a state...').type('Arizona{enter}')
+      cy.findByText('Select MSA/MD...').type('Phoenix{enter}')
+      cy.findByText('Select report...').type(
+        'Applications by Ethnicity and Sex{enter}'
+      )
 
-  it("2018", () => {
-    cy.get({ HOST }).logEnv()
-    // Report: Applications by Income, Race, and Ethnicity
+      // Report Content
+      cy.get('tbody > :nth-child(3) > :nth-child(2)').should(
+        'have.text',
+        '20367'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(3)').should(
+        'have.text',
+        '4558205000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(4)').should('have.text', '999')
+      cy.get('tbody > :nth-child(3) > :nth-child(5)').should(
+        'have.text',
+        '198315000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(6)').should(
+        'have.text',
+        '4726'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(7)').should(
+        'have.text',
+        '861490000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(8)').should(
+        'have.text',
+        '5432'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(9)').should(
+        'have.text',
+        '1201990000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(10)').should(
+        'have.text',
+        '1946'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(11)').should(
+        'have.text',
+        '403290000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(12)').should(
+        'have.text',
+        '1953'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(13)').should(
+        'have.text',
+        '376535000'
+      )
+    })
 
-    cy.viewport(1680, 867)
+    it('2019', () => {
+      cy.get({ HOST }).logEnv()
+      // Report: Applications by Ethnicity and Sex
+      cy.viewport(1680, 867)
+      cy.visit(`${HOST}/data-publication/aggregate-reports/2019`)
 
-    cy.visit(`${HOST}/data-publication/aggregate-reports/2018`)
+      // Select geography and report
+      cy.findByText('Select a state...').type('Arizona{enter}')
+      cy.findByText('Select MSA/MD...').type('Phoenix{enter}')
+      cy.findByText('Select report...').type(
+        'Applications by Ethnicity and Sex{enter}'
+      )
 
-    // Select geography and report
-    openSelector("#StateSelector")
-    cy.get("#react-select-2-option-4").click()
-    cy.get("#react-select-3-option-14").click()
-    cy.get("#react-select-4-option-4").click()
+      // Report Content
+      cy.get('tbody > :nth-child(3) > :nth-child(2)').should(
+        'have.text',
+        '13409'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(3)').should(
+        'have.text',
+        '2710055000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(4)').should('have.text', '608')
+      cy.get('tbody > :nth-child(3) > :nth-child(5)').should(
+        'have.text',
+        '108090000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(6)').should(
+        'have.text',
+        '4384'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(7)').should(
+        'have.text',
+        '610090000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(8)').should(
+        'have.text',
+        '3634'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(9)').should(
+        'have.text',
+        '734050000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(10)').should(
+        'have.text',
+        '1210'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(11)').should(
+        'have.text',
+        '235550000'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(12)').should(
+        'have.text',
+        '2089'
+      )
+      cy.get('tbody > :nth-child(3) > :nth-child(13)').should(
+        'have.text',
+        '462355000'
+      )
+    })
 
-    /* 
+    it('2018', () => {
+      cy.get({ HOST }).logEnv()
+      // Report: Applications by Income, Race, and Ethnicity
+
+      cy.viewport(1680, 867)
+
+      cy.visit(`${HOST}/data-publication/aggregate-reports/2018`)
+
+      // Select geography and report
+      openSelector('#StateSelector')
+      cy.get('#react-select-2-option-4').click()
+      cy.get('#react-select-3-option-14').click()
+      cy.get('#react-select-4-option-4').click()
+
+      /* 
         Check Report Params 
     */
 
-    // Year
-    cy.get(".ProgressCards > :nth-child(1)").should("contain.text", "2018")
+      // Year
+      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2018')
 
-    // Institution
-    cy.get(".ProgressCards > :nth-child(2)").should(
-      "contain.text",
-      "California - CA"
-    )
+      // Institution
+      cy.get('.ProgressCards > :nth-child(2)').should(
+        'contain.text',
+        'California - CA'
+      )
 
-    // MSA/MD
-    cy.get(".ProgressCards > :nth-child(3)").should(
-      "contain.text",
-      "RIVERSIDE-SAN BERNARDINO-ONTARIO - 40140"
-    )
+      // MSA/MD
+      cy.get('.ProgressCards > :nth-child(3)').should(
+        'contain.text',
+        'RIVERSIDE-SAN BERNARDINO-ONTARIO - 40140'
+      )
 
-    // Report Type
-    cy.get(".ProgressCards > :nth-child(4)").should(
-      "contain.text",
-      "Applications by Income, Race, and Ethnicity"
-    )
+      // Report Type
+      cy.get('.ProgressCards > :nth-child(4)').should(
+        'contain.text',
+        'Applications by Income, Race, and Ethnicity'
+      )
 
-    /* 
+      /* 
         Check Report Content
     */
 
-    // Verify a row of the report content
-    // These values can probably still change, so need more resiliant test?
-    cy.get("tbody > :nth-child(9) > :nth-child(2)").should("have.text", "171")
-    cy.get("tbody > :nth-child(9) > :nth-child(3)").should(
-      "have.text",
-      "47085000"
-    )
-    cy.get("tbody > :nth-child(9) > :nth-child(4)").should("have.text", "79")
-    cy.get("tbody > :nth-child(9) > :nth-child(5)").should(
-      "have.text",
-      "23805000"
-    )
-    cy.get("tbody > :nth-child(9) > :nth-child(6)").should("have.text", "5")
-    cy.get("tbody > :nth-child(9) > :nth-child(7)").should(
-      "have.text",
-      "1805000"
-    )
-    cy.get("tbody > :nth-child(9) > :nth-child(8)").should("have.text", "51")
-    cy.get("tbody > :nth-child(9) > :nth-child(9)").should(
-      "have.text",
-      "11105000"
-    )
-    cy.get("tbody > :nth-child(9) > :nth-child(10)").should("have.text", "20")
-    cy.get("tbody > :nth-child(9) > :nth-child(11)").should(
-      "have.text",
-      "5960000"
-    )
-    cy.get("tbody > :nth-child(9) > :nth-child(12)").should("have.text", "16")
-    cy.get("tbody > :nth-child(9) > :nth-child(13)").should(
-      "have.text",
-      "4410000"
-    )
-    cy.get("tbody > :nth-child(9) > :nth-child(14)").should("have.text", "2")
-    cy.get("tbody > :nth-child(9) > :nth-child(15)").should(
-      "have.text",
-      "310000"
-    )
-  })
+      // Verify a row of the report content
+      // These values can probably still change, so need more resiliant test?
+      cy.get('tbody > :nth-child(9) > :nth-child(2)').should('have.text', '171')
+      cy.get('tbody > :nth-child(9) > :nth-child(3)').should(
+        'have.text',
+        '47085000'
+      )
+      cy.get('tbody > :nth-child(9) > :nth-child(4)').should('have.text', '79')
+      cy.get('tbody > :nth-child(9) > :nth-child(5)').should(
+        'have.text',
+        '23805000'
+      )
+      cy.get('tbody > :nth-child(9) > :nth-child(6)').should('have.text', '5')
+      cy.get('tbody > :nth-child(9) > :nth-child(7)').should(
+        'have.text',
+        '1805000'
+      )
+      cy.get('tbody > :nth-child(9) > :nth-child(8)').should('have.text', '51')
+      cy.get('tbody > :nth-child(9) > :nth-child(9)').should(
+        'have.text',
+        '11105000'
+      )
+      cy.get('tbody > :nth-child(9) > :nth-child(10)').should('have.text', '20')
+      cy.get('tbody > :nth-child(9) > :nth-child(11)').should(
+        'have.text',
+        '5960000'
+      )
+      cy.get('tbody > :nth-child(9) > :nth-child(12)').should('have.text', '16')
+      cy.get('tbody > :nth-child(9) > :nth-child(13)').should(
+        'have.text',
+        '4410000'
+      )
+      cy.get('tbody > :nth-child(9) > :nth-child(14)').should('have.text', '2')
+      cy.get('tbody > :nth-child(9) > :nth-child(15)').should(
+        'have.text',
+        '310000'
+      )
+    })
 
-  it("2017", () => {
-    cy.get({ HOST }).logEnv()
-    // Report: Disposition of loan applications, by location of property and type of loan, 2017
+    it('2017', () => {
+      cy.get({ HOST }).logEnv()
+      // Report: Disposition of loan applications, by location of property and type of loan, 2017
 
-    cy.viewport(1680, 867)
+      cy.viewport(1680, 867)
 
-    cy.visit(`${HOST}/data-publication/aggregate-reports/2017`)
+      cy.visit(`${HOST}/data-publication/aggregate-reports/2017`)
 
-    // Select geography and report
-    openSelector("#StateSelector")
-    cy.get("#react-select-2-option-5").click()
-    cy.get("#react-select-3-option-0").click()
-    cy.get("#react-select-4-option-1").click()
+      // Select geography and report
+      openSelector('#StateSelector')
+      cy.get('#react-select-2-option-5').click()
+      cy.get('#react-select-3-option-0').click()
+      cy.get('#react-select-4-option-1').click()
 
-    /*
+      /*
         Check Report Content
     */
 
-    // Verify the 1st "Loans Originated" row of the report contains expected data
-    cy.get("tbody > :nth-child(2) > :nth-child(2)").should("have.text", "1")
-    cy.get("tbody > :nth-child(2) > :nth-child(3)").should("have.text", "701")
-    cy.get("tbody > :nth-child(2) > :nth-child(4)").should("have.text", "65")
-    cy.get("tbody > :nth-child(2) > :nth-child(5)").should("have.text", "64768")
-    cy.get("tbody > :nth-child(2) > :nth-child(6)").should("have.text", "74")
-    cy.get("tbody > :nth-child(2) > :nth-child(7)").should("have.text", "48941")
-    cy.get("tbody > :nth-child(2) > :nth-child(8)").should("have.text", "13")
-    cy.get("tbody > :nth-child(2) > :nth-child(9)").should("have.text", "9897")
-    cy.get("tbody > :nth-child(2) > :nth-child(10)").should("have.text", "0")
-    cy.get("tbody > :nth-child(2) > :nth-child(11)").should("have.text", "0")
-    cy.get("tbody > :nth-child(2) > :nth-child(12)").should("have.text", "26")
-    cy.get("tbody > :nth-child(2) > :nth-child(13)").should(
-      "have.text",
-      "21442"
-    )
-    cy.get("tbody > :nth-child(2) > :nth-child(14)").should("have.text", "0")
-    cy.get("tbody > :nth-child(2) > :nth-child(15)").should("have.text", "0")
+      // Verify the 1st "Loans Originated" row of the report contains expected data
+      cy.get('tbody > :nth-child(2) > :nth-child(2)').should('have.text', '1')
+      cy.get('tbody > :nth-child(2) > :nth-child(3)').should('have.text', '701')
+      cy.get('tbody > :nth-child(2) > :nth-child(4)').should('have.text', '65')
+      cy.get('tbody > :nth-child(2) > :nth-child(5)').should(
+        'have.text',
+        '64768'
+      )
+      cy.get('tbody > :nth-child(2) > :nth-child(6)').should('have.text', '74')
+      cy.get('tbody > :nth-child(2) > :nth-child(7)').should(
+        'have.text',
+        '48941'
+      )
+      cy.get('tbody > :nth-child(2) > :nth-child(8)').should('have.text', '13')
+      cy.get('tbody > :nth-child(2) > :nth-child(9)').should(
+        'have.text',
+        '9897'
+      )
+      cy.get('tbody > :nth-child(2) > :nth-child(10)').should('have.text', '0')
+      cy.get('tbody > :nth-child(2) > :nth-child(11)').should('have.text', '0')
+      cy.get('tbody > :nth-child(2) > :nth-child(12)').should('have.text', '26')
+      cy.get('tbody > :nth-child(2) > :nth-child(13)').should(
+        'have.text',
+        '21442'
+      )
+      cy.get('tbody > :nth-child(2) > :nth-child(14)').should('have.text', '0')
+      cy.get('tbody > :nth-child(2) > :nth-child(15)').should('have.text', '0')
+    })
   })
 })

--- a/cypress/e2e/data-publication/CombinedMLAR.spec.js
+++ b/cypress/e2e/data-publication/CombinedMLAR.spec.js
@@ -1,22 +1,33 @@
+import { isBeta } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
+
 const { HOST } = Cypress.env()
 
+onlyOn(isBeta(HOST), () => {
+  describe('Combined MLAR', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
+
 const years = [2022]
-describe('Combined MLAR', () => {
-  years.forEach(year => {
-    it(`Verify Files Exist ${year}`, () => {
-      cy.visit(`${HOST}/data-publication/modified-lar/${year}`);
-      cy.request({
-        method: 'HEAD',
-        url: `https://s3.amazonaws.com/cfpb-hmda-public/prod/dynamic-data/combined-mlar/${year}/header/${year}_combined_mlar_header.zip`})
-        .its('status')
-        .should('equal', 200)
-      cy.request({
-        method: 'HEAD',
-        url: `https://s3.amazonaws.com/cfpb-hmda-public/prod/dynamic-data/combined-mlar/${year}/${year}_combined_mlar.zip`})
-        .its('status')
-        .should('equal', 200)
-      });
-  });
-      // Assertions or further actions can be added here
-    
-});
+onlyOn(!isBeta(HOST), () => {
+  describe('Combined MLAR', () => {
+    years.forEach(year => {
+      it(`Verify Files Exist ${year}`, () => {
+        cy.visit(`${HOST}/data-publication/modified-lar/${year}`)
+        cy.request({
+          method: 'HEAD',
+          url: `https://s3.amazonaws.com/cfpb-hmda-public/prod/dynamic-data/combined-mlar/${year}/header/${year}_combined_mlar_header.zip`,
+        })
+          .its('status')
+          .should('equal', 200)
+        cy.request({
+          method: 'HEAD',
+          url: `https://s3.amazonaws.com/cfpb-hmda-public/prod/dynamic-data/combined-mlar/${year}/${year}_combined_mlar.zip`,
+        })
+          .its('status')
+          .should('equal', 200)
+      })
+    })
+  })
+})

--- a/cypress/e2e/data-publication/DisclosureReports.spec.js
+++ b/cypress/e2e/data-publication/DisclosureReports.spec.js
@@ -1,257 +1,263 @@
 const { HOST } = Cypress.env()
-import { isProdBeta } from "../../support/helpers"
+import { isBeta } from "../../support/helpers"
+import { onlyOn } from '@cypress/skip-test'
 
-describe("Disclosure Reports", () => {
-  if (isProdBeta(HOST)) it("Does not run on Prod Beta")
-  else {
-    it("Fetches a 2022 Applications by Tract Report", () => {
+onlyOn(isBeta(HOST), () => {
+  describe('Disclosure Reports', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
+
+onlyOn(!isBeta(HOST), () => {
+  describe('Disclosure Reports', () => {
+    it('Fetches a 2022 Applications by Tract Report', () => {
       cy.get({ HOST }).logEnv()
       cy.viewport(1680, 916)
       cy.visit(`${HOST}/data-publication/disclosure-reports/2022`)
 
-      cy.get("#institution-name").click()
-      cy.get("#institution-name").type("cypress")
-      cy.findByText("View MSA/MDs").click()
-      cy.findByText("Select MSA/MD...").type("Dallas{enter}")
-      cy.findByText("Select report...").type("Applications by Tract{enter}")
+      cy.get('#institution-name').click()
+      cy.get('#institution-name').type('cypress')
+      cy.findByText('View MSA/MDs').click()
+      cy.findByText('Select MSA/MD...').type('Dallas{enter}')
+      cy.findByText('Select report...').type('Applications by Tract{enter}')
 
       /* Check Report Params */
 
       // Year
-      cy.get(".ProgressCards > :nth-child(1)").should("contain.text", "2022")
+      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2022')
 
       // Institution
-      cy.get(".ProgressCards > :nth-child(2) .heading > p").should(
-        "contain.text",
-        "CYPRESS BANK, SSB - 549300I4IUWMEMGLST06"
+      cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
+        'contain.text',
+        'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06'
       )
 
       // MSA/MD
-      cy.get(".ProgressCards > :nth-child(3) .heading > p").should(
-        "contain.text",
-        "Dallas-Plano-Irving, TX - 19124"
+      cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
+        'contain.text',
+        'Dallas-Plano-Irving, TX - 19124'
       )
 
       // Report Type
-      cy.get(".ProgressCards > :nth-child(4) .heading > p").should(
-        "contain.text",
-        "Applications by Tract"
+      cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
+        'contain.text',
+        'Applications by Tract'
       )
 
       // Validate a row - Third row called "Applications Denied by Financial Institution"
-      cy.get("tbody > :nth-child(4) > :nth-child(2)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(3)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(4)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(5)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(6)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(7)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(8)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(9)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(10)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(11)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(12)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(13)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(14)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(15)").should("have.text", "0")
+      cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(10)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(11)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(12)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(13)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(14)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(15)').should('have.text', '0')
     })
 
-    it("Fetches a 2021 Applications by Tract Report", () => {
+    it('Fetches a 2021 Applications by Tract Report', () => {
       cy.get({ HOST }).logEnv()
       cy.viewport(1680, 916)
       cy.visit(`${HOST}/data-publication/disclosure-reports/2021`)
 
-      cy.get("#institution-name").click()
-      cy.get("#institution-name").type("cypress")
-      cy.findByText("View MSA/MDs").click()
-      cy.findByText("Select MSA/MD...").type("Dallas{enter}")
-      cy.findByText("Select report...").type("Applications by Tract{enter}")
+      cy.get('#institution-name').click()
+      cy.get('#institution-name').type('cypress')
+      cy.findByText('View MSA/MDs').click()
+      cy.findByText('Select MSA/MD...').type('Dallas{enter}')
+      cy.findByText('Select report...').type('Applications by Tract{enter}')
 
       /* Check Report Params */
 
       // Year
-      cy.get(".ProgressCards > :nth-child(1)").should("contain.text", "2021")
+      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2021')
 
       // Institution
-      cy.get(".ProgressCards > :nth-child(2) .heading > p").should(
-        "contain.text",
-        "CYPRESS BANK, SSB - 549300I4IUWMEMGLST06"
+      cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
+        'contain.text',
+        'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06'
       )
 
       // MSA/MD
-      cy.get(".ProgressCards > :nth-child(3) .heading > p").should(
-        "contain.text",
-        "Dallas-Plano-Irving, TX - 19124"
+      cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
+        'contain.text',
+        'Dallas-Plano-Irving, TX - 19124'
       )
 
       // Report Type
-      cy.get(".ProgressCards > :nth-child(4) .heading > p").should(
-        "contain.text",
-        "Applications by Tract"
+      cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
+        'contain.text',
+        'Applications by Tract'
       )
 
       // Validate a row - Third row called "Applications Denied by Financial Institution"
-      cy.get("tbody > :nth-child(4) > :nth-child(2)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(3)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(4)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(5)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(6)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(7)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(8)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(9)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(10)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(11)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(12)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(13)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(14)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(15)").should("have.text", "0")
+      cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(10)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(11)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(12)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(13)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(14)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(15)').should('have.text', '0')
     })
 
-    it("Fetches a 2020 Applications by Tract Report", () => {
+    it('Fetches a 2020 Applications by Tract Report', () => {
       cy.get({ HOST }).logEnv()
       cy.viewport(1680, 916)
       cy.visit(`${HOST}/data-publication/disclosure-reports/2020`)
 
-      cy.get("#institution-name").click()
-      cy.get("#institution-name").type("cypress")
-      cy.findByText("View MSA/MDs").click()
-      cy.findByText("Select MSA/MD...").type("Dallas{enter}")
-      cy.findByText("Select report...").type("Applications by Tract{enter}")
+      cy.get('#institution-name').click()
+      cy.get('#institution-name').type('cypress')
+      cy.findByText('View MSA/MDs').click()
+      cy.findByText('Select MSA/MD...').type('Dallas{enter}')
+      cy.findByText('Select report...').type('Applications by Tract{enter}')
 
       /* Check Report Params */
 
       // Year
-      cy.get(".ProgressCards > :nth-child(1)").should("contain.text", "2020")
+      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2020')
 
       // Institution
-      cy.get(".ProgressCards > :nth-child(2) .heading > p").should(
-        "contain.text",
-        "CYPRESS BANK, SSB - 549300I4IUWMEMGLST06"
+      cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
+        'contain.text',
+        'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06'
       )
 
       // MSA/MD
-      cy.get(".ProgressCards > :nth-child(3) .heading > p").should(
-        "contain.text",
-        "Dallas-Fort Worth, TX-OK - 19124"
+      cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
+        'contain.text',
+        'Dallas-Fort Worth, TX-OK - 19124'
       )
 
       // Report Type
-      cy.get(".ProgressCards > :nth-child(4) .heading > p").should(
-        "contain.text",
-        "Applications by Tract"
+      cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
+        'contain.text',
+        'Applications by Tract'
       )
 
       // Validate a row - Third row called "Applications Denied by Financial Institution"
-      cy.get("tbody > :nth-child(4) > :nth-child(2)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(3)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(4)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(5)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(6)").should("have.text", "1")
-      cy.get("tbody > :nth-child(4) > :nth-child(7)").should(
-        "have.text",
-        "55000"
+      cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '1')
+      cy.get('tbody > :nth-child(4) > :nth-child(7)').should(
+        'have.text',
+        '55000'
       )
-      cy.get("tbody > :nth-child(4) > :nth-child(8)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(9)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(10)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(11)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(12)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(13)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(14)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(15)").should("have.text", "0")
+      cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(10)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(11)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(12)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(13)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(14)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(15)').should('have.text', '0')
     })
 
-    it("Fetches a 2019 Applications by Tract Report", () => {
+    it('Fetches a 2019 Applications by Tract Report', () => {
       cy.get({ HOST }).logEnv()
       cy.viewport(1680, 916)
       cy.visit(`${HOST}/data-publication/disclosure-reports/2019`)
 
-      cy.get("#institution-name").click()
-      cy.get("#institution-name").type("cypress")
-      cy.findByText("View MSA/MDs").click()
-      cy.findByText("Select MSA/MD...").type("Dallas{enter}")
-      cy.findByText("Select report...").type("Applications by Tract{enter}")
+      cy.get('#institution-name').click()
+      cy.get('#institution-name').type('cypress')
+      cy.findByText('View MSA/MDs').click()
+      cy.findByText('Select MSA/MD...').type('Dallas{enter}')
+      cy.findByText('Select report...').type('Applications by Tract{enter}')
 
       /* Check Report Params */
 
       // Year
-      cy.get(".ProgressCards > :nth-child(1)").should("contain.text", "2019")
+      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2019')
 
       // Institution
-      cy.get(".ProgressCards > :nth-child(2) .heading > p").should(
-        "contain.text",
-        "CYPRESS BANK, SSB - 549300I4IUWMEMGLST06"
+      cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
+        'contain.text',
+        'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06'
       )
 
       // MSA/MD
-      cy.get(".ProgressCards > :nth-child(3) .heading > p").should(
-        "contain.text",
-        "Dallas-Fort Worth, TX-OK - 19124"
+      cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
+        'contain.text',
+        'Dallas-Fort Worth, TX-OK - 19124'
       )
 
       // Report Type
-      cy.get(".ProgressCards > :nth-child(4) .heading > p").should(
-        "contain.text",
-        "Applications by Tract"
+      cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
+        'contain.text',
+        'Applications by Tract'
       )
 
       // Validate a row - Third row called "Applications Denied by Financial Institution"
-      cy.get("tbody > :nth-child(4) > :nth-child(2)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(3)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(4)").should("have.text", "3")
-      cy.get("tbody > :nth-child(4) > :nth-child(5)").should(
-        "have.text",
-        "1845000"
+      cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '3')
+      cy.get('tbody > :nth-child(4) > :nth-child(5)').should(
+        'have.text',
+        '1845000'
       )
-      cy.get("tbody > :nth-child(4) > :nth-child(6)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(7)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(8)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(9)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(10)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(11)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(12)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(13)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(14)").should("have.text", "0")
-      cy.get("tbody > :nth-child(4) > :nth-child(15)").should("have.text", "0")
+      cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(10)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(11)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(12)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(13)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(14)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(15)').should('have.text', '0')
     })
 
-    it("Fetches a 2018 Applications by Tract Report", () => {
+    it('Fetches a 2018 Applications by Tract Report', () => {
       cy.get({ HOST }).logEnv()
       cy.viewport(1680, 867)
       cy.visit(`${HOST}/data-publication/disclosure-reports/2018`)
 
-      cy.get("#institution-name").click()
-      cy.get("#institution-name").type("cypress")
+      cy.get('#institution-name').click()
+      cy.get('#institution-name').type('cypress')
 
       cy.get(
-        "#main-content > .SearchList > .Results > li > .button-link"
+        '#main-content > .SearchList > .Results > li > .button-link'
       ).click()
 
-      cy.get("#react-select-2-option-2").click()
-      cy.get("#react-select-3-option-0").click()
+      cy.get('#react-select-2-option-2').click()
+      cy.get('#react-select-3-option-0').click()
 
       /* 
         Check Report Params 
       */
 
       // Year
-      cy.get(".ProgressCards > :nth-child(1)").should("contain.text", "2018")
+      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2018')
 
       // Institution
-      cy.get(".ProgressCards > :nth-child(2)").should(
-        "contain.text",
-        "CYPRESS BANK, STATE SAVINGS BANK - 549300I4IUWMEMGLST06"
+      cy.get('.ProgressCards > :nth-child(2)').should(
+        'contain.text',
+        'CYPRESS BANK, STATE SAVINGS BANK - 549300I4IUWMEMGLST06'
       )
 
       // MSA/MD
-      cy.get(".ProgressCards > :nth-child(3)").should(
-        "contain.text",
-        "TAMPA-ST. PETERSBURG-CLEARWATER,FL - 45300"
+      cy.get('.ProgressCards > :nth-child(3)').should(
+        'contain.text',
+        'TAMPA-ST. PETERSBURG-CLEARWATER,FL - 45300'
       )
 
       // Report Type
-      cy.get(".ProgressCards > :nth-child(4)").should(
-        "contain.text",
-        "Applications by Tract"
+      cy.get('.ProgressCards > :nth-child(4)').should(
+        'contain.text',
+        'Applications by Tract'
       )
 
       /* 
@@ -259,32 +265,32 @@ describe("Disclosure Reports", () => {
       */
 
       // County
-      cy.get("tbody > :nth-child(1) > th").should(
-        "have.text",
-        "Pinellas County/Florida/027606"
+      cy.get('tbody > :nth-child(1) > th').should(
+        'have.text',
+        'Pinellas County/Florida/027606'
       )
 
       // Verify the Applications Received row of the report content contains expected data
-      cy.get("tbody > :nth-child(7) > :nth-child(2)").should("have.text", "0")
-      cy.get("tbody > :nth-child(7) > :nth-child(3)").should("have.text", "0")
-      cy.get("tbody > :nth-child(7) > :nth-child(4)").should("have.text", "1")
-      cy.get("tbody > :nth-child(7) > :nth-child(5)").should(
-        "have.text",
-        "455000"
+      cy.get('tbody > :nth-child(7) > :nth-child(2)').should('have.text', '0')
+      cy.get('tbody > :nth-child(7) > :nth-child(3)').should('have.text', '0')
+      cy.get('tbody > :nth-child(7) > :nth-child(4)').should('have.text', '1')
+      cy.get('tbody > :nth-child(7) > :nth-child(5)').should(
+        'have.text',
+        '455000'
       )
-      cy.get("tbody > :nth-child(7) > :nth-child(6)").should("have.text", "0")
-      cy.get("tbody > :nth-child(7) > :nth-child(7)").should("have.text", "0")
-      cy.get("tbody > :nth-child(7) > :nth-child(8)").should("have.text", "0")
-      cy.get("tbody > :nth-child(7) > :nth-child(9)").should("have.text", "0")
-      cy.get("tbody > :nth-child(7) > :nth-child(10)").should("have.text", "0")
-      cy.get("tbody > :nth-child(7) > :nth-child(11)").should("have.text", "0")
-      cy.get("tbody > :nth-child(7) > :nth-child(12)").should("have.text", "1")
-      cy.get("tbody > :nth-child(7) > :nth-child(13)").should(
-        "have.text",
-        "455000"
+      cy.get('tbody > :nth-child(7) > :nth-child(6)').should('have.text', '0')
+      cy.get('tbody > :nth-child(7) > :nth-child(7)').should('have.text', '0')
+      cy.get('tbody > :nth-child(7) > :nth-child(8)').should('have.text', '0')
+      cy.get('tbody > :nth-child(7) > :nth-child(9)').should('have.text', '0')
+      cy.get('tbody > :nth-child(7) > :nth-child(10)').should('have.text', '0')
+      cy.get('tbody > :nth-child(7) > :nth-child(11)').should('have.text', '0')
+      cy.get('tbody > :nth-child(7) > :nth-child(12)').should('have.text', '1')
+      cy.get('tbody > :nth-child(7) > :nth-child(13)').should(
+        'have.text',
+        '455000'
       )
-      cy.get("tbody > :nth-child(7) > :nth-child(14)").should("have.text", "0")
-      cy.get("tbody > :nth-child(7) > :nth-child(15)").should("have.text", "0")
+      cy.get('tbody > :nth-child(7) > :nth-child(14)').should('have.text', '0')
+      cy.get('tbody > :nth-child(7) > :nth-child(15)').should('have.text', '0')
 
       // TODO: Test 'Save as CSV' button
       /* Test CSV Download */
@@ -294,45 +300,45 @@ describe("Disclosure Reports", () => {
       // cy.get(".heading > button").click()
     })
 
-    it("Fetches a 2017 Conv Price Info Nationwide report", () => {
+    it('Fetches a 2017 Conv Price Info Nationwide report', () => {
       cy.get({ HOST }).logEnv()
       cy.viewport(1680, 916)
 
       cy.visit(`${HOST}/data-publication/disclosure-reports/2017`)
 
-      cy.get("#institution-name").click()
-      cy.get("#institution-name").type("cypress")
+      cy.get('#institution-name').click()
+      cy.get('#institution-name').type('cypress')
 
       cy.get(
-        "#main-content > .SearchList > .Results > li > .button-link"
+        '#main-content > .SearchList > .Results > li > .button-link'
       ).click()
 
-      cy.get("#react-select-2-option-5").click()
-      cy.get("#react-select-3-option-1").click()
+      cy.get('#react-select-2-option-5').click()
+      cy.get('#react-select-3-option-1').click()
 
       /* 
         Check Report Params 
       */
 
       // Year
-      cy.get(".ProgressCards > :nth-child(1)").should("contain.text", "2017")
+      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2017')
 
       // Institution
-      cy.get(".ProgressCards > :nth-child(2)").should(
-        "contain.text",
-        "CYPRESS BANK, SSB - 31905"
+      cy.get('.ProgressCards > :nth-child(2)').should(
+        'contain.text',
+        'CYPRESS BANK, SSB - 31905'
       )
 
       // MSA/MD
-      cy.get(".ProgressCards > :nth-child(3)").should(
-        "contain.text",
-        "nationwide"
+      cy.get('.ProgressCards > :nth-child(3)').should(
+        'contain.text',
+        'nationwide'
       )
 
       // Report Type
-      cy.get(".ProgressCards > :nth-child(4)").should(
-        "contain.text",
-        "Conv Price Info by Incidence and Level - Nationwide - BW"
+      cy.get('.ProgressCards > :nth-child(4)').should(
+        'contain.text',
+        'Conv Price Info by Incidence and Level - Nationwide - BW'
       )
 
       /* 
@@ -340,35 +346,35 @@ describe("Disclosure Reports", () => {
       */
 
       // County
-      cy.get("tbody > :nth-child(1) > th").should(
-        "have.text",
-        "1- TO 4-FAMILY OWNER OCCUPIED DWELLINGS (EXCLUDES MANUFACTURED HOMES)"
+      cy.get('tbody > :nth-child(1) > th').should(
+        'have.text',
+        '1- TO 4-FAMILY OWNER OCCUPIED DWELLINGS (EXCLUDES MANUFACTURED HOMES)'
       )
 
       // Verify the Applications Received row of the report contains expected data
-      cy.get("tbody > :nth-child(6) > :nth-child(2)").should(
-        "have.text",
-        "1.77"
+      cy.get('tbody > :nth-child(6) > :nth-child(2)').should(
+        'have.text',
+        '1.77'
       )
-      cy.get("tbody > :nth-child(6) > :nth-child(3)").should("have.text", "0")
-      cy.get("tbody > :nth-child(6) > :nth-child(4)").should("have.text", "0")
-      cy.get("tbody > :nth-child(6) > :nth-child(5)").should(
-        "have.text",
-        "1.95"
+      cy.get('tbody > :nth-child(6) > :nth-child(3)').should('have.text', '0')
+      cy.get('tbody > :nth-child(6) > :nth-child(4)').should('have.text', '0')
+      cy.get('tbody > :nth-child(6) > :nth-child(5)').should(
+        'have.text',
+        '1.95'
       )
-      cy.get("tbody > :nth-child(6) > :nth-child(6)").should("have.text", "0")
-      cy.get("tbody > :nth-child(6) > :nth-child(7)").should("have.text", "0")
-      cy.get("tbody > :nth-child(6) > :nth-child(8)").should(
-        "have.text",
-        "1.98"
+      cy.get('tbody > :nth-child(6) > :nth-child(6)').should('have.text', '0')
+      cy.get('tbody > :nth-child(6) > :nth-child(7)').should('have.text', '0')
+      cy.get('tbody > :nth-child(6) > :nth-child(8)').should(
+        'have.text',
+        '1.98'
       )
-      cy.get("tbody > :nth-child(6) > :nth-child(9)").should(
-        "have.text",
-        "6.85"
+      cy.get('tbody > :nth-child(6) > :nth-child(9)').should(
+        'have.text',
+        '6.85'
       )
-      cy.get("tbody > :nth-child(6) > :nth-child(10)").should("have.text", "0")
+      cy.get('tbody > :nth-child(6) > :nth-child(10)').should('have.text', '0')
 
       // TODO: Test 'Save as CSV' button
     })
-  }
+  })
 })

--- a/cypress/e2e/data-publication/DynamicDatasets.spec.js
+++ b/cypress/e2e/data-publication/DynamicDatasets.spec.js
@@ -1,26 +1,39 @@
+import { isBeta } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
+
 const { HOST, TEST_DELAY, ACTION_DELAY } = Cypress.env()
 
-describe('Dynamic National Loan-Level Dataset', () => {
-  const years = ['2020', '2019', '2018', '2017']
-  const datasetUrl = '/data-publication/dynamic-national-loan-level-dataset/'
-  const linksPath = '#main-content > .grid > :nth-child(1) > ul > li > a'
+onlyOn(isBeta(HOST), () => {
+  describe('Dynamic National Loan-Level Dataset', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
 
-  years.forEach((year) => {
-    describe(year + ' Dynamic Datasets', () => {
-      it('has valid Dataset links', () => {
-        cy.get({ HOST, TEST_DELAY, ACTION_DELAY }).logEnv()
-        cy.viewport(1440, 798)
-        cy.visit(`${HOST}${datasetUrl}${year}`)
-        
-        // Test validity of each link in the Datasets list
-        cy.get(linksPath).each(link => {
-          cy.get(link).hasValidHref().then(({ status }) => {
-            assert.isTrue(status, `${link.text()} is a valid link`)
+onlyOn(!isBeta(HOST), () => {
+  describe('Dynamic National Loan-Level Dataset', () => {
+    const years = ['2020', '2019', '2018', '2017']
+    const datasetUrl = '/data-publication/dynamic-national-loan-level-dataset/'
+    const linksPath = '#main-content > .grid > :nth-child(1) > ul > li > a'
+
+    years.forEach(year => {
+      describe(year + ' Dynamic Datasets', () => {
+        it('has valid Dataset links', () => {
+          cy.get({ HOST, TEST_DELAY, ACTION_DELAY }).logEnv()
+          cy.viewport(1440, 798)
+          cy.visit(`${HOST}${datasetUrl}${year}`)
+
+          // Test validity of each link in the Datasets list
+          cy.get(linksPath).each(link => {
+            cy.get(link)
+              .hasValidHref()
+              .then(({ status }) => {
+                assert.isTrue(status, `${link.text()} is a valid link`)
+              })
+            cy.wait(ACTION_DELAY)
           })
-          cy.wait(ACTION_DELAY)
+
+          cy.wait(TEST_DELAY)
         })
-        
-        cy.wait(TEST_DELAY)
       })
     })
   })

--- a/cypress/e2e/data-publication/ModifiedLAR.spec.js
+++ b/cypress/e2e/data-publication/ModifiedLAR.spec.js
@@ -13,7 +13,7 @@ const testCases = [
 
 onlyOn(isBeta(HOST), () => {
   describe("Modified LAR", function() {
-    it("Does not run on Beta", () => {})
+    it("Does not run in Beta environments", () => {})
   })
 })
 

--- a/cypress/e2e/data-publication/NationalAggregateReports.spec.js
+++ b/cypress/e2e/data-publication/NationalAggregateReports.spec.js
@@ -1,60 +1,76 @@
+import { isBeta } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
+
 const { HOST } = Cypress.env()
 
-describe("National Aggregate Report - Not Generated", () => {
-  ["2021", "2020", "2019", "2018"].forEach((year) => {
-    it(`${year} does not have Reports`, () => {
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1000, 867)
-      cy.visit(`${HOST}/data-publication/national-aggregate-reports/${year}`)
-      cy.get("#main-content h3")
-        .last()
-        .should(
-          "have.text",
-          `National Aggregate reports are not produced for data collected in or after 2018.`
-        )
+onlyOn(isBeta(HOST), () => {
+  describe('National Aggregate Reports', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
+
+onlyOn(!isBeta(HOST), () => {
+  describe('National Aggregate Report - Not Generated', () => {
+    ;['2021', '2020', '2019', '2018'].forEach(year => {
+      it(`${year} does not have Reports`, () => {
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1000, 867)
+        cy.visit(`${HOST}/data-publication/national-aggregate-reports/${year}`)
+        cy.get('#main-content h3')
+          .last()
+          .should(
+            'have.text',
+            `National Aggregate reports are not produced for data collected in or after 2018.`
+          )
+      })
     })
   })
 })
 
-describe("National Aggregate Report 2017", () => {
-  it("Loans Sold by Purchaser Type", () => {
-    cy.get({ HOST }).logEnv()
-    cy.viewport(1680, 867)
-    cy.visit(`${HOST}/data-publication/national-aggregate-reports/2017`)
+onlyOn(!isBeta(HOST), () => {
+  describe('National Aggregate Report 2017', () => {
+    it('Loans Sold by Purchaser Type', () => {
+      cy.get({ HOST }).logEnv()
+      cy.viewport(1680, 867)
+      cy.visit(`${HOST}/data-publication/national-aggregate-reports/2017`)
 
-    // Select Report
-    cy.get("#react-select-2-option-0-1").click()
+      // Select Report
+      cy.get('#react-select-2-option-0-1').click()
 
-    // Confirm Report Selections
-    cy.get(".ProgressCards > :nth-child(1)").should("contain.text", "2017")
-    cy.get(".ProgressCards > :nth-child(2)").should(
-      "contain.text",
-      "Loans Sold by Purchaser Type - 3-2"
-    )
+      // Confirm Report Selections
+      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2017')
+      cy.get('.ProgressCards > :nth-child(2)').should(
+        'contain.text',
+        'Loans Sold by Purchaser Type - 3-2'
+      )
 
-    // Validate a row of report data
-    cy.get(".Report table:first-of-type > tbody > tr:first-of-type").within(
-      () => {
-        cy.get(":nth-child(1)").should("have.text", "No reported pricing data")
-        cy.get(":nth-child(2)").should("have.text", "1348626")
-        cy.get(":nth-child(3)").should("have.text", "437")
-        cy.get(":nth-child(4)").should("have.text", "874594")
-        cy.get(":nth-child(5)").should("have.text", "51")
-        cy.get(":nth-child(6)").should("have.text", "895110")
-        cy.get(":nth-child(7)").should("have.text", "127")
-        cy.get(":nth-child(8)").should("have.text", "1184")
-        cy.get(":nth-child(9)").should("have.text", "16")
-        cy.get(":nth-child(10)").should("have.text", "38017")
-        cy.get(":nth-child(11)").should("have.text", "828")
-        cy.get(":nth-child(12)").should("have.text", "680187")
-        cy.get(":nth-child(13)").should("have.text", "8543")
-        cy.get(":nth-child(14)").should("have.text", "710460")
-        cy.get(":nth-child(15)").should("have.text", "14291")
-        cy.get(":nth-child(16)").should("have.text", "73583")
-        cy.get(":nth-child(17)").should("have.text", "548")
-        cy.get(":nth-child(18)").should("have.text", "309291")
-        cy.get(":nth-child(19)").should("have.text", "35227")
-      }
-    )
+      // Validate a row of report data
+      cy.get('.Report table:first-of-type > tbody > tr:first-of-type').within(
+        () => {
+          cy.get(':nth-child(1)').should(
+            'have.text',
+            'No reported pricing data'
+          )
+          cy.get(':nth-child(2)').should('have.text', '1348626')
+          cy.get(':nth-child(3)').should('have.text', '437')
+          cy.get(':nth-child(4)').should('have.text', '874594')
+          cy.get(':nth-child(5)').should('have.text', '51')
+          cy.get(':nth-child(6)').should('have.text', '895110')
+          cy.get(':nth-child(7)').should('have.text', '127')
+          cy.get(':nth-child(8)').should('have.text', '1184')
+          cy.get(':nth-child(9)').should('have.text', '16')
+          cy.get(':nth-child(10)').should('have.text', '38017')
+          cy.get(':nth-child(11)').should('have.text', '828')
+          cy.get(':nth-child(12)').should('have.text', '680187')
+          cy.get(':nth-child(13)').should('have.text', '8543')
+          cy.get(':nth-child(14)').should('have.text', '710460')
+          cy.get(':nth-child(15)').should('have.text', '14291')
+          cy.get(':nth-child(16)').should('have.text', '73583')
+          cy.get(':nth-child(17)').should('have.text', '548')
+          cy.get(':nth-child(18)').should('have.text', '309291')
+          cy.get(':nth-child(19)').should('have.text', '35227')
+        }
+      )
+    })
   })
 })

--- a/cypress/e2e/data-publication/SnapshotDatasets.spec.js
+++ b/cypress/e2e/data-publication/SnapshotDatasets.spec.js
@@ -1,35 +1,53 @@
+import { isBeta } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
+
 const { HOST, ACTION_DELAY, TEST_DELAY } = Cypress.env()
 
 const sectionMap = {
-  "Loan/Application Records (LAR)": 1,
-  "Transmittal Sheet Records (TS)": 2,
-  "Report Panel": 3,
-  "MSA/MD Description": 4,
+  'Loan/Application Records (LAR)': 1,
+  'Transmittal Sheet Records (TS)': 2,
+  'Report Panel': 3,
+  'MSA/MD Description': 4,
 }
 
-describe('Snapshot National Loan-Level Dataset', () => {
-  const years = ['2020', '2019', '2018', '2017']
-  const datasetUrl = '/data-publication/snapshot-national-loan-level-dataset/'
-  const basePath = '.grid > :nth-child(1) > :nth-child(2)'
-  
-  years.forEach((year) => {
-    describe(year + ' Datasets', () => {
-      it('has valid Dataset links', () => {
-        cy.get({ HOST, ACTION_DELAY, TEST_DELAY }).logEnv()
-        cy.viewport(1440, 798)
-        cy.visit(`${HOST}${datasetUrl}${year}`)
+onlyOn(isBeta(HOST), () => {
+  describe('Snapshot National Loan-Level Dataset', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
 
-        // Test validity of each link in the Datasets list
-        Object.keys(sectionMap).forEach(key => {
-          cy.get(`${basePath} > :nth-child(${sectionMap[key]}) a`).each(link => {
-            cy.get(link).hasValidHref().then(({ status }) => {
-              assert.isTrue(status, `${key} - ${link.text()} is a valid link`)
-            })
-            cy.wait(ACTION_DELAY)
+onlyOn(!isBeta(HOST), () => {
+  describe('Snapshot National Loan-Level Dataset', () => {
+    const years = ['2020', '2019', '2018', '2017']
+    const datasetUrl = '/data-publication/snapshot-national-loan-level-dataset/'
+    const basePath = '.grid > :nth-child(1) > :nth-child(2)'
+
+    years.forEach(year => {
+      describe(year + ' Datasets', () => {
+        it('has valid Dataset links', () => {
+          cy.get({ HOST, ACTION_DELAY, TEST_DELAY }).logEnv()
+          cy.viewport(1440, 798)
+          cy.visit(`${HOST}${datasetUrl}${year}`)
+
+          // Test validity of each link in the Datasets list
+          Object.keys(sectionMap).forEach(key => {
+            cy.get(`${basePath} > :nth-child(${sectionMap[key]}) a`).each(
+              link => {
+                cy.get(link)
+                  .hasValidHref()
+                  .then(({ status }) => {
+                    assert.isTrue(
+                      status,
+                      `${key} - ${link.text()} is a valid link`
+                    )
+                  })
+                cy.wait(ACTION_DELAY)
+              }
+            )
           })
-        })        
-        
-        cy.wait(TEST_DELAY)
+
+          cy.wait(TEST_DELAY)
+        })
       })
     })
   })

--- a/cypress/e2e/hmda-help/institution.spec.js
+++ b/cypress/e2e/hmda-help/institution.spec.js
@@ -1,6 +1,7 @@
-import { isCI, getSelectedOptionValue } from '../../support/helpers'
+import { isCI, getSelectedOptionValue, isBeta } from '../../support/helpers'
 import { getFilingYears } from '../../../src/common/constants/configHelpers'
 import { getDefaultConfig } from '../../../src/common/configUtils'
+import { onlyOn } from '@cypress/skip-test'
 
 const {
   HOST,
@@ -17,231 +18,241 @@ const LOCAL_ACTION_DELAY = 250
 
 const NOTE_HISTORY_ON_CI_FIXED = false
 
-describe('HMDA Help - Institutions', () => {
-  const years = getFilingYears(getDefaultConfig(HOST))
+onlyOn(isBeta(HOST), () => {
+  describe('HMDA Help - Institutions', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
 
-  it('Can update existing Institutions', () => {
-    cy.get({
-      HOST,
-      ENVIRONMENT,
-      AUTH_BASE_URL,
-      AUTH_CLIENT_ID,
-      AUTH_REALM,
-      USERNAME,
-      PASSWORD,
-      INSTITUTION,
-    }).logEnv()
-    
+onlyOn(!isBeta(HOST), () => {
+  describe('HMDA Help - Institutions', () => {
+    const years = getFilingYears(getDefaultConfig(HOST))
 
-    // Log in
-    if (!isCI(ENVIRONMENT)) {
-      cy.hmdaLogin('hmda-help')
-      cy.url().should('contains', `${AUTH_BASE_URL}hmda-help/`)
-    }
-    
-    // Load site
-    cy.viewport(1600, 900)
-    cy.visit(`${HOST}/hmda-help/`)
-    cy.wait(LOCAL_ACTION_DELAY)
-    
-    
-    // Search for existing Instititution
-    cy.wait(5000) // HACK TO ALLOW CASCADING FILER LIST SEARCHES
-    cy.get('#lei-select').click().type(INSTITUTION + "{enter}")
-    cy.wait(LOCAL_ACTION_DELAY)
-    cy.findAllByText('Update')
-      .eq(1) // First row
-      .click()
+    it('Can update existing Institutions', () => {
+      cy.get({
+        HOST,
+        ENVIRONMENT,
+        AUTH_BASE_URL,
+        AUTH_CLIENT_ID,
+        AUTH_REALM,
+        USERNAME,
+        PASSWORD,
+        INSTITUTION,
+      }).logEnv()
 
-    const successMessage = `The institution, ${INSTITUTION}, has been updated.`
-    const nameLabelText = 'Respondent Name'
-    const updateButtonText = 'Update the Institution'
-    const testName = 'Cypress Test Name Update'
-    const quarterlyFilerLabel = 'Quarterly Filer'
+      // Log in
+      if (!isCI(ENVIRONMENT)) {
+        cy.hmdaLogin('hmda-help')
+        cy.url().should('contains', `${AUTH_BASE_URL}hmda-help`)
+      }
 
-    const timestamp1 = Date.now()
-    cy.findByText('Note History').click()
-    
-    // CI will not have any existing History 
-    if(!isCI(ENVIRONMENT)) {
-      cy.get('.note-list li', { timeout: 30000 })
-      .first()
-      .find('button .text')
-      .should('not.contain.text', timestamp1)
-    } 
+      // Load site
+      cy.viewport(1600, 900)
+      cy.visit(`${HOST}/hmda-help`)
+      cy.wait(LOCAL_ACTION_DELAY)
 
-    cy.findByLabelText(nameLabelText).then(($name) => {
-      const savedName = $name.attr('value')
+      // Search for existing Instititution
+      cy.wait(5000) // HACK TO ALLOW CASCADING FILER LIST SEARCHES
+      cy.get('#lei-select')
+        .click()
+        .type(INSTITUTION + '{enter}')
+      cy.wait(LOCAL_ACTION_DELAY)
+      cy.findAllByText('Update')
+        .eq(1) // First row
+        .click()
 
-      cy.findByLabelText(quarterlyFilerLabel).then(($qFiler) => {
-        const savedQFiler = getSelectedOptionValue($qFiler, 'false')
-        const flippedQFilerVal =
-          ['true'].indexOf(savedQFiler) > -1 ? 'false' : 'true'
+      const successMessage = `The institution, ${INSTITUTION}, has been updated.`
+      const nameLabelText = 'Respondent Name'
+      const updateButtonText = 'Update the Institution'
+      const testName = 'Cypress Test Name Update'
+      const quarterlyFilerLabel = 'Quarterly Filer'
 
-        /**
-         * Make changes to the Institution data
-         */
+      const timestamp1 = Date.now()
+      cy.findByText('Note History').click()
 
-        // Change Respondent Name [Text Field]
-        cy.findByLabelText(nameLabelText)
-          .type('{selectAll}' + testName)
-          .blur()
-          .then(($name2) => {
-            // Flip Quarterly Filer value [Select Field]
-            cy.findByLabelText(quarterlyFilerLabel)
-              .select(flippedQFilerVal)
-              .blur()
-              .then(($qFiler2) => {
-                // Notes field is required on Update
-                cy.findByText(updateButtonText).should('not.be.enabled')
-                cy.findByLabelText('Notes')
-                  .type('Cypress - Change respondent name ' + timestamp1)
-                  .blur()
-                cy.findByText(updateButtonText)
-                  .should('be.enabled')
-                  .click()
-                  .then(() => {
-                    // Validate
-                    cy.findAllByText(successMessage)
-                      .should('exist')
-                      .then(() => {
-                        expect($name2.attr('value')).to.contain(testName)
-                        expect(getSelectedOptionValue($qFiler2)).to.contain(
-                          flippedQFilerVal
-                        )
+      // CI will not have any existing History
+      if (!isCI(ENVIRONMENT)) {
+        cy.get('.note-list li', { timeout: 30000 })
+          .first()
+          .find('button .text')
+          .should('not.contain.text', timestamp1)
+      }
 
-                        // Check Note History entry correctly created
-                        if (isCI(ENVIRONMENT) && NOTE_HISTORY_ON_CI_FIXED) {
-                          cy.wait(2000)
-                          cy.get('.note-list li').first().as('firstNote')
-                          cy.get('@firstNote')
-                            .find('button .text')
-                            .should('contain.text', timestamp1)
-                          cy.get('@firstNote')
-                            .find('.details tbody td')
-                            .eq(0)
-                            .should('contain.text', 'respondent')
-                            .should('contain.text', 'name')
-                          cy.get('@firstNote')
-                            .find('.details tbody td')
-                            .eq(1)
-                            .should('contain.text', savedName)
-                          cy.get('@firstNote')
-                            .find('.details tbody td')
-                            .eq(2)
-                            .should('contain.text', testName)
-                        }
-                      })
-                  })
-              })
-          })
+      cy.findByLabelText(nameLabelText).then($name => {
+        const savedName = $name.attr('value')
 
-        /**
-         * Revert changes to the Institution data
-         */
-        cy.findByLabelText(nameLabelText)
-          .type('{selectAll}' + savedName)
-          .blur()
-        cy.findByLabelText(quarterlyFilerLabel).select(savedQFiler).blur()
+        cy.findByLabelText(quarterlyFilerLabel).then($qFiler => {
+          const savedQFiler = getSelectedOptionValue($qFiler, 'false')
+          const flippedQFilerVal =
+            ['true'].indexOf(savedQFiler) > -1 ? 'false' : 'true'
 
-        // Notes field is required on Update
-        cy.findByText(updateButtonText).should('not.be.enabled')
-        cy.findByLabelText('Notes')
-          .type('Cypress - Change respondent name back')
-          .blur()
-          .then(() => {
-            cy.wait(LOCAL_ACTION_DELAY)
-            cy.findByText(updateButtonText)
-              .should('be.enabled')
-              .click()
-              .then(() => {
-                // Validate
-                cy.findAllByText(successMessage)
-                  .should('exist')
-                  .then(() => {
-                    expect($name.attr('value')).to.contain(savedName)
-                    expect(getSelectedOptionValue($qFiler)).to.contain(
-                      savedQFiler
-                    )
-                  })
-              })
-          })
+          /**
+           * Make changes to the Institution data
+           */
+
+          // Change Respondent Name [Text Field]
+          cy.findByLabelText(nameLabelText)
+            .type('{selectAll}' + testName)
+            .blur()
+            .then($name2 => {
+              // Flip Quarterly Filer value [Select Field]
+              cy.findByLabelText(quarterlyFilerLabel)
+                .select(flippedQFilerVal)
+                .blur()
+                .then($qFiler2 => {
+                  // Notes field is required on Update
+                  cy.findByText(updateButtonText).should('not.be.enabled')
+                  cy.findByLabelText('Notes')
+                    .type('Cypress - Change respondent name ' + timestamp1)
+                    .blur()
+                  cy.findByText(updateButtonText)
+                    .should('be.enabled')
+                    .click()
+                    .then(() => {
+                      // Validate
+                      cy.findAllByText(successMessage)
+                        .should('exist')
+                        .then(() => {
+                          expect($name2.attr('value')).to.contain(testName)
+                          expect(getSelectedOptionValue($qFiler2)).to.contain(
+                            flippedQFilerVal
+                          )
+
+                          // Check Note History entry correctly created
+                          if (isCI(ENVIRONMENT) && NOTE_HISTORY_ON_CI_FIXED) {
+                            cy.wait(2000)
+                            cy.get('.note-list li').first().as('firstNote')
+                            cy.get('@firstNote')
+                              .find('button .text')
+                              .should('contain.text', timestamp1)
+                            cy.get('@firstNote')
+                              .find('.details tbody td')
+                              .eq(0)
+                              .should('contain.text', 'respondent')
+                              .should('contain.text', 'name')
+                            cy.get('@firstNote')
+                              .find('.details tbody td')
+                              .eq(1)
+                              .should('contain.text', savedName)
+                            cy.get('@firstNote')
+                              .find('.details tbody td')
+                              .eq(2)
+                              .should('contain.text', testName)
+                          }
+                        })
+                    })
+                })
+            })
+
+          /**
+           * Revert changes to the Institution data
+           */
+          cy.findByLabelText(nameLabelText)
+            .type('{selectAll}' + savedName)
+            .blur()
+          cy.findByLabelText(quarterlyFilerLabel).select(savedQFiler).blur()
+
+          // Notes field is required on Update
+          cy.findByText(updateButtonText).should('not.be.enabled')
+          cy.findByLabelText('Notes')
+            .type('Cypress - Change respondent name back')
+            .blur()
+            .then(() => {
+              cy.wait(LOCAL_ACTION_DELAY)
+              cy.findByText(updateButtonText)
+                .should('be.enabled')
+                .click()
+                .then(() => {
+                  // Validate
+                  cy.findAllByText(successMessage)
+                    .should('exist')
+                    .then(() => {
+                      expect($name.attr('value')).to.contain(savedName)
+                      expect(getSelectedOptionValue($qFiler)).to.contain(
+                        savedQFiler
+                      )
+                    })
+                })
+            })
+        })
       })
     })
-  })
 
-  it('Can delete and create Institutions', () => {
-    cy.get({
-      HOST,
-      ENVIRONMENT,
-      AUTH_BASE_URL,
-      AUTH_CLIENT_ID,
-      AUTH_REALM,
-      USERNAME,
-      PASSWORD,
-      INSTITUTION,
-    }).logEnv()
-    
-    // Log in
-    if (!isCI(ENVIRONMENT)) {
-      cy.hmdaLogin('hmda-help')
-      cy.url().should('contains', `${AUTH_BASE_URL}hmda-help/`)
-    }
+    it('Can delete and create Institutions', () => {
+      cy.get({
+        HOST,
+        ENVIRONMENT,
+        AUTH_BASE_URL,
+        AUTH_CLIENT_ID,
+        AUTH_REALM,
+        USERNAME,
+        PASSWORD,
+        INSTITUTION,
+      }).logEnv()
 
-    // Load site
-    cy.viewport(1600, 900)
-    cy.visit(`${HOST}/hmda-help/`)
-    cy.wait(LOCAL_ACTION_DELAY)
+      // Log in
+      if (!isCI(ENVIRONMENT)) {
+        cy.hmdaLogin('hmda-help')
+        cy.url().should('contains', `${AUTH_BASE_URL}hmda-help`)
+      }
 
-    const institution = 'MEISSADIATESTBANK001'
-    const year = years[0].toString()
+      // Load site
+      cy.viewport(1600, 900)
+      cy.visit(`${HOST}/hmda-help`)
+      cy.wait(LOCAL_ACTION_DELAY)
 
-    // Delete
-    cy.wait(5000) // HACK TO ALLOW CASCADING FILER LIST SEARCHES
-    cy.get('#lei-select').click().type(`${institution}{enter}`)
-    cy.wait(LOCAL_ACTION_DELAY)
-    cy.get('table.institutions tbody tr')
-      .first()
-      .get('td')
-      .first()
-      .should('contain', year)
-    cy.findAllByText('Delete').first().click()
-    cy.findAllByText('Yes').first().click()
-    cy.get('table.institutions tbody tr')
-      .first()
-      .get('td')
-      .first()
-      .should('not.contain', year)
+      const institution = 'MEISSADIATESTBANK001'
+      const year = years[0].toString()
 
-    // Create
-    cy.wait(LOCAL_ACTION_DELAY)
-    cy.visit(`${HOST}/hmda-help/`)
-    cy.wait(5000) // HACK TO ALLOW CASCADING FILER LIST SEARCHES
-    cy.get('#lei-select').click().type('MEISSADIATESTBANK001{enter}')
-    cy.wait(LOCAL_ACTION_DELAY)
-    cy.findByText(`Add ${institution} for ${year}`).click()
+      // Delete
+      cy.wait(5000) // HACK TO ALLOW CASCADING FILER LIST SEARCHES
+      cy.get('#lei-select').click().type(`${institution}{enter}`)
+      cy.wait(LOCAL_ACTION_DELAY)
+      cy.get('table.institutions tbody tr')
+        .first()
+        .get('td')
+        .first()
+        .should('contain', year)
+      cy.findAllByText('Delete').first().click()
+      cy.findAllByText('Yes').first().click()
+      cy.get('table.institutions tbody tr')
+        .first()
+        .get('td')
+        .first()
+        .should('not.contain', year)
 
-    cy.findByLabelText('Activity Year').select(year).should('have.value', year)
-    cy.findByLabelText('Respondent Name').type('MD Bank 1')
-    cy.findByLabelText('Email Domains').type('bank1.com')
-    cy.findByLabelText('Tax Id').type('53-0000001')
-    cy.findByLabelText(
-      '9 - Consumer Financial Protection Bureau (CFPB)'
-    ).click()
-    cy.findByLabelText('Quarterly Filer')
-      .select('true')
-      .should('have.value', 'true')
+      // Create
+      cy.wait(LOCAL_ACTION_DELAY)
+      cy.visit(`${HOST}/hmda-help`)
+      cy.wait(5000) // HACK TO ALLOW CASCADING FILER LIST SEARCHES
+      cy.get('#lei-select').click().type('MEISSADIATESTBANK001{enter}')
+      cy.wait(LOCAL_ACTION_DELAY)
+      cy.findByText(`Add ${institution} for ${year}`).click()
 
-    cy.findByText('Show other fields').click()
-    cy.findByLabelText('RSSD').type('-1')
-    cy.findByLabelText('Parent ID RSSD').type('-1')
-    cy.findByLabelText('Assets').type('-1')
-    cy.findByLabelText('Top Holder ID RSSD').type('-1')
+      cy.findByLabelText('Activity Year')
+        .select(year)
+        .should('have.value', year)
+      cy.findByLabelText('Respondent Name').type('MD Bank 1')
+      cy.findByLabelText('Email Domains').type('bank1.com')
+      cy.findByLabelText('Tax Id').type('53-0000001')
+      cy.findByLabelText(
+        '9 - Consumer Financial Protection Bureau (CFPB)'
+      ).click()
+      cy.findByLabelText('Quarterly Filer')
+        .select('true')
+        .should('have.value', 'true')
 
-    cy.findByText('Add the Institution').should('be.enabled').click()
+      cy.findByText('Show other fields').click()
+      cy.findByLabelText('RSSD').type('-1')
+      cy.findByLabelText('Parent ID RSSD').type('-1')
+      cy.findByLabelText('Assets').type('-1')
+      cy.findByLabelText('Top Holder ID RSSD').type('-1')
 
-    cy.findAllByText(`The institution, ${institution}, has been added!`).should(
-      'exist'
-    )
+      cy.findByText('Add the Institution').should('be.enabled').click()
+
+      cy.findAllByText(
+        `The institution, ${institution}, has been added!`
+      ).should('exist')
+    })
   })
 })

--- a/cypress/e2e/hmda-help/publication.spec.js
+++ b/cypress/e2e/hmda-help/publication.spec.js
@@ -1,4 +1,5 @@
-import { isCI, isProd } from '../../support/helpers'
+import { isCI, isProd, isBeta } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
 
 const {
   HOST,
@@ -13,59 +14,74 @@ const {
 
 const ACTION_DELAY = 250
 
-describe('HMDA Help - Publications', () => {
-  it('Can trigger Publication regeneration', () => {
-    cy.get({
-      HOST,
-      ENVIRONMENT,
-      AUTH_BASE_URL,
-      AUTH_CLIENT_ID,
-      AUTH_REALM,
-      USERNAME,
-      PASSWORD,
-      INSTITUTION,
-    }).logEnv()
-    
-    cy.on('window:confirm', () => true)
+onlyOn(isBeta(HOST), () => {
+  describe('HMDA Help - Publications', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
 
-    // Log in
-    if (!isCI(ENVIRONMENT)) {
-      cy.wait(ACTION_DELAY)
-      cy.hmdaLogin('hmda-help')
-      cy.url().should('contains', `${AUTH_BASE_URL}hmda-help/`)
-    }
-    
-    // Load site
-    cy.viewport(1600, 900)
-    cy.visit(`${HOST}/hmda-help/`)
-    cy.wait(ACTION_DELAY)
+onlyOn(!isBeta(HOST), () => {
+  describe('HMDA Help - Publications', () => {
+    it('Can trigger Publication regeneration', () => {
+      cy.get({
+        HOST,
+        ENVIRONMENT,
+        AUTH_BASE_URL,
+        AUTH_CLIENT_ID,
+        AUTH_REALM,
+        USERNAME,
+        PASSWORD,
+        INSTITUTION,
+      }).logEnv()
 
-    // Search for existing Instititution
-    cy.wait(5000) // HACK TO ALLOW CASCADING FILER LIST SEARCHES
-    cy.get('#lei-select').click().type(INSTITUTION + "{enter}")
-    cy.wait(2*ACTION_DELAY)
-    cy.findByText('Search Publications').click()
-    cy.wait(ACTION_DELAY)
+      cy.on('window:confirm', () => true)
 
-    // Trigger Publication regeneration
-    cy.findAllByText('IRS')
-      .parent('tr')
-      .last()
-      .findByText('Regenerate')
-      .should('not.have.class', 'disabled')
-      .as('lastRow')
-      .click()
-      
-    cy.get('@lastRow').parent('div').should('contain.text', 'triggered!')
-
-    if (isProd(HOST)) {
-      // Has valid Download links
-      cy.findAllByText('Download').each(link => {
-        cy.get(link).hasValidHref().then(({ status, url }) => {
-          assert.isTrue(status, `"${link.text()}" is a valid link. URL: ${url}`)
-        })
+      // Log in
+      if (!isCI(ENVIRONMENT)) {
         cy.wait(ACTION_DELAY)
-      })
-    }
+        cy.hmdaLogin('hmda-help')
+        cy.url().should('contains', `${AUTH_BASE_URL}hmda-help`)
+      }
+
+      // Load site
+      cy.viewport(1600, 900)
+      cy.visit(`${HOST}/hmda-help`)
+      cy.wait(ACTION_DELAY)
+
+      // Search for existing Instititution
+      cy.wait(5000) // HACK TO ALLOW CASCADING FILER LIST SEARCHES
+      cy.get('#lei-select')
+        .click()
+        .type(INSTITUTION + '{enter}')
+      cy.wait(2 * ACTION_DELAY)
+      cy.findByText('Search Publications').click()
+      cy.wait(ACTION_DELAY)
+
+      // Trigger Publication regeneration
+      cy.findAllByText('IRS')
+        .parent('tr')
+        .last()
+        .findByText('Regenerate')
+        .should('not.have.class', 'disabled')
+        .as('lastRow')
+        .click()
+
+      cy.get('@lastRow').parent('div').should('contain.text', 'triggered!')
+
+      if (isProd(HOST)) {
+        // Has valid Download links
+        cy.findAllByText('Download').each(link => {
+          cy.get(link)
+            .hasValidHref()
+            .then(({ status, url }) => {
+              assert.isTrue(
+                status,
+                `"${link.text()}" is a valid link. URL: ${url}`
+              )
+            })
+          cy.wait(ACTION_DELAY)
+        })
+      }
+    })
   })
 })

--- a/cypress/e2e/tools/CheckDigitTool.spec.js
+++ b/cypress/e2e/tools/CheckDigitTool.spec.js
@@ -5,7 +5,12 @@ const { HOST, TEST_DELAY, ENVIRONMENT } = Cypress.env()
 
 onlyOn(!isCI(ENVIRONMENT) && (isBeta(HOST) || !isProd(HOST)), () => {
   describe("Check Digit Tool UI", function() {
-    it(`Does not run on ${HOST}`, () => {})
+    it(
+      isBeta(HOST)
+        ? 'Does not run in Beta environments'
+        : `Does not run on ${HOST}`,
+      () => {}
+    )
   })
 })
 

--- a/cypress/e2e/tools/FFVT.spec.js
+++ b/cypress/e2e/tools/FFVT.spec.js
@@ -1,3 +1,6 @@
+import { isBeta } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
+
 const { HOST, TEST_DELAY, ENVIRONMENT } = Cypress.env()
 
 // Test files
@@ -11,83 +14,104 @@ const INVALID_FILE_ENCODING = 'FFVT-Invalid-utf16.txt'
 // Helper functions
 const isValid = () => cy.get('.alert-success').contains('Congratulations')
 
-const isNotValid = () => cy.get('.alert-error .alert-heading').contains('Invalid File')
+const isNotValid = () =>
+  cy.get('.alert-error .alert-heading').contains('Invalid File')
 
-const isNotTxt = () => cy.get('.alert-error .alert-text')
-  .contains('The file you uploaded is not a text file (.txt). Please check your file and re-upload.')
-  .should('have.length', 1)
+const isNotTxt = () =>
+  cy
+    .get('.alert-error .alert-text')
+    .contains(
+      'The file you uploaded is not a text file (.txt). Please check your file and re-upload.'
+    )
+    .should('have.length', 1)
 
-const isNotUTF8 = () => cy.get('.alert-error .alert-text')
-  .contains('Verify that your file is UTF-8 encoded.')
-  .should('have.length', 1)
+const isNotUTF8 = () =>
+  cy
+    .get('.alert-error .alert-text')
+    .contains('Verify that your file is UTF-8 encoded.')
+    .should('have.length', 1)
 
 const uploadFile = filename => {
-  cy.fixture(filename).then((fileContent) => {
-    cy.get('div > .UploadForm > .container-upload > .dropzone > input')
-      .attachFile({
-        fileContent,
-        fileName: filename,
-        mimeType: 'text/plain',
-      })
-  })  
+  cy.fixture(filename).then(fileContent => {
+    cy.get(
+      'div > .UploadForm > .container-upload > .dropzone > input'
+    ).attachFile({
+      fileContent,
+      fileName: filename,
+      mimeType: 'text/plain',
+    })
+  })
 }
 
+onlyOn(isBeta(HOST), () => {
+  describe('FFVT', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
+
 // Spec
-describe('FFVT', () => {
-  beforeEach(() => {
-    cy.viewport(1680, 916)
-    cy.visit(`${HOST}/tools/file-format-verification`)
-    cy.get({ HOST, TEST_DELAY, ENVIRONMENT }).logEnv()
-    cy.get("div > .UploadForm > .container-upload > .dropzone > input")
-      .click({ force: true })
-  })
+onlyOn(!isBeta(HOST), () => {
+  describe('FFVT', () => {
+    beforeEach(() => {
+      cy.viewport(1680, 916)
+      cy.visit(`${HOST}/tools/file-format-verification`)
+      cy.get({ HOST, TEST_DELAY, ENVIRONMENT }).logEnv()
+      cy.get('div > .UploadForm > .container-upload > .dropzone > input').click(
+        { force: true }
+      )
+    })
 
-  afterEach(() => cy.wait(TEST_DELAY))
- 
-  it(`Validates a clean file`, () => {
-    uploadFile(CLEAN_FILE)
-    isValid()
-  })
+    afterEach(() => cy.wait(TEST_DELAY))
 
-  it(`Validates a clean file with BOM`, () => {
-    uploadFile(CLEAN_FILE_BOM)
-    isValid()
-  })
+    it(`Validates a clean file`, () => {
+      uploadFile(CLEAN_FILE)
+      isValid()
+    })
 
-  it(`Catches formatting errors in a file`, () => {
-    uploadFile(PARSE_ERROR_FILE)
-    cy.get('#parseErrors .alert-heading').contains('2 Formatting Errors')
+    it(`Validates a clean file with BOM`, () => {
+      uploadFile(CLEAN_FILE_BOM)
+      isValid()
+    })
 
-    // TS Error
-    cy.get('tbody:first > tr > :nth-child(1)').contains('1')
-    cy.get('tbody:first > tr > :nth-child(2)').contains('Federal Agency')
-    cy.get('tbody:first > tr > :nth-child(3)').contains('taco')
-    cy.get('tbody:first > tr > :nth-child(4)').contains('Integer')
+    it(`Catches formatting errors in a file`, () => {
+      uploadFile(PARSE_ERROR_FILE)
+      cy.get('#parseErrors .alert-heading').contains('2 Formatting Errors')
 
-    // LAR Error
-    cy.get('tbody:not(:first) > tr > :nth-child(1)').contains('11')
-    cy.get('tbody:not(:first) > tr > :nth-child(2)').contains('MEISSADIATESTBANK001MGJIPL5D07WUU8HO33EPNI975')
-    cy.get('tbody:not(:first) > tr > :nth-child(3)').contains('Incorrect Number of LAR Fields')
-    cy.get('tbody:not(:first) > tr > :nth-child(4)').contains('109')
-    cy.get('tbody:not(:first) > tr > :nth-child(5)').contains('110 Fields')
-  })
+      // TS Error
+      cy.get('tbody:first > tr > :nth-child(1)').contains('1')
+      cy.get('tbody:first > tr > :nth-child(2)').contains('Federal Agency')
+      cy.get('tbody:first > tr > :nth-child(3)').contains('taco')
+      cy.get('tbody:first > tr > :nth-child(4)').contains('Integer')
 
-  it('Catches invalid file extension', () => {
-    uploadFile(INVALID_FILE_1)
-    isNotValid()
-    isNotTxt()
-  })
+      // LAR Error
+      cy.get('tbody:not(:first) > tr > :nth-child(1)').contains('11')
+      cy.get('tbody:not(:first) > tr > :nth-child(2)').contains(
+        'MEISSADIATESTBANK001MGJIPL5D07WUU8HO33EPNI975'
+      )
+      cy.get('tbody:not(:first) > tr > :nth-child(3)').contains(
+        'Incorrect Number of LAR Fields'
+      )
+      cy.get('tbody:not(:first) > tr > :nth-child(4)').contains('109')
+      cy.get('tbody:not(:first) > tr > :nth-child(5)').contains('110 Fields')
+    })
 
-  it('Catches invalid file encoding', () => {
-    uploadFile(INVALID_FILE_ENCODING)
-    isNotValid()
-    isNotUTF8()
-  })
-  
-  it('Catches multiple file validity issues', () => {
-    uploadFile(INVALID_FILE_2)
-    isNotValid()
-    isNotUTF8()
-    isNotTxt()
+    it('Catches invalid file extension', () => {
+      uploadFile(INVALID_FILE_1)
+      isNotValid()
+      isNotTxt()
+    })
+
+    it('Catches invalid file encoding', () => {
+      uploadFile(INVALID_FILE_ENCODING)
+      isNotValid()
+      isNotUTF8()
+    })
+
+    it('Catches multiple file validity issues', () => {
+      uploadFile(INVALID_FILE_2)
+      isNotValid()
+      isNotUTF8()
+      isNotTxt()
+    })
   })
 })

--- a/cypress/e2e/tools/RateSpread.spec.js
+++ b/cypress/e2e/tools/RateSpread.spec.js
@@ -1,121 +1,139 @@
-import { withFormData, isProdDefault, isCI, isProdBeta } from "../../support/helpers"
+import {
+  withFormData,
+  isProdDefault,
+  isCI,
+  isBeta,
+} from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
 
 const { HOST, TEST_DELAY, ENVIRONMENT } = Cypress.env()
 
-describe("Rate Spread Tool", function() {
-  beforeEach(() => {
-    cy.viewport(1680, 916)
-    cy.visit(`${HOST}/tools/rate-spread`)
+onlyOn(isBeta(HOST), () => {
+  describe('Rate Spread', function () {
+    it('Does not run in Beta environments', () => {})
   })
-  if(isCI(ENVIRONMENT) || !isProdBeta(HOST)) {
-
-    it("Generates Fixed Rate", function() {
-      cy.get({ HOST, TEST_DELAY }).logEnv()
-      cy.get(".item > div > .Form > div > #rateSetDate").clear().click().type("12/16/2019")
-      cy.get(".item > div > .Form > div > #APR").type("3.2")
-      cy.get(".item > div > .Form > div > #loanTerm").click().type("45")
-      cy.get(".grid > .item > div > .Form > input").click()
-
-      // Validate
-      cy.get(".item  .alert").contains("-0.590")
-
-      cy.wait(TEST_DELAY)
-    })
-
-    it("Generates Variable Rate", function() {
-      cy.get({ HOST, TEST_DELAY }).logEnv()
-      cy.get(".Form > fieldset > .unstyled-list > li > #actionTaken1").click()
-      cy.get(
-        ".Form > fieldset > .unstyled-list > li > #amortizationVariable"
-      ).click()
-      cy.get(
-        ".Form > fieldset > .unstyled-list > li > #amortizationVariable"
-      ).type("Variable")
-      cy.get(".item > div > .Form > div > #rateSetDate").clear().click().type("01/22/2018")
-      cy.get(".item > div > .Form > div > #APR").type("2.5")
-      cy.get(".item > div > .Form > div > #loanTerm").click().type("30")
-      cy.get(".grid > .item > div > .Form > input").click()
-
-      // Validate
-      cy.get(".item  .alert").contains("-1.500")
-
-      // Todo: 
-      //   Determine why this trailing wait() causes a pageLoadTimeout error.
-      //   This only seems to be an issue when wait() is the final command of the final test 
-      //   in a large suite, as this error only manifests when running the entire 
-      //   Cypress collection, but not when running the RateSpread specs specificially.
-      // cy.wait(TEST_DELAY) 
-    })
-  } 
-  else {
-    it(`Does not run on ${HOST}`, () => cy.get({ HOST, TEST_DELAY, ENVIRONMENT }).logEnv())
-  }
 })
 
-describe("Rate Spread API", () => {
-  
-  if(isCI(ENVIRONMENT) || !isProdBeta(HOST)) {
-    it("Generates rates from file", () => {
-      cy.get({ HOST, TEST_DELAY, ENVIRONMENT }).logEnv()
-      let response
-      const fileName = "RateSpread_Generate.csv"
-      const method = "POST"
-      const url = `${HOST}/public/rateSpread/csv`
-      const fileType = "application/json"
-      const expectedAnswer =
-        "action_taken_type,loan_term,amortization_type,apr,lock_in_date,reverse_mortgage,rate_spread\n" +
-        "1,30,FixedRate,6.0,2017-11-20,2,2.010\n" +
-        "1,30,VariableRate,6.0,2017-11-20,2,2.150\n"
+onlyOn(!isBeta(HOST), () => {
+  describe('Rate Spread Tool', function () {
+    beforeEach(() => {
+      cy.viewport(1680, 916)
+      cy.visit(`${HOST}/tools/rate-spread`)
+    })
+    if (isCI(ENVIRONMENT) || !isBeta(HOST)) {
+      it('Generates Fixed Rate', function () {
+        cy.get({ HOST, TEST_DELAY }).logEnv()
+        cy.get('.item > div > .Form > div > #rateSetDate')
+          .clear()
+          .click()
+          .type('12/16/2019')
+        cy.get('.item > div > .Form > div > #APR').type('3.2')
+        cy.get('.item > div > .Form > div > #loanTerm').click().type('45')
+        cy.get('.grid > .item > div > .Form > input').click()
 
-      // Get file from fixtures as binary
-      cy.fixture(fileName, "binary").then(excelBin => {
-        // File in binary format gets converted to blob so it can be sent as Form data
-        const blob = Cypress.Blob.binaryStringToBlob(excelBin, fileType)
-
-        // Build up the form
-        const formData = new FormData()
-        formData.set("file", blob, fileName) //adding a file to the form
-        
-        // Perform the request
-        withFormData(method, url, formData, function(res) {
-          response = res
-        })
-
-        cy.wrap(null).should(() => {
-          expect(response.status).to.eq(200)
-          expect(expectedAnswer).to.equal(response.response)
-        })
+        // Validate
+        cy.get('.item  .alert').contains('-0.590')
 
         cy.wait(TEST_DELAY)
       })
-    })
-  }
-  else {
-    it(`Does not run on ${HOST}`, () => cy.get({ HOST, TEST_DELAY, ENVIRONMENT }).logEnv())
-  }
-})
 
-describe('Rate Spread - External Referrer', function () {
-  if (isProdDefault(HOST)) {
-    it('Is accessible from Google search', function () {
-      cy.viewport(1680, 916)
-      cy.visit(`https://www.google.com/search?q=hmda+rate+spread`)
-      cy.get('div#search a').contains('rate-spread').click()
+      it('Generates Variable Rate', function () {
+        cy.get({ HOST, TEST_DELAY }).logEnv()
+        cy.get('.Form > fieldset > .unstyled-list > li > #actionTaken1').click()
+        cy.get(
+          '.Form > fieldset > .unstyled-list > li > #amortizationVariable'
+        ).click()
+        cy.get(
+          '.Form > fieldset > .unstyled-list > li > #amortizationVariable'
+        ).type('Variable')
+        cy.get('.item > div > .Form > div > #rateSetDate')
+          .clear()
+          .click()
+          .type('01/22/2018')
+        cy.get('.item > div > .Form > div > #APR').type('2.5')
+        cy.get('.item > div > .Form > div > #loanTerm').click().type('30')
+        cy.get('.grid > .item > div > .Form > input').click()
 
-      cy.wait(TEST_DELAY)
+        // Validate
+        cy.get('.item  .alert').contains('-1.500')
 
-      cy.get('.item > div > .Form > div > #rateSetDate')
-        .clear()
-        .click()
-        .type('12/16/2019')
-      cy.get('.item > div > .Form > div > #APR').type('3.2')
-      cy.get('.item > div > .Form > div > #loanTerm').click().type('45')
-      cy.get('.grid > .item > div > .Form > input').click()
+        // Todo:
+        //   Determine why this trailing wait() causes a pageLoadTimeout error.
+        //   This only seems to be an issue when wait() is the final command of the final test
+        //   in a large suite, as this error only manifests when running the entire
+        //   Cypress collection, but not when running the RateSpread specs specificially.
+        // cy.wait(TEST_DELAY)
+      })
+    } else {
+      it(`Does not run on ${HOST}`, () =>
+        cy.get({ HOST, TEST_DELAY, ENVIRONMENT }).logEnv())
+    }
+  })
 
-      // Validate
-      cy.get('.item  .alert').contains('-0.590')
+  describe('Rate Spread API', () => {
+    if (isCI(ENVIRONMENT) || !isBeta(HOST)) {
+      it('Generates rates from file', () => {
+        cy.get({ HOST, TEST_DELAY, ENVIRONMENT }).logEnv()
+        let response
+        const fileName = 'RateSpread_Generate.csv'
+        const method = 'POST'
+        const url = `${HOST}/public/rateSpread/csv`
+        const fileType = 'application/json'
+        const expectedAnswer =
+          'action_taken_type,loan_term,amortization_type,apr,lock_in_date,reverse_mortgage,rate_spread\n' +
+          '1,30,FixedRate,6.0,2017-11-20,2,2.010\n' +
+          '1,30,VariableRate,6.0,2017-11-20,2,2.150\n'
 
-      cy.wait(TEST_DELAY)
-    })
-  }
+        // Get file from fixtures as binary
+        cy.fixture(fileName, 'binary').then(excelBin => {
+          // File in binary format gets converted to blob so it can be sent as Form data
+          const blob = Cypress.Blob.binaryStringToBlob(excelBin, fileType)
+
+          // Build up the form
+          const formData = new FormData()
+          formData.set('file', blob, fileName) //adding a file to the form
+
+          // Perform the request
+          withFormData(method, url, formData, function (res) {
+            response = res
+          })
+
+          cy.wrap(null).should(() => {
+            expect(response.status).to.eq(200)
+            expect(expectedAnswer).to.equal(response.response)
+          })
+
+          cy.wait(TEST_DELAY)
+        })
+      })
+    } else {
+      it(`Does not run on ${HOST}`, () =>
+        cy.get({ HOST, TEST_DELAY, ENVIRONMENT }).logEnv())
+    }
+  })
+
+  describe('Rate Spread - External Referrer', function () {
+    if (isProdDefault(HOST)) {
+      it('Is accessible from Google search', function () {
+        cy.viewport(1680, 916)
+        cy.visit(`https://www.google.com/search?q=hmda+rate+spread`)
+        cy.get('div#search a').contains('rate-spread').click()
+
+        cy.wait(TEST_DELAY)
+
+        cy.get('.item > div > .Form > div > #rateSetDate')
+          .clear()
+          .click()
+          .type('12/16/2019')
+        cy.get('.item > div > .Form > div > #APR').type('3.2')
+        cy.get('.item > div > .Form > div > #loanTerm').click().type('45')
+        cy.get('.grid > .item > div > .Form > input').click()
+
+        // Validate
+        cy.get('.item  .alert').contains('-0.590')
+
+        cy.wait(TEST_DELAY)
+      })
+    }
+  })
 })

--- a/cypress/e2e/tools/olarft.spec.js
+++ b/cypress/e2e/tools/olarft.spec.js
@@ -1,5 +1,6 @@
 import { WARN_LOST_UNSAVED } from '../../../src/tools/larft/config/messages'
-import { isCI } from '../../support/helpers'
+import { isCI, isBeta } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
 
 const { HOST, ENVIRONMENT } = Cypress.env()
 
@@ -11,6 +12,13 @@ let urlForTesting = baseURLToVisit + '/tools/online-lar-formatting'
 // Workaround as the IDs have a space in them i.e -> Calendar Year
 Cypress.Commands.add('getID', value => cy.get(`[id="${value}"]`))
 
+onlyOn(isBeta(HOST), () => {
+  describe('Online LAR Formatting Tool', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
+
+onlyOn(!isBeta(HOST), () => {
 describe('General OLART Tests', () => {
   it("Tests 'Filter by label' functionality", () => {
     cy.visit(urlForTesting)
@@ -311,4 +319,5 @@ describe('Record specific tests', () => {
     // LAR should have no records
     cy.get('.no-records').should('have.text', 'No Records Saved')
   })
+})
 })

--- a/cypress/e2e/updates-notes/ChangeLog.spec.js
+++ b/cypress/e2e/updates-notes/ChangeLog.spec.js
@@ -1,68 +1,78 @@
 import log from '../../../src/updates-notes/change-log-data.json'
+import { isBeta } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
 const { HOST } = Cypress.env()
 const EXPECTED_SELECTED_PILLS = ['release', 'documentation', 'tools']
 const entries = log.log
 
-describe('Change Log', () => {
-  describe('Filter Bar', () => {
-    it('Sets Type and Product filters from URL query string', () => {
-      cy.visit(
-        `${HOST}/updates-notes/updates?type=release&product=documentation,tools`
-      )
-      EXPECTED_SELECTED_PILLS.forEach((pillClass) => {
-        cy.get(`#filter-bar .pill.selected.${pillClass}`)
+onlyOn(isBeta(HOST), () => {
+  describe('Change Log', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
+
+onlyOn(!isBeta(HOST), () => {
+  describe('Change Log', () => {
+    describe('Filter Bar', () => {
+      it('Sets Type and Product filters from URL query string', () => {
+        cy.visit(
+          `${HOST}/updates-notes/updates?type=release&product=documentation,tools`
+        )
+        EXPECTED_SELECTED_PILLS.forEach(pillClass => {
+          cy.get(`#filter-bar .pill.selected.${pillClass}`)
+        })
       })
-    })
 
-    it('Applies keyword filter from URL query string', () => {
-      cy.visit(`${HOST}/updates-notes/updates?keywords=2020,tool`)
-      cy.get('.change-row').should('have.length', 2)
-      cy.get('.result-count .body').should(
-        'contain',
-        'Showing ' + 1 + ' out of'
-      )
-      cy.get('.change-row')
-        .find('.highlighted')
-        .its('length')
-        .should('be.gte', 2)
+      it('Applies keyword filter from URL query string', () => {
+        cy.visit(`${HOST}/updates-notes/updates?keywords=2020,tool`)
+        cy.get('.change-row').should('have.length', 2)
+        cy.get('.result-count .body').should(
+          'contain',
+          'Showing ' + 1 + ' out of'
+        )
+        cy.get('.change-row')
+          .find('.highlighted')
+          .its('length')
+          .should('be.gte', 2)
 
-      cy.get('.reset-filters').click()
-      cy.get('.change-row').should('have.length.gte', entries.length + 1)
-      cy.get('.result-count').should('not.exist')
-    })
+        cy.get('.reset-filters').click()
+        cy.get('.change-row').should('have.length.gte', entries.length + 1)
+        cy.get('.result-count').should('not.exist')
+      })
 
-    it('Adds filters to URL', () => {
-      cy.visit(`${HOST}/updates-notes/updates`)
-      cy.get('#filter-bar').findByText('correction').click()
-      cy.url().should('contain', '?type=correction')
-      cy.get('.change-row:not(.header)').should('exist')
+      it('Adds filters to URL', () => {
+        cy.visit(`${HOST}/updates-notes/updates`)
+        cy.get('#filter-bar').findByText('correction').click()
+        cy.url().should('contain', '?type=correction')
+        cy.get('.change-row:not(.header)').should('exist')
 
-      cy.get('#filter-bar').findByText('update').click()
-      cy.get('#filter-bar').findByText('HMDA Tools').click()
-      cy.url().should('contain', '?type=correction,update&product=tools')
-      cy.get('.change-row:not(.header)').should('have.length.gte', 5)
-    })
+        cy.get('#filter-bar').findByText('update').click()
+        cy.get('#filter-bar').findByText('HMDA Tools').click()
+        cy.url().should('contain', '?type=correction,update&product=tools')
+        cy.get('.change-row:not(.header)').should('have.length.gte', 5)
+      })
 
-    it('Filters by keyword', () => {
-      cy.visit(`${HOST}/updates-notes/updates?product=tools`)
-      cy.findByLabelText('by Change Description').type(
-        'The 2017 File Format Verification Tool'
-      )
-      cy.url().should(
-        'contain',
-        'keywords=The,2017,File,Format,Verification,Tool'
-      )
-      cy.get('.change-row').should('have.length', 2)
-      cy.get('.result-count .body').should(
-        'contain',
-        'Showing ' + 1 + ' out of'
-      )
-      cy.log('>> Highlight keywords')
-      cy.get('.change-row .highlighted').should('have.length', 7)
+      it('Filters by keyword', () => {
+        cy.visit(`${HOST}/updates-notes/updates?product=tools`)
+        cy.findByLabelText('by Change Description').type(
+          'The 2017 File Format Verification Tool'
+        )
+        cy.url().should(
+          'contain',
+          'keywords=The,2017,File,Format,Verification,Tool'
+        )
+        cy.get('.change-row').should('have.length', 2)
+        cy.get('.result-count .body').should(
+          'contain',
+          'Showing ' + 1 + ' out of'
+        )
+        cy.log('>> Highlight keywords')
+        cy.get('.change-row .highlighted').should('have.length', 7)
 
-      cy.log('>> Clear keyword search with button')
-      cy.get('.clear-text').click()
-      cy.get('.change-row:not(.header)').should('have.length.gte', 7)
+        cy.log('>> Clear keyword search with button')
+        cy.get('.clear-text').click()
+        cy.get('.change-row:not(.header)').should('have.length.gte', 7)
+      })
     })
   })
 })

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -36,7 +36,7 @@ Cypress.Commands.add("logEnv", { prevSubject: true }, vars => {
 // Login via UI
 Cypress.Commands.add('hmdaLogin', (app) => {
   const { USERNAME, PASSWORD, AUTH_BASE_URL } = Cypress.env()
-  cy.visit(`${AUTH_BASE_URL}${app}/`)
+  cy.visit(`${AUTH_BASE_URL}${app}`)
 
   if (app.match('filing')) cy.get('button[title="Login"').click()
 


### PR DESCRIPTION
Closes #1975

Recommend opening Cypress for Dev, Prod Beta and Prod and run Cypress against all environments. 

**Filing** and **Keycloak** test files are the only tests that should run in `Prod Beta`.

Production should have all test files running except for two files:
- https://github.com/cfpb/hmda-frontend/blob/master/cypress/e2e/data-browser/dataset-filtering-2017.spec.js
- https://github.com/cfpb/hmda-frontend/blob/master/cypress/e2e/data-browser/Switching.spec.js

Dev should have all tests files running except for three files:
- https://github.com/cfpb/hmda-frontend/blob/master/cypress/e2e/data-browser/dataset-filtering-2017.spec.js
- https://github.com/cfpb/hmda-frontend/blob/master/cypress/e2e/data-browser/Switching.spec.js
- https://github.com/cfpb/hmda-frontend/blob/master/cypress/e2e/tools/CheckDigitTool.spec.js