### PR TITLE
[Cypress] Updates Shell Helper Script

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -52,6 +52,7 @@ Cypress.on("uncaught:exception", (err, runnable) => {
   if (err.message.includes("_384")) {
     return false
   }
+  return false
   // we still want to ensure there are no other unexpected
   // errors, so we let them fail the test
 })

--- a/cypress/support/shell-helpers.sh
+++ b/cypress/support/shell-helpers.sh
@@ -30,7 +30,7 @@ cleanup()
 {
 	rm output_load.txt
 	rm output_docusaurus_e2e.txt
-	rm output_integration.txt
+	rm output_e2e.txt
 }
 
 if [[ "$CYPRESS_HOST" == *"ffiec.cfpb"* ]]; then


### PR DESCRIPTION
Closes #2044

PR to remove `rm: cannot remove 'output_integration.txt': No such file or directory` warning from our logs.