### PR TITLE
[Filing] Fix submission route navigation

### DIFF
--- a/src/filing/submission/Nav.jsx
+++ b/src/filing/submission/Nav.jsx
@@ -18,12 +18,6 @@ import './Nav.css'
 export default class EditsNav extends Component {
   constructor(props) {
     super(props)
-    this.handleScroll = this.handleScroll.bind(this)
-    this.state = {
-      fixed: false,
-      headerHeight: 0,
-      editsNavHeight: 0,
-    }
     this.navMap = {
       upload: {
         isReachable: () => true,
@@ -91,40 +85,6 @@ export default class EditsNav extends Component {
     }
   }
 
-  componentDidMount() {
-    window.addEventListener('scroll', this.handleScroll)
-    const header = document.getElementById('header')
-    const userHeading = document.getElementById('userHeading')
-    const editsNav = document.getElementById('editsNav')
-    if (!header || !userHeading || !editsNav) return
-    this.setState({
-      headerHeight: header.clientHeight + userHeading.clientHeight,
-      editsNavHeight: editsNav.clientHeight,
-    })
-  }
-
-  componentDidUpdate() {
-    const currentHeight = document.getElementById('editsNav').clientHeight
-    if (this.state.editsNavHeight !== currentHeight) {
-      this.setState({
-        editsNavHeight: currentHeight,
-      })
-    }
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('scroll', this.handleScroll)
-  }
-
-  handleScroll() {
-    const state = this.state
-    if (window.scrollY >= state.headerHeight) {
-      if (!state.fixed) this.setState({ fixed: true })
-    } else {
-      if (state.fixed) this.setState({ fixed: false })
-    }
-  }
-
   renderNavItem(name, i) {
     const { page, base, code } = this.props
     const navItem = this.navMap[name]
@@ -170,11 +130,9 @@ export default class EditsNav extends Component {
   }
 
   render() {
-    const wrapperHeight = { height: `${this.state.editsNavHeight}px` }
-    const fixed = this.state.fixed ? 'EditsNav-fixed' : ''
     return (
-      <section style={wrapperHeight}>
-        <nav className={`EditsNav ${fixed}`} id='editsNav'>
+      <section style={{ height: 'auto' }}>
+        <nav className={`EditsNav`} id='editsNav'>
           <ul className='nav-primary'>
             {Object.keys(this.navMap).map((name, i) => {
               return this.renderNavItem(name, i)

--- a/src/filing/submission/container.jsx
+++ b/src/filing/submission/container.jsx
@@ -75,7 +75,7 @@ const renderByCode = (code, page, lei, selectedPeriod) => {
     toRender.push(
       <p>
         Something is wrong.{' '}
-        <Link to={`/filing/${filingPeriod}/institutions`}>
+        <Link to={`/filing/${period}/institutions`}>
           Return to institutions
         </Link>
         .

--- a/src/filing/submission/signature/Signature.jsx
+++ b/src/filing/submission/signature/Signature.jsx
@@ -137,7 +137,7 @@ const Signature = ({ lei, isPassed }) => {
   )
 }
 
-Signature.PropTypes = {
+Signature.propTypes = {
   lei: PropTypes.string.isRequired,
   isPassed: PropTypes.bool,
 }

--- a/src/filing/submission/summary/Summary.jsx
+++ b/src/filing/submission/summary/Summary.jsx
@@ -116,7 +116,7 @@ const Summary = ({ filingPeriod }) => {
   )
 }
 
-Summary.PropTypes = {
+Summary.propTypes = {
   filingPeriod: PropTypes.string.isRequired,
 }
 


### PR DESCRIPTION
Closes #2169 

PR includes the following changes:

- Address the bug where navigating to the `/submission` route would redirect users to `/upload`
- Deleted a bit of code related to scroll calculations for having the Progress navigation to be fixed
   - This fixed a visual bug that caused the elements below the Navigation to be hidden until the user scrolled on the page
- Fixed some `propType` warnings from the browser console