### PR TITLE
[Change Log] Adds 2024-Q2 Graph Release

### DIFF
--- a/src/updates-notes/change-log-data.json
+++ b/src/updates-notes/change-log-data.json
@@ -1,6 +1,18 @@
 {
   "log": [
     {
+      "date": "10/22/24",
+      "type": "update",
+      "product": "tools",
+      "description": "HMDA Quarterly Graphs have been updated to include data for 2024-Q2.",
+      "links": [
+        {
+          "text": "HMDA Quarterly Graphs",
+          "url": "https://ffiec.cfpb.gov/data-browser/graphs/quarterly"
+        }
+      ]
+    },
+    {
       "date": "10/18/24",
       "type": "update",
       "product": "documentation",


### PR DESCRIPTION
Closes #2305

Adds 2024-Q2 graphs release entry to the change-log.

<img width="779" alt="image" src="https://github.com/user-attachments/assets/f036b5ef-aab1-4c9a-a855-6b87283376f9">
