### PR TITLE
2409-cypress-14.3

### DIFF
--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -5,11 +5,9 @@ FROM cypress/included:14.3.0
 WORKDIR /hmda-frontend
 
 USER root
-# RUN apt-get update && apt-get install -y curl nodejs npm microsoft-edge-stable
 RUN apt-get update && apt-get install -y curl
 
 COPY cypress/package.json ./
-# RUN npm install cypress@13.5.0 --save-dev
 RUN npm install cypress@14.3.0 --save-dev --force
 RUN npx cypress verify
 

--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -1,18 +1,16 @@
-ARG NODE_VERSION='20.9.0'
-ARG CYPRESS_VERSION='13.5.0'
-
-# Using specific versioned tag that includes Node, Cypress and Edge versions
-FROM cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+# Install Cypress v14.3.0
+FROM cypress/included:14.3.0
 
 # Set working directory
 WORKDIR /hmda-frontend
 
 USER root
-RUN apt-get update && apt-get install -y curl nodejs npm microsoft-edge-stable
-#RUN apt-get install -y curl
+# RUN apt-get update && apt-get install -y curl nodejs npm microsoft-edge-stable
+RUN apt-get update && apt-get install -y curl
 
 COPY cypress/package.json ./
-RUN npm install cypress@13.5.0 --save-dev
+# RUN npm install cypress@13.5.0 --save-dev
+RUN npm install cypress@14.3.0 --save-dev --force
 RUN npx cypress verify
 
 # Prepare working directory

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@cypress/skip-test": "2.6.1",
     "@testing-library/cypress": "10.0.2",
-    "cypress": "13.3.1",
+    "cypress": "14.3.0",
     "cypress-file-upload": "5.0.8",
     "cypress-keycloak": "2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@testing-library/cypress": "10.0.2",
     "@vitejs/plugin-react": "^4.1.0",
-    "cypress": "13.3.1",
+    "cypress": "^14.0",
     "cypress-file-upload": "5.0.8",
     "cypress-keycloak": "2.0.2",
     "dotenv": "^16.3.1",


### PR DESCRIPTION
Updated Cypress to v14.3, reduced load test file from 280Mb to 90Mb, optimized Dockerfile. All tests passing from Dev pod against production. Closes #2409.