### PR TITLE
test(disclosure-reports): update 2024 tests

### DIFF
--- a/cypress/e2e/data-publication/DisclosureReports.spec.js
+++ b/cypress/e2e/data-publication/DisclosureReports.spec.js
@@ -55,8 +55,8 @@ onlyOn(!isBeta(HOST), () => {
       // Validate a row - Third row called "Applications Denied by Financial Institution"
       cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
       cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
+      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '1')
+      cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '665000')
       cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
       cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
       cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')


### PR DESCRIPTION
As part of data publication, we needed to update two values in the disclosure report tests once it was on prod.

## Changes

- update disclosure report tests

## Testing

1. Do all tests pass? (they do!)
![Screenshot 2025-06-24 at 8 40 54 AM](https://github.com/user-attachments/assets/2d3fe555-bbfc-4218-9ce2-1d861381fabb)
