### PR TITLE
Resolves Prod Beta Banner due to Maintenance Script

### DIFF
--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -2,12 +2,6 @@
   "name": "prod-beta",
   "announcement": [
     {
-      "message": "We will be performing scheduled system maintenance on December 31 from 5PM - 6PM EST. During this time users will be unable to log in to the Filing application or create new accounts.",
-      "type": "warning",
-      "heading": "Scheduled Maintenance",
-      "link": null
-    },
-    {
       "message": "Our beta platform is currently unavailable.",
       "type": "error",
       "heading": "System Temporarily Unavailable",
@@ -17,9 +11,9 @@
   "publicationReleaseYear": "2020",
   "maintenanceMode": true,
   "filingAnnouncement": {
-    "message": "We will be performing scheduled system maintenance on December 31 from 5PM - 6PM EST. During this time users will be unable to log in to the Filing application or create new accounts.",
-    "type": "warning",
-    "heading": "Scheduled Maintenance",
+    "message": "Our beta platform is currently unavailable.",
+    "type": "error",
+    "heading": "System Temporarily Unavailable",
     "endDate": null
   },
   "ffvtAnnouncement": null,


### PR DESCRIPTION
Resolves the banner maintenance confusion on production beta site. Update the prod beta banner to say the service is unavailable.