### PR TITLE
chore(beta): announce user data change on beta

### DIFF
--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -1,9 +1,27 @@
 {
   "name": "prod-beta",
-  "announcement": [],
+  "announcement": [
+    {
+      "message": "An important update has been deployed to the HMDA Beta Platform on July 10th. As part of this update, existing data has been reset and removed from the platform. For any questions, contact ",
+      "type": "warning",
+      "heading": "Scheduled Maintenance",
+      "link": {
+        "url": "mailto:hmdahelp@cfpb.gov?subject=Question%20About%20User%20Data%20Maintenance%20on%20HMDA%20Beta%20Platform%20On%20July%2010th",
+        "text": "hmdahelp@cfpb.gov"
+      }
+    }
+  ],
   "publicationReleaseYear": "2020",
   "maintenanceMode": false,
-  "filingAnnouncement": null,
+  "filingAnnouncement": {
+    "message": "An important update has been deployed to the HMDA Beta Platform on July 10th. As part of this update, existing data has been reset and removed from the platform. For any questions, contact ",
+    "type": "warning",
+    "heading": "Scheduled Maintenance",
+    "link": {
+      "url": "mailto:hmdahelp@cfpb.gov?subject=Question%20About%20User%20Data%20Maintenance%20on%20HMDA%20Beta%20Platform%20on%20July%2010th",
+      "text": "hmdahelp@cfpb.gov"
+    }
+  },
   "ffvtAnnouncement": null,
   "dataPublicationYears": {
     "shared": [


### PR DESCRIPTION
## Changes

- announces the planned removal of user data on beta platform

## Testing

1. Does the screenshot below look good?
![Screenshot 2025-07-09 at 1 05 06 PM](https://github.com/user-attachments/assets/db9770be-7085-4df8-bac3-67d6d86b6a08)

Link goes to: hmdahelp@cfpb.gov with prefilled subject line: 
`Question About User Data Maintenance on HMDA Beta Platform on July 10th`


<img width="659" height="24" alt="Screenshot 2025-07-10 at 11 26 09 AM" src="https://github.com/user-attachments/assets/6ae707f9-3b85-4ccd-8535-460e72a98209" />




Closes: #2560 
