### PR TITLE
[Security] Update vite and resolve elliptic peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,8 @@
     "jest": "^29.7.0",
     "react-icons": "^4.4.0",
     "serialize-javascript": "5.0.1",
-    "vite": "5.4.12",
-    "vite-plugin-node-polyfills": "^0.19.0",
+    "vite": "5.4.15",
+    "vite-plugin-node-polyfills": "0.22.0",
     "vite-plugin-svgr": "^4.1.0"
   },
   "resolutions": {
@@ -116,7 +116,8 @@
     "browserify-sign": ">=4.2.2",
     "dompurify": "3.2.4",
     "esbuild": "0.25.0",
-    "canvg": "3.0.11"
+    "canvg": "3.0.11",
+    "elliptic": "6.6.1"
   },
   "packageManager": "yarn@4.1.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5195,21 +5195,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.5.3, elliptic@npm:^6.5.5":
-  version: 6.5.6
-  resolution: "elliptic@npm:6.5.6"
-  dependencies:
-    bn.js: "npm:^4.11.9"
-    brorand: "npm:^1.1.0"
-    hash.js: "npm:^1.0.0"
-    hmac-drbg: "npm:^1.0.1"
-    inherits: "npm:^2.0.4"
-    minimalistic-assert: "npm:^1.0.1"
-    minimalistic-crypto-utils: "npm:^1.0.1"
-  checksum: 10c0/635ccd2b3c76a8506071804fc1f7b34db62f8b1b570032f593417f2a84853211d891003ec952730a310577ac30898bc338c91c10d53d4b9e13339896b05420a1
-  languageName: node
-  linkType: hard
-
 "emittery@npm:^0.13.1":
   version: 0.13.1
   resolution: "emittery@npm:0.13.1"
@@ -6724,8 +6709,8 @@ __metadata:
     serialize-javascript: "npm:5.0.1"
     split2: "npm:3.2.2"
     streamsaver: "npm:2.0.6"
-    vite: "npm:5.4.12"
-    vite-plugin-node-polyfills: "npm:^0.19.0"
+    vite: "npm:5.4.15"
+    vite-plugin-node-polyfills: "npm:0.22.0"
     vite-plugin-svgr: "npm:^4.1.0"
     web-streams-ponyfill: "npm:1.4.2"
   languageName: unknown
@@ -11956,15 +11941,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-node-polyfills@npm:^0.19.0":
-  version: 0.19.0
-  resolution: "vite-plugin-node-polyfills@npm:0.19.0"
+"vite-plugin-node-polyfills@npm:0.22.0":
+  version: 0.22.0
+  resolution: "vite-plugin-node-polyfills@npm:0.22.0"
   dependencies:
     "@rollup/plugin-inject": "npm:^5.0.5"
     node-stdlib-browser: "npm:^1.2.0"
   peerDependencies:
     vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
-  checksum: 10c0/807ab14d94a693a3f9ba1e46258eaf8bce9e663d0a5f6a31f43c82d1a95ae0df1a03855e103bf50fa08f7485ffbe201623bf7c78d2ba91075ec5eae1e8a42555
+  checksum: 10c0/f8ddc452eb6fba280977d037f8a6406aa522e69590641ce72ce5bb31c3498856a9f63ab3671bc6a822dcd1ff9ba5cac02cacef4a0e170fd8500cdeeb38c81675
   languageName: node
   linkType: hard
 
@@ -11981,9 +11966,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:5.4.12":
-  version: 5.4.12
-  resolution: "vite@npm:5.4.12"
+"vite@npm:5.4.15":
+  version: 5.4.15
+  resolution: "vite@npm:5.4.15"
   dependencies:
     esbuild: "npm:^0.21.3"
     fsevents: "npm:~2.3.3"
@@ -12020,7 +12005,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/a0f130e3e0c781f54c60ee4b7cccf92c266e4117be1f65ab55c02abc27b29fa70dc0ed05eca54a9983f76450063a47f86db06ac49f28ee96392a0dc362b17da8
+  checksum: 10c0/f8a4893bf9d57fe3ded6dc0a2278e8ded707fc9cf38d5a3255fe3caaeea41c52f29bf4deb5e85c9e8dbc8848e9046a7306727ca3fb7b67847d75ee2f2afda5e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
🚀 It's currently up on dev: `v3.2.4d` 🚀

## Changes

- Updates `vite` to `5.4.12`
- Update `vite-plugin-node-polyfills` to `0.22.0`
  - the most recent `0.23.0` has some bugs with vite/yarn, so holding off on updating to that
- resolve `elliptic` to `6.6.1`
  - `vite-plugin-node-polyfills` is what's pulling in an older version of elliptic at `6.5.6`, but even `0.23.0` wouldn't fix it

## Testing


1. Do the tests pass on Dev?
<img width="745" alt="Screenshot 2025-03-27 at 1 48 28 PM" src="https://github.com/user-attachments/assets/7d8c8f5c-2955-4f96-8d6e-e055d1b90806" />


2. Does the website still work normally?
<img width="1316" alt="Screenshot 2025-03-27 at 1 49 36 PM" src="https://github.com/user-attachments/assets/c5a048b5-a740-4622-a004-0d85cb1d1a7e" />
