### PR TITLE
chore(beta): remove beta announcement about data update

### DIFF
--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -1,27 +1,9 @@
 {
   "name": "prod-beta",
-  "announcement": [
-    {
-      "message": "An important update has been deployed to the HMDA Beta Platform on July 10th. As part of this update, existing data has been reset and removed from the platform. For any questions, contact ",
-      "type": "warning",
-      "heading": "Scheduled Maintenance",
-      "link": {
-        "url": "mailto:hmdahelp@cfpb.gov?subject=Question%20About%20User%20Data%20Maintenance%20on%20HMDA%20Beta%20Platform%20On%20July%2010th",
-        "text": "hmdahelp@cfpb.gov"
-      }
-    }
-  ],
+  "announcement": [],
   "publicationReleaseYear": "2020",
   "maintenanceMode": false,
-  "filingAnnouncement": {
-    "message": "An important update has been deployed to the HMDA Beta Platform on July 10th. As part of this update, existing data has been reset and removed from the platform. For any questions, contact ",
-    "type": "warning",
-    "heading": "Scheduled Maintenance",
-    "link": {
-      "url": "mailto:hmdahelp@cfpb.gov?subject=Question%20About%20User%20Data%20Maintenance%20on%20HMDA%20Beta%20Platform%20on%20July%2010th",
-      "text": "hmdahelp@cfpb.gov"
-    }
-  },
+  "filingAnnouncement": null,
   "ffvtAnnouncement": null,
   "dataPublicationYears": {
     "shared": [


### PR DESCRIPTION
This removes the below banner by reverting commit 1844ae2ba1bc28d25e17c17382441051b911f56a.

<img width="1093" height="147" alt="image" src="https://github.com/user-attachments/assets/687f1dab-e723-4c73-9126-0b9dc115f319" />

Closes https://github.com/cfpb/hmda-frontend/issues/2576

## Changes

- Removes the beta data announcement
