### PR TITLE
Removed 'agency' from initial sorting in Graphs > Quarterly Filers table

### DIFF
--- a/src/data-browser/graphs/slice/institutionsSlice.js
+++ b/src/data-browser/graphs/slice/institutionsSlice.js
@@ -4,7 +4,6 @@ import { QuarterlyFilerInstitutionApiUrl } from '../constants'
 
 const initialState = {
   sort: [
-    { id: 'agency', desc: false },
     { id: 'name', desc: false },
   ],
 }


### PR DESCRIPTION
Closes 2314. All tests passed in dev.