### PR TITLE
fix(dockerfile): bump alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.20 as build-stage
+FROM node:20-alpine3.22 as build-stage
 WORKDIR /usr/src/app
 ARG DOCKER_TAG="latest"
 
@@ -21,7 +21,7 @@ RUN echo "{ \"version\": \"${DOCKER_TAG}\" }" > ./src/common/constants/release.j
 
 RUN yarn build
 
-FROM nginx:alpine3.20
+FROM nginx:alpine3.22
 ENV NGINX_USER=svc_nginx_hmda
 RUN apk update && apk upgrade
 RUN rm -rf /etc/nginx/conf.d


### PR DESCRIPTION
## Changes

- bumps alpine version from `3.20` to `3.22` to address OS security vulnerabilities

## Testing

1. Do the tests still pass on Dev?
(updated 10-20-2025)

<img width="710" height="835" alt="Screenshot 2025-10-20 at 9 44 55 AM" src="https://github.com/user-attachments/assets/48805674-b431-4972-b8e5-e4d792be5316" />
