### PR TITLE
fix(cache): bust config cache by adding random string to URL when fetching

### DIFF
--- a/src/common/configUtils.js
+++ b/src/common/configUtils.js
@@ -8,10 +8,7 @@ const CONFIG_URL_PREFIX =
   'https://raw.githubusercontent.com/cfpb/hmda-frontend/master/src/common/constants/'
 
 export function fetchEnvConfig(setFn, host) {
-  const url = `${CONFIG_URL_PREFIX}${getDefaultConfig(host).name}-config.json?nocache=${Date.now()}`
-  return fetch(url, {
-      cache: 'no-store'
-    })
+  return fetch(`${CONFIG_URL_PREFIX}${getDefaultConfig(host).name}-config.json?nocache=${Date.now()}`)
     .then((data) => data.json())
     .then((config) => setFn(deriveConfig(config)))
 }


### PR DESCRIPTION
The year is ~~1995~~ 1996 and we need to trick our users' browsers into thinking the file they just downloaded is different from the file they downloaded yesterday.

Fixes #2401 

## Changes

- Adds unique query param to GH fetch requests to fool web browsers.

## Testing

1. Squint

## Notes

We tried being mature grown-ups and adding [`cache: 'no-store'`](https://github.com/cfpb/hmda-frontend/commit/e820c86881d73bf4a69cb41f8dcaf346f4027cbd) to the request but github.com yells at you and fails the request when you add custom headers because they don't want you using them as a CDN (but too bad we're doing it anyway).
