### PR TITLE
fix(announcements): prevent potential crash with fewer than 2 announcements

### DIFF
--- a/src/common/useAutoAdvance.jsx
+++ b/src/common/useAutoAdvance.jsx
@@ -27,7 +27,7 @@ export const useAutoAdvance = ({
   useEffect(() => {
     if (isPaused) clearTimeout(advanceTimeout)
     else {
-      if (totalCount < 2) return null
+      if (totalCount < 2) return undefined
       const secs = parseInt(cycleTime)
       if (secs > 0) {
         advanceTimeout = setTimeout(showNext, secs * 1000)


### PR DESCRIPTION
🚀 Currently on Dev: `v3.2.10` 🚀

When there's exactly one announcement (since nothing is rendered when there are no announcements), this line preventing the auto-advancement of the announcements is performed inside of a useEffect [in `useAutoAdvance.jsx`](https://github.com/cfpb/hmda-frontend/blob/master/src/common/useAutoAdvance.jsx#L30):

        if (totalCount < 2) return null

Since I believe React 18, you can't return null in a useEffect since it's reserved for a cleanup function, so a useEffect can now only return undefined, nothing, or a cleanup function. Returning null was causing a crash on unmount of the announcement component, throwing an error in the react internals ("t is not a function" when compiled on dev/prod).

So when the total number of announcements including timed announcements was equal to one, then the page could crash when the announcement banner unmounted, like on page navigation. This is why crashes only happened when navigating from the home page to another page, and could be "fixed" with a refresh.

## Changes

- change `null` to `undefined` in `useAutoAdvance`

## Testing

1. Does the site behave normally?
2. Do the tests pass on Dev?

## Notes
In the future I could see a few new e2e tests including one that checks navigation from the home page to the filing app.

Closes #2537, #2528 
