### PR TITLE
[Cypress + Maps] Add additional test coverage for State and County

### DIFF
--- a/cypress/e2e/data-browser/maps.spec.js
+++ b/cypress/e2e/data-browser/maps.spec.js
@@ -66,6 +66,61 @@ onlyOn(!isBeta(HOST), () => {
       ).should('contain', '15.88%')
     })
 
+    it('County 2023', () => {
+      cy.get({ HOST, ENVIRONMENT }).logEnv()
+      cy.viewport(1000, 940)
+      cy.visit(mapsURL(HOST, '2023?geography=county'))
+      deleteBetaBanner(HOST)
+
+      openSelector('#map-filter-1').type('denied{enter}')
+      openSelector('#map-filter-2').type('age 55{enter}')
+
+      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
+      cy.get('.mapboxgl-canvas').click()
+
+      cy.get('.maps-nav-bar .feature').should('contain', 'GREENWOOD COUNTY, KS')
+      cy.get('.maps-nav-bar .left .count').should('contain', '1')
+      cy.get('.maps-nav-bar .right .count').should('contain', '0.08')
+
+      cy.get('.summary-page .featureName > .colorTextWithBias').should(
+        'contain',
+        'GREENWOOD COUNTY, KS',
+      )
+      cy.get('.summary-page .count').should('contain', '1')
+
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', 'Application denied')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '14')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '10.29%')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '1')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '4.35%')
+
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', '55-64')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '23')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '16.91%')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '1')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '7.14%')
+    })
+
     it('State 2022', () => {
       cy.get({ HOST, ENVIRONMENT }).logEnv()
       cy.viewport(1000, 940)
@@ -121,6 +176,61 @@ onlyOn(!isBeta(HOST), () => {
       ).should('contain', '16.55%')
     })
 
+    it('County 2022', () => {
+      cy.get({ HOST, ENVIRONMENT }).logEnv()
+      cy.viewport(1000, 940)
+      cy.visit(mapsURL(HOST, '2022?geography=county'))
+      deleteBetaBanner(HOST)
+
+      openSelector('#map-filter-1').type('denied{enter}')
+      openSelector('#map-filter-2').type('age 55{enter}')
+
+      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
+      cy.get('.mapboxgl-canvas').click()
+
+      cy.get('.maps-nav-bar .feature').should('contain', 'GREENWOOD COUNTY, KS')
+      cy.get('.maps-nav-bar .left .count').should('contain', '3')
+      cy.get('.maps-nav-bar .right .count').should('contain', '0.25')
+
+      cy.get('.summary-page .featureName > .colorTextWithBias').should(
+        'contain',
+        'GREENWOOD COUNTY, KS',
+      )
+      cy.get('.summary-page .count').should('contain', '3')
+
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', 'Application denied')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '25')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '18.25%')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '3')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '12.50%')
+
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', '55-64')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '24')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '17.52%')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '3')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '12.00%')
+    })
+
     it('State 2021', () => {
       cy.get({ HOST, ENVIRONMENT }).logEnv()
       cy.viewport(1000, 940)
@@ -174,6 +284,116 @@ onlyOn(!isBeta(HOST), () => {
       cy.get(
         '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)',
       ).should('contain', '18.24%')
+    })
+
+    it('County 2021', () => {
+      cy.get({ HOST, ENVIRONMENT }).logEnv()
+      cy.viewport(1000, 940)
+      cy.visit(mapsURL(HOST, '2021?geography=county'))
+      deleteBetaBanner(HOST)
+
+      openSelector('#map-filter-1').type('denied{enter}')
+      openSelector('#map-filter-2').type('age 55{enter}')
+
+      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
+      cy.get('.mapboxgl-canvas').click()
+
+      cy.get('.maps-nav-bar .feature').should('contain', 'GREENWOOD COUNTY, KS')
+      cy.get('.maps-nav-bar .left .count').should('contain', '11')
+      cy.get('.maps-nav-bar .right .count').should('contain', '1.85')
+
+      cy.get('.summary-page .featureName > .colorTextWithBias').should(
+        'contain',
+        'GREENWOOD COUNTY, KS',
+      )
+      cy.get('.summary-page .count').should('contain', '11')
+
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', 'Application denied')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '27')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '15.08%')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '11')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '25.58%')
+
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', '55-64')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '43')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '24.02%')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '11')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '40.74%')
+    })
+
+    it('State 2020', () => {
+      cy.get({ HOST, ENVIRONMENT }).logEnv()
+      cy.viewport(1000, 940)
+      cy.visit(mapsURL(HOST, '2020?geography=state'))
+      deleteBetaBanner(HOST)
+
+      openSelector('#map-filter-1').type('denied{enter}')
+      openSelector('#map-filter-2').type('age 55{enter}')
+
+      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
+      cy.get('.mapboxgl-canvas').click()
+
+      cy.get('.maps-nav-bar .left .count').should('contain', '2,854')
+      cy.get('.maps-nav-bar .right .count').should('contain', '0.97')
+      cy.get('.maps-nav-bar .feature').should('contain', 'KANSAS')
+
+      cy.get('.summary-page .featureName > .colorTextWithBias').should(
+        'contain',
+        'KANSAS',
+      )
+      cy.get('.summary-page .count').should('contain', '2,854')
+
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', 'Application denied')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '16,361')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '9.22%')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '2,854')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '12.13%')
+
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', '55-64')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '23,527')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '13.26%')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '2,854')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '17.44%')
     })
 
     it('County 2020', () => {
@@ -284,6 +504,116 @@ onlyOn(!isBeta(HOST), () => {
       cy.get(
         '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)',
       ).should('contain', '18.43%')
+    })
+
+    it('County 2019', () => {
+      cy.get({ HOST, ENVIRONMENT }).logEnv()
+      cy.viewport(1000, 940)
+      cy.visit(mapsURL(HOST, '2019?geography=county'))
+      deleteBetaBanner(HOST)
+
+      openSelector('#map-filter-1').type('denied{enter}')
+      openSelector('#map-filter-2').type('age 55{enter}')
+
+      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
+      cy.get('.mapboxgl-canvas').click()
+
+      cy.get('.maps-nav-bar .feature').should('contain', 'GREENWOOD COUNTY, KS')
+      cy.get('.maps-nav-bar .left .count').should('contain', '1')
+      cy.get('.maps-nav-bar .right .count').should('contain', '0.17')
+
+      cy.get('.summary-page .featureName > .colorTextWithBias').should(
+        'contain',
+        'GREENWOOD COUNTY, KS',
+      )
+      cy.get('.summary-page .count').should('contain', '1')
+
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', 'Application denied')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '21')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '15.22%')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '1')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '3.57%')
+
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', '55-64')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '28')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '20.29%')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '1')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '4.76%')
+    })
+
+    it('State 2018', () => {
+      cy.get({ HOST, ENVIRONMENT }).logEnv()
+      cy.viewport(1000, 940)
+      cy.visit(mapsURL(HOST, '2018?geography=state'))
+      deleteBetaBanner(HOST)
+
+      openSelector('#map-filter-1').type('denied{enter}')
+      openSelector('#map-filter-2').type('age 55{enter}')
+
+      cy.wait(ACTION_DELAY) // Allow the map to complete it's initial render
+      cy.get('.mapboxgl-canvas').click()
+
+      cy.get('.maps-nav-bar .left .count').should('contain', '2,782')
+      cy.get('.maps-nav-bar .right .count').should('contain', '0.96')
+      cy.get('.maps-nav-bar .feature').should('contain', 'KANSAS')
+
+      cy.get('.summary-page .featureName > .colorTextWithBias').should(
+        'contain',
+        'KANSAS',
+      )
+      cy.get('.summary-page .count').should('contain', '2,782')
+
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', 'Application denied')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '14,630')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '13.71%')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '2,782')
+      cy.get(
+        '.filter-report-1 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '17.48%')
+
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(1)',
+      ).should('contain', '55-64')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(2)',
+      ).should('contain', '15,917')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(3)',
+      ).should('contain', '14.92%')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(4)',
+      ).should('contain', '2,782')
+      cy.get(
+        '.filter-report-2 > table > tbody > tr.highlight > :nth-child(5)',
+      ).should('contain', '19.02%')
     })
 
     it('County 2018', () => {


### PR DESCRIPTION
Closes #2253 

Further adds test coverage for Maps at the state and county level.

State level coverage for the following years: 2018, 2020, and 2022
County level coverage for the following years: 2019, 2021, 2022 and 2023

Tests are passing against production ✅ 