### PR TITLE
Updated change log for V695 correction

### DIFF
--- a/src/updates-notes/change-log-data.json
+++ b/src/updates-notes/change-log-data.json
@@ -1,6 +1,18 @@
 {
   "log": [
     {
+      "date": "2/16/24",
+      "type": "correction",
+      "product": "filing",
+      "description": "V695 was corrected on the HMDA Filing Platform to only allow numeric values for Mortgage Loan Originator NMLSR Identifier (Field 95), unless filers are reporting 'NA' or 'Exempt', to conform to the language in the Filing Instructions Guide.",
+      "links": [
+        {
+          "text": "V695 Edit Description",
+          "url": "https://ffiec.cfpb.gov/documentation/fig/2023/overview#table6-V695"
+        }
+      ]
+    },
+    {
       "date": "2/15/24",
       "type": "update",
       "product": "tools",


### PR DESCRIPTION
Added this to the change log: 
<img width="1014" alt="Screenshot 2024-02-16 at 7 37 22 AM" src="https://github.com/cfpb/hmda-frontend/assets/3650300/dd30a134-de24-4ec1-a1b5-bc8bea07bf8e">
