### PR TITLE
fix(help): add nonce to blob streaming script to fix submission downloads

### DIFF
--- a/public/filesaver.html
+++ b/public/filesaver.html
@@ -12,7 +12,7 @@
 	when the worker then receives a stream then the worker will tell the opener
 	to open up a link that will start the download
 -->
-<script>
+<script nonce="nonce-placeholder">
   // This will prevent the sw from restarting
   let keepAlive = () => {
     keepAlive = () => {}


### PR DESCRIPTION
When we [added nonces](https://github.com/cfpb/hmda-frontend/pull/2204) to deter XSS vulns, we accidentally broke support for the [third-party library](https://github.com/cfpb/hmda-frontend/pull/851) we use to stream large (> 500MB) LAR blobs. The script loaded by the streaming library throws a CSP error because it doesn't have a nonce. This PR adds one and restores the file download functionality.

We don't actually need the third-party streaming library anymore because modern browsers support up to [2GB of in-memory blobs](https://chromium.googlesource.com/chromium/src/+/HEAD/storage/browser/blob/README.md). I started a [branch](https://github.com/cfpb/hmda-frontend/compare/master...5105-hmda-help-file-download) that removes it and adds tests to catch regressions but I abandoned it when my coworkers and I (the people who maintain free software used by the entire country's mortgage industry) received an [email](https://news.bloomberglaw.com/banking-law/cfpb-eyeing-more-job-cuts-as-republican-funding-cap-takes-hold) implying we're all about to be fired.

## Changes

- Adds `nonce` attribute that will be populated by [nginx](https://github.com/cfpb/hmda-frontend/blob/ff2da8b7d98c82b1b3f217ae83468dc3c419654f/nginx/nginx.conf#L26).

## Testing

1. Log into HMDA Help on prod and try downloading an institution's submission. Nothing happens.
2. Try on dev and it'll download the file.
