### PR TITLE
[Bug Fix] Fix page scroll position not resetting on navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import {
 import { AppContext } from './common/appContextHOC'
 
 import './app.css'
+import ScrollToTop from './common/ScrollToTop'
 
 const Homepage = makeAsyncComponent(
   () => import('./homepage'),
@@ -77,27 +78,29 @@ const App = () => {
 
   return (
     <AppContext.Provider value={{ config }}>
-      {showCommonHeader && (
-        <Route
-          path='/'
-          render={(props) => <Header links={headerLinks} {...props} />}
-        />
-      )}
-      {showBetaBanner && <Beta />}
-      <div id='mainWrapper' style={mainWrapperStyles}>
-        <Switch>
-          <Route exact path='/' component={Homepage} />
-          <Route path='/data-browser' component={DataBrowser} />
-          <Route path='/documentation' component={Documentation} />
-          <Route path='/tools' component={Tools} />
-          <Route path='/data-publication' component={DataPublication} />
-          <Route path='/filing' component={Filing} />
-          <Route path='/hmda-help' component={HmdaHelp} />
-          <Route path='/updates-notes' component={UpdatesNotes} />
-          <Route component={NotFound} />
-        </Switch>
-      </div>
-      {showFooter && <Footer config={config} />}
+      <ScrollToTop>
+        {showCommonHeader && (
+          <Route
+            path='/'
+            render={(props) => <Header links={headerLinks} {...props} />}
+          />
+        )}
+        {showBetaBanner && <Beta />}
+        <div id='mainWrapper' style={mainWrapperStyles}>
+          <Switch>
+            <Route exact path='/' component={Homepage} />
+            <Route path='/data-browser' component={DataBrowser} />
+            <Route path='/documentation' component={Documentation} />
+            <Route path='/tools' component={Tools} />
+            <Route path='/data-publication' component={DataPublication} />
+            <Route path='/filing' component={Filing} />
+            <Route path='/hmda-help' component={HmdaHelp} />
+            <Route path='/updates-notes' component={UpdatesNotes} />
+            <Route component={NotFound} />
+          </Switch>
+        </div>
+        {showFooter && <Footer config={config} />}
+      </ScrollToTop>
     </AppContext.Provider>
   )
 }


### PR DESCRIPTION
Closes #2330

Previously, when users navigated between certain pages from the Homepage, the scroll position was maintained from the previous page, causing users to start at a non-zero scroll position. This was particularly noticeable when users navigated from the bottom of a page.

Changes:
- Implemented `ScrollToTop` component to reset scroll position on route changes
- Maintains scroll position for hash links (#) while resetting for regular navigation
- Provides consistent scrolling behavior across all routes