### PR TITLE
Add links to LAR tools in filing banners to assist with file formatting and verification

### DIFF
--- a/src/filing/institutions/Header.jsx
+++ b/src/filing/institutions/Header.jsx
@@ -27,8 +27,12 @@ export const HeaderDocsLink = ({ period }) => {
   const [filingYear, isQuarterly] = period.split('-')
 
   const text = isQuarterly
-    ? 'For more information on quarterly filing dates, visit the '
-    : 'For more information regarding filing, please visit the '
+    ? 'For more information on quarterly filing dates, visit our '
+    : 'For more information regarding filing, please visit our '
+
+  const linkText = isQuarterly
+    ? 'Documentation'
+    : 'FAQ'
 
   const url = isQuarterly
     ? `/documentation/faq/data-collection-timelines#quarterly-filing-period-dates`
@@ -38,7 +42,7 @@ export const HeaderDocsLink = ({ period }) => {
     <>
       {text}
       <a href={url} rel='noopener noreferrer' target='_blank'>
-        Documentation
+        {linkText}
       </a>{' '}
       page.
     </>

--- a/src/filing/institutions/HeaderOpen.jsx
+++ b/src/filing/institutions/HeaderOpen.jsx
@@ -41,6 +41,12 @@ export const HeaderOpen = ({ period, lateDate, endDate }) => {
                 HMDA Beta Platform
               </a>{' '}
               is available to test your HMDA data prior to official submission.
+              <br />
+              Our{' '}
+              <a href='/tools/online-lar-formatting' target='_blank'>
+                Online LAR Formatting Tool
+              </a>{' '}
+              can help you validate your file.
             </>
           )}
           <br />

--- a/src/filing/refileWarning/index.jsx
+++ b/src/filing/refileWarning/index.jsx
@@ -90,7 +90,14 @@ export const getText = (props) => {
       {button}
       {periodAfter ? '.' : null}
       <p style={{ marginTop: '15px' }}>
-        Need help? Visit our{' '}
+        Need help? Use our{' '}
+        <a
+          target='_blank'
+          href='/tools/online-lar-formatting'
+        >
+          Online LAR formatting tool
+        </a>,{' '}
+        visit the{' '}
         <a
           target='_blank'
           rel='noopener noreferrer'


### PR DESCRIPTION
Updates two banners to include links to LAR tools to make submissions easier.

See [#5029](https://[GHE]/HMDA-Operations/hmda-devops/issues/5029).

## Changes

- Updates two banners with links to LAR tools.

## Testing

1. Log into the filing app and check the contents of the blue banner.
2. Upload a malformed LAR and check the contents of the red banner.

## Screenshots

Banner at the top of the initial filing screen, slightly different text for annual vs quarterly filers:

| annual filers | quarterly filers |
| ------------- | ---------------- |
| <img width="1996" height="650" alt="image" src="https://github.com/user-attachments/assets/8f5af1d9-a77c-4e21-8327-ebec673067c6" /> | <img width="1996" height="650" alt="image" src="https://github.com/user-attachments/assets/e4b1db78-75af-45cb-9dc2-f00c21355000" /> |

Error banner that appears when edits are presents:

<img width="1990" height="328" alt="image" src="https://github.com/user-attachments/assets/e5a6855a-fb7d-4af7-bc58-17c2f93eceb9" />



