### PR TITLE
Upgraded http-proxy-middleware to v2.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "eslint-plugin-prettier": "3.1.1",
-    "http-proxy-middleware": "1.0.6",
+    "http-proxy-middleware": "2.0.7",
     "jest": "^29.7.0",
     "react-icons": "^4.4.0",
     "serialize-javascript": "5.0.1",


### PR DESCRIPTION
Closes #2412. All tests passed on dev.
