### PR TITLE
fix(deps): bump jspdf for security patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "highcharts": "10.3.3",
     "highcharts-react-official": "3.2.1",
     "html-to-image": "1.11.11",
-    "jspdf": "3.0.1",
+    "jspdf": "3.0.2",
     "jwt-decode": "^3.1.2",
     "keycloak-js": "25.0.6",
     "mapbox-gl": "1.13.3",


### PR DESCRIPTION
Currently on Dev as `v3.2.14` 🚀

## Changes

- update jspdf from `3.0.1` to `3.0.2`

## Testing

1. Do the test still pass?
2. How do things look on Dev?

<img width="753" height="863" alt="Screenshot 2025-08-28 at 11 53 41 AM" src="https://github.com/user-attachments/assets/1e36cbed-298f-4a64-93cd-f0d9c49b2330" />

