### PR TITLE
Filing Landing Page Login/Create an Account button Update & Cypress Keycloak Test Skip

### DIFF
--- a/cypress/e2e/filing/Keycloak.spec.js
+++ b/cypress/e2e/filing/Keycloak.spec.js
@@ -4,7 +4,13 @@ import { isCI } from '../../support/helpers'
 
 const { HOST, USERNAME, PASSWORD, ENVIRONMENT, YEARS } = Cypress.env()
 
-describe('Keycloak', () => {
+/**
+ * Keycloaks tests are now being skipped due to using Login.gov as the only method of Login as of Jan 1st, 2025.
+ * 
+ * The below tests will remain in code and must not be deleted.
+ */
+
+describe.skip('Keycloak', () => {
   if (isCI(ENVIRONMENT)) it('Does not run on CI')
   else {
     beforeEach(() => {

--- a/src/filing/common/LoginHeader.css
+++ b/src/filing/common/LoginHeader.css
@@ -51,11 +51,7 @@
 }
 
 .login-content .button-container .login-button {
-  max-width: 180px;
-}
-
-.login-content .button-container .register-account {
-  max-width: 180px;
+  max-width: 280px;
 }
 
 .login-gov-icon-button {
@@ -122,10 +118,6 @@
   }
 
   .login-content .button-container .login-button {
-    max-width: 100%;
-  }
-
-  .login-content .button-container .register-account {
     max-width: 100%;
   }
 }

--- a/src/filing/common/LoginHeader.jsx
+++ b/src/filing/common/LoginHeader.jsx
@@ -1,6 +1,7 @@
 import React, { lazy } from 'react'
-import { login, register } from '../utils/keycloak.js'
+import { login } from '../utils/keycloak.js'
 import FilingPeriodsCard from './FilingPeriodsCard'
+import loginGovWhiteLogo from '../images/login-gov-logo-white.svg'
 import LoginGovPromo from './LoginGovPromo'
 
 import './LoginHeader.css'
@@ -52,37 +53,18 @@ const LoginHeader = ({
             disabled={buttonsDisabled}
             title={maintenanceTitle || 'Login'}
           >
-            Log in
-            {/* Delete "Log in" text and uncomment the below code on December 27th, 2024 */}
-            {/* Sign in with{' '}
+            Sign in with{' '}
             <img
               src={loginGovWhiteLogo}
               className='login-gov-icon-button'
               alt='Login.Gov Logo (white)'
-            /> */}
-          </button>
-          <span className='text-small'>or</span>
-          {/* Remove the "Create an account" button on December 27th, 2024 */}
-          <button
-            className='button register-account'
-            onClick={(e) => {
-              e.preventDefault()
-              register()
-            }}
-            disabled={buttonsDisabled}
-            title={maintenanceTitle || 'Register'}
-          >
-            Create an account
+            />
           </button>
         </div>
         <LoginGovPromo />
       </div>
       <div className='filing-periods-container'>
         <FilingPeriodsCard timedGuards={config.timedGuards} />
-        {/* <FilingPeriodsCard
-          timedGuards={testTimedGuards}
-          testDate='2025-04-01'
-        /> */}
       </div>
     </div>
   )


### PR DESCRIPTION
Closes #2353 & Closes #2354

The Login button now says `Sign in with {LoginGov Logo}` and the `Create an Account` button was removed.

## Before:

<img width="598" alt="image" src="https://github.com/user-attachments/assets/573dcab1-27a7-492a-ad48-412593dc590f" />

## After:

<img width="598" alt="image" src="https://github.com/user-attachments/assets/2eff0a94-9900-429b-a100-19dd22d21e3a" />