### PR TITLE
[MLAR] Add 2024 mlar release to changelog

### DIFF
--- a/src/updates-notes/change-log-data.json
+++ b/src/updates-notes/change-log-data.json
@@ -7,7 +7,7 @@
       "description": "On March 31, 2025, the 2024 Modified LAR data was released. A combined file containing all financial institutions' LAR records in a single file is also available for users to download.",
       "links": [
         {
-          "text": "View the press release.",
+          "text": "View the press release",
           "url": "https://www.consumerfinance.gov/about-us/newsroom/2024-hmda-data-on-mortgage-lending-now-available/"
         }
       ]


### PR DESCRIPTION
## Changes

- add 2024 MLAR release to changelog

## Testing

1. Does this add MLAR to the changelog?
<img width="776" alt="Screenshot 2025-03-31 at 11 46 46 AM" src="https://github.com/user-attachments/assets/856e651b-d9c3-4f23-8da6-e54c751e8f66" />

2. Do the tests still pass?