### PR TITLE
Add homepage navigation tests to detect page crash regressions

### DIFF
--- a/cypress/e2e/common-features/navigation.spec.js
+++ b/cypress/e2e/common-features/navigation.spec.js
@@ -1,0 +1,34 @@
+import { isCI, isBeta } from '../../support/helpers'
+import { onlyOn } from '@cypress/skip-test'
+const { HOST, ENVIRONMENT } = Cypress.env()
+
+let baseURLToVisit = isCI(ENVIRONMENT) ? 'http://localhost:3000' : HOST
+
+onlyOn(isBeta(HOST), () => {
+  describe('Site navigation', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
+
+onlyOn(!isBeta(HOST), () => {
+  describe('HMDA homepage hero navigation', () => {
+    // HMDA's homepage has four "quick links" leading to core pages
+    const quickLinks = [
+      { text: 'Rate Spread Calculator', pageHeading: 'Rate Spread Calculator' },
+      { text: 'HMDA Filing Platform', pageHeading: 'File your HMDA Data' },
+      { text: 'Frequently Asked Questions', pageHeading: 'Frequently Asked Questions' },
+      { text: 'Filing Instructions Guide', pageHeading: 'Filing Instructions Guide' }
+    ]
+
+    quickLinks.forEach(({ text, pageHeading }) => {
+      it(`Allows visitors to navigate to ${text} page`, () => {
+        cy.visit(`${baseURLToVisit}/`)
+        // Quick links have hardcoded `<br>` tags that need to be stripped out
+        const cleanText = new RegExp(text.replace(/\s+/g, '\\s*'), 'i')
+        cy.get('#quicklinks a').contains(cleanText).click()
+        cy.get('h1').should('contain', pageHeading)
+      })
+    })
+  })
+
+})


### PR DESCRIPTION
In the past, we've had bugs cause pages to silently crash when accessed from the homepage. This adds a test that clicks all the quick links on the homepage and confirms the relevant page headings load.

See [#4951](https://GHE/HMDA-Operations/hmda-devops/issues/4951)

## Changes

- Adds a new navigation spec

## Testing

1. `yarn test --spec cypress/e2e/common-features/navigation.spec.js` should pass
