### PR TITLE
[Deploy] Revert 6:00 PM maintenance window

### DIFF
--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -1,21 +1,9 @@
 {
   "name": "prod-beta",
-  "announcement": [
-    {
-      "message": "We will be performing scheduled system maintenance on April 29 from 6PM - 8PM EST. During this time users will be unable to log in to the Filing application or create new accounts.",
-      "type": "warning",
-      "heading": "Scheduled Maintenance",
-      "link": null
-    }
-  ],
+  "announcement": [],
   "publicationReleaseYear": "2020",
   "maintenanceMode": false,
-  "filingAnnouncement": {
-    "message": "We will be performing scheduled system maintenance on April 29 from 6PM - 8PM EST. During this time users will be unable to log in to the Filing application or create new accounts.",
-    "type": "warning",
-    "heading": "Scheduled Maintenance",
-    "endDate": null
-  },
+  "filingAnnouncement": null,
   "ffvtAnnouncement": null,
   "dataPublicationYears": {
     "shared": [

--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -2,12 +2,6 @@
   "name": "prod",
   "announcement": [
     {
-      "message": "We will be performing scheduled system maintenance on April 29 from 6PM - 8PM EST. During this time users will be unable to log in to the Filing application or create new accounts.",
-      "type": "warning",
-      "heading": "Scheduled Maintenance",
-      "link": null
-    },
-    {
       "heading": "2024 Modified LAR Data Release",
       "message": "On March 31, 2025, the 2024 Modified LAR was released. A combined file containing all LAR records in a single file is also available. These files can be accessed via the ",
       "type": "info",
@@ -20,12 +14,7 @@
   "publicationReleaseYear": "2023",
   "mlarReleaseYear": "2024",
   "maintenanceMode": false,
-  "filingAnnouncement": {
-    "message": "We will be performing scheduled system maintenance on April 29 from 6PM - 8PM EST. During this time users will be unable to log in to the Filing application or create new accounts.",
-    "type": "warning",
-    "heading": "Scheduled Maintenance",
-    "endDate": null
-  },
+  "filingAnnouncement": null,
   "ffvtAnnouncement": null,
   "dataPublicationYears": {
     "shared": [


### PR DESCRIPTION
This reverts the previous announcement PR here: #2501 so that it can be replaced with a new window from 8:30 to 10:30pm in a later PR.

## Changes

- Reverts #2501 

## Testing

1. After merging, does it remove the maintenance window notice?
