### PR TITLE
[MLAR] Add 2024 MLAR test coverage

### DIFF
--- a/cypress/e2e/data-publication/CombinedMLAR.spec.js
+++ b/cypress/e2e/data-publication/CombinedMLAR.spec.js
@@ -9,7 +9,7 @@ onlyOn(isBeta(HOST), () => {
   })
 })
 
-const years = [2023, 2022]
+const years = [2024, 2023, 2022]
 onlyOn(!isBeta(HOST), () => {
   describe('Combined MLAR', () => {
     years.forEach((year) => {

--- a/cypress/e2e/data-publication/ModifiedLAR.spec.js
+++ b/cypress/e2e/data-publication/ModifiedLAR.spec.js
@@ -4,6 +4,11 @@ const { HOST } = Cypress.env()
 
 const testCases = [
   {
+    year: 2024,
+    name: 'cypress bank, ssb',
+    institution: '549300I4IUWMEMGLST06',
+  },
+  {
     year: 2023,
     name: 'cypress bank, ssb',
     institution: '549300I4IUWMEMGLST06',


### PR DESCRIPTION
## DRAFT PR

These tests should not be merged until probably the data is loaded into at least Dev, and should probably not be deployed until the steps are completed up to this point in the https://github.com/cfpb/hmda-frontend/issues/2415#:~:text=Merge%20in%20e2e%20tests%20for%202024%20mLAR%20data%2C%20like%20these%20(to%20later%20be%20deployed%20via%20CLI%20after%20changes%20hit%20prod).

Tests will fail until the data is loaded.

The same kind of PR as: https://github.com/cfpb/hmda-frontend/pull/2134

## Changes

1. Adds e2e tests for modified LAR and combined MLAR for 2024

## Testing
- Do the new tests pass?

Closes: #2417 
