### PR TITLE
fix(e2e): update graph tests for 2024

### DIFF
--- a/cypress/e2e/data-browser/graphs.spec.js
+++ b/cypress/e2e/data-browser/graphs.spec.js
@@ -50,7 +50,7 @@ onlyOn(!isBeta(HOST), () => {
       )
     })
 
-    it('Institution level data is correct for 2021-2023', () => {
+    it('Institution level data is correct for 2022-2024', () => {
       // Using Bank of America as the test institution
       const institutionDetails = {
         name: 'BANK OF AMERICA, NATIONAL ASSOCIATION',
@@ -59,9 +59,9 @@ onlyOn(!isBeta(HOST), () => {
       }
 
       const yearData = [
+        { year: '2024', count: '233,637' },
         { year: '2023', count: '271,974' },
         { year: '2022', count: '348,961' },
-        { year: '2021', count: '368,728' },
       ]
 
       cy.visit(`${baseURLToVisit}/data-browser/graphs/quarterly/info/filers`)
@@ -87,12 +87,12 @@ onlyOn(!isBeta(HOST), () => {
       })
     })
 
-    it('Total of Quarterly Filers counts appear for 2021-2023', () => {
+    it('Total of Quarterly Filers counts appear for 2022-2024', () => {
       // Data ordered from newest to oldest year to match table layout
       const yearData = [
-        { year: '2023', count: '4,801,852' },
-        { year: '2022', count: '6,242,438' },
-        { year: '2021', count: '10,403,604' },
+        { year: '2024', count: '5,654,134' },
+        { year: '2023', count: '5,045,979' },
+        { year: '2022', count: '6,636,512' },
       ]
 
       cy.visit(`${baseURLToVisit}/data-browser/graphs/quarterly/info/filers`)
@@ -111,12 +111,12 @@ onlyOn(!isBeta(HOST), () => {
       })
     })
 
-    it('Total of All Filers counts appear for 2021-2023', () => {
+    it('Total of All Filers counts appear for 2022-2024', () => {
       // Data ordered from newest to oldest year to match table layout
       const yearData = [
+        { year: '2024', count: '12,229,298' },
         { year: '2023', count: '11,564,178' },
         { year: '2022', count: '16,099,307' },
-        { year: '2021', count: '26,269,980' },
       ]
 
       cy.visit(`${baseURLToVisit}/data-browser/graphs/quarterly/info/filers`)


### PR DESCRIPTION
We're updating the graph data, so time to update some tests.

## Changes

For the filer info tab tests:
- adds 2024 data
- updates 2022 and 2023 data
- removes 2021 data

## Testing

1. Do the tests pass against dev? (they do!)
<img width="518" height="618" alt="Screenshot 2025-08-22 at 3 03 58 PM" src="https://github.com/user-attachments/assets/dd794772-ecb3-416c-8686-3500b2d04fbc" />

Closes #2588 