### PR TITLE
fix(metrics): fix CSP errors for mouseflow

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -28,13 +28,13 @@ http {
   # CSP
   add_header Content-Security-Policy 
   "default-src 'self' blob:; 
-  script-src 'self' 'nonce-$request_id' blob: data: https://dap.digitalgov.gov https://tagmanager.google.com https://www.googletagmanager.com https://www.google-analytics.com https://*.cfpb.gov https://www.consumerfinance.gov https://cdn.mouseflow.com; 
+  script-src 'self' 'nonce-$request_id' blob: data: https://dap.digitalgov.gov https://tagmanager.google.com https://www.googletagmanager.com https://www.google-analytics.com https://*.cfpb.gov https://www.consumerfinance.gov https://*.mouseflow.com; 
   img-src 'self' blob: data: https://www.googletagmanager.com https://www.google-analytics.com https://raw.githubusercontent.com; 
   style-src 'self' 'unsafe-inline'; 
   font-src 'self' data:; 
   object-src 'none'; 
   frame-src 'self' https://www.youtube.com/ https://ffiec.cfpb.gov/; 
-  connect-src 'self' https://www.googletagmanager.com https://*.cfpb.gov https://www.consumerfinance.gov https://raw.githubusercontent.com https://ffiec.cfpb.gov https://*.mapbox.com https://www.google-analytics.com https://s3.amazonaws.com https://*.algolia.net https://stats.g.doubleclick.net;";
+  connect-src 'self' https://www.googletagmanager.com https://*.cfpb.gov https://www.consumerfinance.gov https://raw.githubusercontent.com https://ffiec.cfpb.gov https://*.mapbox.com https://www.google-analytics.com https://s3.amazonaws.com https://*.algolia.net https://*.mouseflow.com https://stats.g.doubleclick.net;";
 
   # Restrict referrer
   add_header Referrer-Policy "strict-origin";


### PR DESCRIPTION
🚀 Now on Dev: `v3.2.9a` 🚀

EDA updated the mouseflow tag in GTM, but that means the CDNs they use are different than they were before and the exceptions they need have shifted.

![Image](https://github.com/user-attachments/assets/b41795b5-a8a1-46fb-bc0b-4098a7f249d9)

https://help.mouseflow.com/en/articles/4270388-content-security-policy-csp#adding-mouseflow-to-your-csp

The docs above recommend putting a lot of exceptions even with the "stricter restrictions" route in order to "future-proof" things, but let's start with this, see what functionality we get, and then add more if we need to.

## Changes

- add `*mouseflow.com` to `script-src` and `connect-src`

## Testing

1. Does mouseflow still throw CSP errors?

![Screenshot 2025-04-30 at 6 39 28 AM](https://github.com/user-attachments/assets/a60cb5e5-5450-40c0-bf2e-b0e6781769e8)

Closes #2512 