### PR TITLE
[Panel] Removes note from UI

### DIFF
--- a/src/data-publication/reports/snapshot/SnapshotDataset.jsx
+++ b/src/data-publication/reports/snapshot/SnapshotDataset.jsx
@@ -77,7 +77,7 @@ export const SnapshotDataset = ({ label, match, config, dataKey }) => {
         <div className='grid'>
           <div className='item'>
             <Heading type={4} headingText={year + ' Datasets'} />
-            {renderDatasets(dataForYear, year, dataKey)}
+            {renderDatasets(dataForYear)}
           </div>
           <div className='item'>{renderDocumentation(dataForYear, year)}</div>
         </div>

--- a/src/data-publication/reports/snapshot/snapshotHelpers.jsx
+++ b/src/data-publication/reports/snapshot/snapshotHelpers.jsx
@@ -47,50 +47,26 @@ export function linkToSpecs(year = '2018') {
 /**
  * Renders a formatted list of Datasets
  */
-export function renderDatasets(
-  { datasets, exception },
-  selectedYear,
-  datasetType,
-) {
+export function renderDatasets({ datasets, exception }) {
   if (!datasets) return <p>{exception}</p>
-
-  // One Year 2022 and Three Year 2020 Reporter Panel files are not going to be ready for 2023 Data Publication
-  // Adding extra logic to target these years and the files to display a message to users that the files are missing
-  // Remove the logic once the data team has generated these files and is made available
-  const displayMessage = `Files for ${selectedYear} are not available at this time`
-
-  const shouldDisplayMessage =
-    (selectedYear === '2022' && datasetType === 'oneYear') ||
-    (selectedYear === '2020' && datasetType === 'threeYear')
 
   return (
     <ul id='datasetList'>
       {datasets.map((dataset, i) => {
-        const isReporterPanel = dataset.dataKey === 'panel'
-
         return (
           <li key={i}>
             <LabelWithTooltip {...dataset} />
-
             <ul className='dataset-items'>
-              {isReporterPanel && shouldDisplayMessage ? (
-                <li>
-                  <p>{displayMessage}</p>
-                </li>
-              ) : (
-                <>
-                  <S3DatasetLink
-                    url={dataset.csv}
-                    label='CSV'
-                    showLastUpdated={true}
-                  />
-                  <S3DatasetLink
-                    url={dataset.txt}
-                    label='Pipe Delimited'
-                    showLastUpdated={true}
-                  />
-                </>
-              )}
+              <S3DatasetLink
+                url={dataset.csv}
+                label='CSV'
+                showLastUpdated={true}
+              />
+              <S3DatasetLink
+                url={dataset.txt}
+                label='Pipe Delimited'
+                showLastUpdated={true}
+              />
             </ul>
           </li>
         )
@@ -98,6 +74,7 @@ export function renderDatasets(
     </ul>
   )
 }
+
 /**
  * Render documentation links
  */


### PR DESCRIPTION
Closes #2254

Removes note about files not being available from the UI for 2022 One Year and 2020 Three Year `panel` files.

<img width="381" alt="image" src="https://github.com/user-attachments/assets/0e2b7d63-b3c1-46f9-a60b-220704026d4d">
