### PR TITLE
[MLAR] Add 2024 MLAR to prod config

### DIFF
--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -21,7 +21,7 @@
     }
   ],
   "publicationReleaseYear": "2023",
-  "mlarReleaseYear": "2023",
+  "mlarReleaseYear": "2024",
   "maintenanceMode": false,
   "filingAnnouncement": null,
   "ffvtAnnouncement": null,
@@ -36,6 +36,7 @@
       "2017"
     ],
     "mlar": [
+      "2024",
       "2023",
       "2022",
       "2021",


### PR DESCRIPTION
## Changes

- Adds `2024` to `mlarReleaseYear` and `dataPublicationYears.mlar` to `prod-config.json`

## Testing

1. `dataPublicationYears.mlar`- Does [this page](https://ffiec.cfpb.gov/data-publication/modified-lar/2024) display `2024` mLAR data by institution? (with full data and combined mLAR data coming once the backend completes running the data pipeline for it)

<img width="829" alt="Image" src="https://github.com/user-attachments/assets/3135c407-88e6-417d-bc6e-7d680634c272" />


2. `mlarReleaseYear` - Does the link on the home page direct to `2024` mLAR data?

<img width="629" alt="Image" src="https://github.com/user-attachments/assets/e9699b6e-c593-4a5d-b30a-d0dc0b7ef1e0" />

Related to: #2415 
Closes: #2448 