### PR TITLE
[e2e] Redirection tests can pull dev config

### DIFF
--- a/cypress/e2e/common-features/redirection.spec.js
+++ b/cypress/e2e/common-features/redirection.spec.js
@@ -1,9 +1,10 @@
-import config from '../../../src/common/constants/prod-config.json'
 import { isBeta } from '../../support/helpers'
 import { onlyOn } from '@cypress/skip-test'
-const years = config.dataPublicationYears
+import { getDefaultConfig } from '../../../src/common/configUtils';
 
 const { HOST } = Cypress.env()
+const config = getDefaultConfig(HOST);
+const years = config.dataPublicationYears;
 
 const FromTo = [
   // Reports that will break if auto-redirect is enabled


### PR DESCRIPTION
## Changes

- allow redirection tests to pull the right config for dev vs prod env

## Testing

1. Do the tests pass in Dev?
_Only expected tests failing on Dev_
![Screenshot 2025-03-28 at 12 36 43 AM](https://github.com/user-attachments/assets/abaf46e3-3ec9-4b22-8a80-bfa04b137be9)


3. Do the tests pass in Prod?
(tests on prod are currently failing due to issues with test data)
