### PR TITLE
[OLARFT] Update changelog for 2024 and 2025 updates

### DIFF
--- a/src/updates-notes/change-log-data.json
+++ b/src/updates-notes/change-log-data.json
@@ -1,7 +1,7 @@
 {
   "log": [
     {
-      "date": "04/18/25",
+      "date": "04/21/25",
       "type": "release",
       "product": "tools",
       "description": "The Online LAR Formatting tool has been updated for data collected in 2024 and 2025.",


### PR DESCRIPTION
@kgudel said that a changelog would be appropriate for this update to OLARFT for the 2024/2025 collection years, so here it is. 🎉 I'd like to get this across the finish line before I leave. 🤞

We'll do a release to coincide with this changelog update.

## Changes

- Updates the changelog to [reflect OLARFT updates](https://github.com/cfpb/hmda-frontend/pull/2476) for 2024 and 2025
- Based on [this changelog update](https://github.com/cfpb/hmda-frontend/blob/2483-olarft-changelog-for-2024-2025/src/updates-notes/change-log-data.json#L231-L242) for OLARFT

## Testing

1. Does the changelog look good?

![Screenshot 2025-04-18 at 6 47 01 AM](https://github.com/user-attachments/assets/7ee34de1-f1d7-495e-b516-8085d99cfe4a)
