### PR TITLE
feat(help): add links back to institution search results after editing

### DIFF
--- a/src/hmda-help/institution/index.jsx
+++ b/src/hmda-help/institution/index.jsx
@@ -1,33 +1,33 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { flushSync } from 'react-dom'
 import { Link } from 'react-router-dom'
 
 import {
-  searchInputs,
-  requiredInputs,
-  otherInputs,
   notesInput,
+  otherInputs,
+  requiredInputs,
+  searchInputs,
 } from '../constants/inputs'
 import {
-  nestInstitutionStateForAPI,
   flattenApiForInstitutionState,
+  nestInstitutionStateForAPI,
 } from '../utils/convert'
 import { validateAll } from '../utils/validate'
 
-import OtherFields from './OtherFields'
-import InputText from '../InputText'
+import * as AccessToken from '../../common/api/AccessToken'
+import { getFilingYears } from '../../common/constants/configHelpers'
+import Loading from '../../common/LoadingIcon.jsx'
+import Alert from '../Alert'
 import InputRadio from '../InputRadio'
 import InputSelect from '../InputSelect'
 import InputSubmit from '../InputSubmit'
-import Alert from '../Alert'
-import Loading from '../../common/LoadingIcon.jsx'
+import InputText from '../InputText'
 import Notes from '../Notes'
 import NoteHistory from './NoteHistory'
-import { getFilingYears } from '../../common/constants/configHelpers'
-import * as AccessToken from '../../common/api/AccessToken'
+import OtherFields from './OtherFields'
 
-import './Form.css'
 import { fetchSingleInstitutionByYear } from '../search/fetchInstitution'
+import './Form.css'
 
 const defaultInstitutionState = {}
 searchInputs
@@ -299,8 +299,11 @@ class Institution extends Component {
         }
       >
         <p>
-          You can update this institution by using the form on this page,{' '}
-          <Link to='/'>search for an institution</Link>, or{' '}
+          You can{' '}
+          <Link to={`/search/institution/${this.state.lei}`}>
+            return to the institution page
+          </Link>
+          , <Link to='/'>search for a new institution</Link>, or{' '}
           <Link to='/add'>add a new institution.</Link>
         </p>
       </Alert>
@@ -308,6 +311,13 @@ class Institution extends Component {
 
     return (
       <>
+        <Link
+          to={`/search/institution/${this.state.lei}`}
+          className='button-link'
+          style={{ marginBottom: '1em', display: 'inline-block' }}
+        >
+          &larr; Back to Institution Details
+        </Link>
         <h3>
           {pathname === '/add'
             ? 'Add an institution record'


### PR DESCRIPTION
Currently, there's no way to go back to the search results page (also called "institution details" page, the app uses the search results view to also show all the details of an institution) after editing an institution for a filing year. This PR adds a couple links to both a breadcrumb at the top of the page and the "success" notification that appears after making an edit.

Note: The HMDA Help app overzealously [pushes to history](https://github.com/cfpb/hmda-frontend/blob/ba5ef532f0e97b2b0ed332aea3d1a8a2f36e1527/src/hmda-help/institution/index.jsx#L230) when institutions are modified and unwinding that functionality to restore use of the browser's native back button is a non-trivial task. It's much easier to just link to the institution's dedicated search results page.

See [#5027](https://ghe/HMDA-Operations/hmda-devops/issues/5027)

## Changes

- Adds two links to the institution component that point to the institution's page.

## Testing

1. Visit `/hmda-help/update/institution/FRONTENDTESTBANK9999/2024` on dev and notice the `← Back to Institution Details` link that takes you back to the full institution page (technically a "search results page" in the HMDA Help app).
2. Make a random edit to the institution and you'll see a similar link in the green success notification.

## Screenshots

<img width="1056" height="166" alt="Screenshot 2025-09-15 at 12 00 48 PM" src="https://github.com/user-attachments/assets/6ea36904-a52f-42de-ad5d-d8fea18af603" />
<hr>
<img width="1058" height="133" alt="Screenshot 2025-09-15 at 12 01 27 PM" src="https://github.com/user-attachments/assets/39d1cacd-a809-4340-b0e0-b1bd586f713e" />


