### PR TITLE
Bug fix for Graphs dateRange selector

### DIFF
--- a/src/data-browser/graphs/PeriodSelectors.jsx
+++ b/src/data-browser/graphs/PeriodSelectors.jsx
@@ -34,7 +34,10 @@ export const PeriodSelectors = ({
         <Select
           aria-label='Set lower limit of Filing Period range'
           classNamePrefix='react-select__period_start' // Used for cypress testing
-          options={periodOpts.slice(0, -1)}
+          //options={periodOpts.slice(0, -1)}
+          options={periodOpts.filter((yq) =>
+            periodHigh ? yq.value < periodHigh.value : yq,
+          )}
           onChange={(e) => setPeriodLow(e)}
           value={periodLow}
         />

--- a/src/data-browser/graphs/PeriodSelectors.jsx
+++ b/src/data-browser/graphs/PeriodSelectors.jsx
@@ -34,7 +34,6 @@ export const PeriodSelectors = ({
         <Select
           aria-label='Set lower limit of Filing Period range'
           classNamePrefix='react-select__period_start' // Used for cypress testing
-          //options={periodOpts.slice(0, -1)}
           options={periodOpts.filter((yq) =>
             periodHigh ? yq.value < periodHigh.value : yq,
           )}


### PR DESCRIPTION
Updated dateRange logic to limit periodLow options to less than periodHigh selection. Closes 2153.