### PR TITLE
feat: npm script that runs cypress tests that don't require auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Cypress tests
+
+on:
+  pull_request:
+
+run-name: "Cypress tests that don't require auth: branch ${{ github.head_ref }} by @${{ github.actor }}"
+
+jobs:
+  non-auth-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run Cypress tests that don't require auth
+        run: yarn test-non-auth

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 run-name: "Cypress tests that don't require auth: branch ${{ github.head_ref }} by @${{ github.actor }}"
 
 jobs:
-  non-auth-tests:
+  unauthenticated-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,4 +25,4 @@ jobs:
         run: yarn
 
       - name: Run Cypress tests that don't require auth
-        run: yarn test-non-auth
+        run: yarn test-unauthenticated

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require('cypress')
+const { plugin: cypressGrepPlugin } = require('@cypress/grep/plugin')
 const fs = require('fs')
 
 module.exports = defineConfig({
@@ -15,6 +16,10 @@ module.exports = defineConfig({
     AUTH_REALM: 'hmda2',
     AUTH_CLIENT_ID: 'hmda2-api',
     preserveCookies: ['_login_gov_session'],
+    // Always enable spec filtering
+    grepFilterSpecs: true,
+    // Always omit filtered tests
+    grepOmitFiltered: true,
   },
 
   defaultCommandTimeout: 10000,
@@ -40,7 +45,7 @@ module.exports = defineConfig({
     pageLoadTimeout: 30000,
     retries: {
       runMode: 2,
-      openMode: 0
+      openMode: 0,
     },
     // Delete videos for specs without failing or retried tests, see docs:
     // https://docs.cypress.io/app/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
@@ -49,16 +54,20 @@ module.exports = defineConfig({
         if (results && results.video) {
           // Do we have failures for any retry attempts?
           const failures = results.tests.some((test) =>
-            test.attempts.some((attempt) => attempt.state === 'failed')
+            test.attempts.some((attempt) => attempt.state === 'failed'),
           )
           // Check to make sure the video file exists before deleting, see https://stackoverflow.com/a/76113045
           if (!failures && fs.existsSync(results.video)) {
             // delete the video if the spec passed and no tests retried
             fs.unlinkSync(results.video)
-            console.log(`All tests passed, deleting video file: ${results.video}`)
+            console.log(
+              `All tests passed, deleting video file: ${results.video}`,
+            )
           }
         }
       })
+      cypressGrepPlugin(config)
+      return config
     },
   },
 

--- a/cypress/e2e/filing/Filing.spec.js
+++ b/cypress/e2e/filing/Filing.spec.js
@@ -1,6 +1,6 @@
-import { isBeta, isCI } from '../../support/helpers'
 import { getDefaultConfig } from '../../../src/common/configUtils'
 import { getFilingPeriods } from '../../../src/common/constants/configHelpers'
+import { isBeta } from '../../support/helpers'
 
 const {
   HOST,
@@ -21,205 +21,210 @@ const getFilename = (filingPeriod, lei) => `${filingPeriod}-${lei}.txt`
 const years = (YEARS && YEARS.toString().split(',')) || getFilingPeriods(config)
 const { filingPeriodStatus } = config
 
+describe(
+  'Filing',
+  { testIsolation: false, tags: ['@auth-required'] },
+  function () {
+    before(() => {
+      cy.keycloakLogin('filing/2024/institutions/')
+    })
 
-describe('Filing', {testIsolation: false}, function () {
+    beforeEach(() => {
+      cy.get({
+        HOST,
+        USERNAME,
+        PASSWORD,
+        INSTITUTION,
+        ACTION_DELAY,
+        TEST_DELAY,
+        NAV_DELAY,
+        ENVIRONMENT,
+        AUTH_BASE_URL,
+        AUTH_REALM,
+        AUTH_CLIENT_ID,
+      }).logEnv()
 
-  before(() => {
-    cy.keycloakLogin('filing/2024/institutions/')
-  })
+      cy.visit(`${AUTH_BASE_URL}filing/2020/institutions`)
+      cy.viewport(1600, 900)
+    })
 
-  beforeEach(() => {
+    const THIS_IS_BETA = isBeta(HOST)
+    const testVsOfficial = THIS_IS_BETA ? 'test' : 'official'
 
-    cy.get({
-      HOST,
-      USERNAME,
-      PASSWORD,
-      INSTITUTION,
-      ACTION_DELAY,
-      TEST_DELAY,
-      NAV_DELAY,
-      ENVIRONMENT,
-      AUTH_BASE_URL,
-      AUTH_REALM,
-      AUTH_CLIENT_ID,
-    }).logEnv()
+    years.forEach((filingPeriod, index) => {
+      it(`${filingPeriod}`, function () {
+        const status = filingPeriodStatus[filingPeriod]
 
-    cy.visit(`${AUTH_BASE_URL}filing/2020/institutions`)
-    cy.viewport(1600, 900)
-  })
+        cy.wait(ACTION_DELAY)
 
-  const THIS_IS_BETA = isBeta(HOST)
-  const testVsOfficial = THIS_IS_BETA ? 'test' : 'official'
+        // Select the year using the filing-year
+        cy.get('.filing-year-selector .filing-year__control').click()
+        // For quarterly filings, we need to select just the year part
+        const yearToSelect = filingPeriod.includes('-')
+          ? filingPeriod.split('-')[0]
+          : filingPeriod
+        cy.get('.filing-year__menu').contains(yearToSelect).click()
 
-  years.forEach((filingPeriod, index) => {
-    it(`${filingPeriod}`, function () {
-      const status = filingPeriodStatus[filingPeriod]
+        // Use the quarterly selector if it is a quarterly filing
+        if (filingPeriod.includes('Q')) {
+          cy.get('body').then(($body) => {
+            // Check if annual-or-quarter dropdown is disabled
+            const hasDisabledControl =
+              $body.find('.annual-or-quarter--is-disabled').length > 0
 
-      cy.wait(ACTION_DELAY)
+            if (!hasDisabledControl) {
+              // Only attempt to interact if not disabled
+              cy.get('.annual-or-quarter__control').click()
+              cy.get('.annual-or-quarter__menu')
+                .contains(filingPeriod.split('-')[1])
+                .click()
+            }
+          })
+        } else if (!status.isClosed) {
+          // For open annual filings, select "Annual"
+          cy.get('.annual-or-quarter__control').click()
+          cy.get('.annual-or-quarter__menu').contains('Annual').click()
+        }
 
-      // Select the year using the filing-year
-      cy.get('.filing-year-selector .filing-year__control').click()
-      // For quarterly filings, we need to select just the year part
-      const yearToSelect = filingPeriod.includes('-')
-        ? filingPeriod.split('-')[0]
-        : filingPeriod
-      cy.get('.filing-year__menu').contains(yearToSelect).click()
-
-      // Use the quarterly selector if it is a quarterly filing
-      if (filingPeriod.includes('Q')) {
-        cy.get('body').then($body => {
-          // Check if annual-or-quarter dropdown is disabled
-          const hasDisabledControl = $body.find('.annual-or-quarter--is-disabled').length > 0;
-          
-          if (!hasDisabledControl) {
-            // Only attempt to interact if not disabled
-            cy.get('.annual-or-quarter__control').click()
-            cy.get('.annual-or-quarter__menu')
-              .contains(filingPeriod.split('-')[1])
-              .click()
+        // After Close - Cannot file/refile after Filing period is passed
+        if (status.isClosed && status.isPassed) {
+          if (!THIS_IS_BETA) {
+            cy.contains(
+              `Collection of ${filingPeriod} HMDA data has ended`,
+            ).should('exist')
+            cy.contains(
+              `Submissions of ${filingPeriod} HMDA data are no longer accepted as of ${status.endDate}.`,
+            ).should('exist')
           }
-        })
-      } else if (!status.isClosed) {
-        // For open annual filings, select "Annual"
-        cy.get('.annual-or-quarter__control').click()
-        cy.get('.annual-or-quarter__menu').contains('Annual').click()
-      }
+          cy.contains(`Upload your ${testVsOfficial} file`).should('not.exist')
+          cy.contains('Upload a new file').should('not.exist')
+          cy.contains('For Review Only', { timout: 5000 }).should('exist')
+          return
+        }
 
-      // After Close - Cannot file/refile after Filing period is passed
-      if (status.isClosed && status.isPassed) {
-        if (!THIS_IS_BETA) {
+        // Late filing - Can file after timely deadline but should see the message
+        if (status.isLate && !THIS_IS_BETA) {
+          cy.contains(`The ${filingPeriod} filing period is closed.`).should(
+            'exist',
+          )
           cy.contains(
-            `Collection of ${filingPeriod} HMDA data has ended`,
-          ).should('exist')
-          cy.contains(
-            `Submissions of ${filingPeriod} HMDA data are no longer accepted as of ${status.endDate}.`,
+            `The HMDA Platform remains available outside of the filing period for late submissions and resubmissions of ${filingPeriod} HMDA data until ${status.endDate}.`,
           ).should('exist')
         }
-        cy.contains(`Upload your ${testVsOfficial} file`).should('not.exist')
-        cy.contains('Upload a new file').should('not.exist')
-        cy.contains('For Review Only', { timout: 5000 }).should('exist')
-        return
-      }
 
-      // Late filing - Can file after timely deadline but should see the message
-      if (status.isLate && !THIS_IS_BETA) {
-        cy.contains(`The ${filingPeriod} filing period is closed.`).should(
-          'exist',
-        )
-        cy.contains(
-          `The HMDA Platform remains available outside of the filing period for late submissions and resubmissions of ${filingPeriod} HMDA data until ${status.endDate}.`,
-        ).should('exist')
-      }
+        // Filing period is open
+        if (status.isOpen && !THIS_IS_BETA) {
+          cy.contains(`The ${filingPeriod} filing period is open.`).should(
+            'exist',
+          )
+          cy.contains(
+            `Timely submissions of ${filingPeriod} HMDA data will be accepted until ${status.lateDate}`,
+          ).should('exist')
+          cy.contains(
+            `Resubmissions and late submissions will be accepted until ${status.endDate}`,
+          ).should('exist')
+        }
 
-      // Filing period is open
-      if (status.isOpen && !THIS_IS_BETA) {
-        cy.contains(`The ${filingPeriod} filing period is open.`).should(
-          'exist',
-        )
-        cy.contains(
-          `Timely submissions of ${filingPeriod} HMDA data will be accepted until ${status.lateDate}`,
-        ).should('exist')
-        cy.contains(
-          `Resubmissions and late submissions will be accepted until ${status.endDate}`,
-        ).should('exist')
-      }
+        // Wait for API request to finish
+        cy.get('.LoadingIcon', { timeout: 10000 }).should('not.exist')
 
-      // Wait for API request to finish
-      cy.get('.LoadingIcon', { timeout: 10000 }).should('not.exist')
+        cy.get(`#main-content .institution`, { timeout: 20000 })
+          .then(($list) => {
+            // Find target institution
+            const institution = $list
+              .toArray()
+              .filter((x) => x.innerText.indexOf(INSTITUTION) > -1)[0]
 
-      cy.get(`#main-content .institution`, { timeout: 20000 })
-        .then(($list) => {
-          // Find target institution
-          let institution = $list
-            .toArray()
-            .filter((x) => x.innerText.indexOf(INSTITUTION) > -1)[0]
+            if (!institution) throw Error(`${INSTITUTION} not found!`)
 
-          if (!institution) throw Error(`${INSTITUTION} not found!`)
-
-          let clicked = false
-          cy.wrap(institution)
-            .find('.current-status > .ViewButton')
-            .then(($viewButton) => {
-              const first = $viewButton[0]
-              if (
-                first &&
-                first.innerText.indexOf(`Upload your ${testVsOfficial} file`) >
-                  -1
-              ) {
-                /* Start a new Submission */
-                first.click()
-                clicked = true
-              }
-            })
-            .then(() => {
-              if (!clicked) {
-                /* Start a Refile */
-                cy.wrap(institution).find('.RefileButton').click()
-                cy.get('.modal button:first-of-type').click()
-              }
-            })
-        })
-        .then(() => {
-          /* File Upload */
-          const FILENAME = getFilename(filingPeriod, INSTITUTION)
-
-          cy.fixture(FILENAME).then((fileContent) => {
-            cy.get('.UploadForm input', { force: true }).attachFile({
-              fileContent,
-              fileName: FILENAME,
-              mimeType: 'text/plain',
-            })
-
-            // Wait up to 3 minutes for upload to complete, then start reviewing edits
-            cy.get('.NavButtonContainer > .NavButton').click({
-              timeout: 180000,
-            })
-
-            // Action: Review Quality Edits
-            cy.get('.NavButtonContainer > .NavButton').click()
-            cy.wait(NAV_DELAY)
-
-            /* Action: Verify Quality Edits */
-            cy.get('.EditsTableWrapper').then((wrapper) => {
-              // Verify edits, if triggered
-              if (wrapper.find('.Verifier').length)
-                cy.get('#qualityVerifier').check()
-              cy.wait(NAV_DELAY)
-              // Move to next step in Submission process
-              cy.get('.NavButtonContainer > .NavButton').click()
-            })
-            cy.wait(ACTION_DELAY)
-
-            /* Action: Verify Macro Edits */
-            cy.get('.EditsTableWrapper').then((wrapper) => {
-              // Verify edits, if triggered
-              if (wrapper.find('.Verifier').length)
-                cy.get('#macroVerifier').check()
-              // Move to next step in Submission process
-              cy.get('.NavButtonContainer > .NavButton').click()
-            })
-            cy.wait(ACTION_DELAY)
-
-            /* Action: Sign Submission */
-            if (THIS_IS_BETA) {
-              cy.get('.alert.alert-warning:last').should(
-                'contain.text',
-                '[Beta Platform] Filing Simulation Complete!',
-              )
-            } else {
-              cy.wait(500)
-              cy.get('#signature li:first > label').click({ timeout: 2000 })
-              cy.get('#signatureAuth').check('signature', { timeout: 2000 })
-              cy.get('#signature > button').click({ timeout: 2000 })
-            }
-            cy.wait(TEST_DELAY)
+            let clicked = false
+            cy.wrap(institution)
+              .find('.current-status > .ViewButton')
+              .then(($viewButton) => {
+                const first = $viewButton[0]
+                if (
+                  first &&
+                  first.innerText.indexOf(
+                    `Upload your ${testVsOfficial} file`,
+                  ) > -1
+                ) {
+                  /* Start a new Submission */
+                  first.click()
+                  clicked = true
+                }
+              })
+              .then(() => {
+                if (!clicked) {
+                  /* Start a Refile */
+                  cy.wrap(institution).find('.RefileButton').click()
+                  cy.get('.modal button:first-of-type').click()
+                }
+              })
           })
-        })
-    })
-  })
+          .then(() => {
+            /* File Upload */
+            const FILENAME = getFilename(filingPeriod, INSTITUTION)
 
-  // Logout of Keycloak
-  it('Logout of Keycloak', function() {
-    cy.visit(`${AUTH_BASE_URL}auth/realms/hmda2/protocol/openid-connect/logout`)
-  })
-})
+            cy.fixture(FILENAME).then((fileContent) => {
+              cy.get('.UploadForm input', { force: true }).attachFile({
+                fileContent,
+                fileName: FILENAME,
+                mimeType: 'text/plain',
+              })
+
+              // Wait up to 3 minutes for upload to complete, then start reviewing edits
+              cy.get('.NavButtonContainer > .NavButton').click({
+                timeout: 180000,
+              })
+
+              // Action: Review Quality Edits
+              cy.get('.NavButtonContainer > .NavButton').click()
+              cy.wait(NAV_DELAY)
+
+              /* Action: Verify Quality Edits */
+              cy.get('.EditsTableWrapper').then((wrapper) => {
+                // Verify edits, if triggered
+                if (wrapper.find('.Verifier').length)
+                  cy.get('#qualityVerifier').check()
+                cy.wait(NAV_DELAY)
+                // Move to next step in Submission process
+                cy.get('.NavButtonContainer > .NavButton').click()
+              })
+              cy.wait(ACTION_DELAY)
+
+              /* Action: Verify Macro Edits */
+              cy.get('.EditsTableWrapper').then((wrapper) => {
+                // Verify edits, if triggered
+                if (wrapper.find('.Verifier').length)
+                  cy.get('#macroVerifier').check()
+                // Move to next step in Submission process
+                cy.get('.NavButtonContainer > .NavButton').click()
+              })
+              cy.wait(ACTION_DELAY)
+
+              /* Action: Sign Submission */
+              if (THIS_IS_BETA) {
+                cy.get('.alert.alert-warning:last').should(
+                  'contain.text',
+                  '[Beta Platform] Filing Simulation Complete!',
+                )
+              } else {
+                cy.wait(500)
+                cy.get('#signature li:first > label').click({ timeout: 2000 })
+                cy.get('#signatureAuth').check('signature', { timeout: 2000 })
+                cy.get('#signature > button').click({ timeout: 2000 })
+              }
+              cy.wait(TEST_DELAY)
+            })
+          })
+      })
+    })
+
+    // Logout of Keycloak
+    it('Logout of Keycloak', function () {
+      cy.visit(
+        `${AUTH_BASE_URL}auth/realms/hmda2/protocol/openid-connect/logout`,
+      )
+    })
+  },
+)

--- a/cypress/e2e/filing/Profile.spec.js
+++ b/cypress/e2e/filing/Profile.spec.js
@@ -1,6 +1,3 @@
-import { isBeta, isCI } from '../../support/helpers'
-import { getDefaultConfig } from '../../../src/common/configUtils'
-import { getFilingPeriods } from '../../../src/common/constants/configHelpers'
 
 const {
   HOST,
@@ -17,75 +14,78 @@ const {
   YEARS,
 } = Cypress.env()
 
-describe('Complete Profile Page', {testIsolation: false}, () => {
-  before(() => {    
-    cy.get({
-      HOST,
-      USERNAME,
-      PASSWORD,
-      INSTITUTION,
-      ACTION_DELAY,
-      TEST_DELAY,
-      NAV_DELAY,
-      ENVIRONMENT,
-      AUTH_BASE_URL,
-      AUTH_REALM,
-      AUTH_CLIENT_ID,
-    }).logEnv()
+describe(
+  'Complete Profile Page',
+  { testIsolation: false, tags: ['@auth-required'] },
+  () => {
+    before(() => {
+      cy.get({
+        HOST,
+        USERNAME,
+        PASSWORD,
+        INSTITUTION,
+        ACTION_DELAY,
+        TEST_DELAY,
+        NAV_DELAY,
+        ENVIRONMENT,
+        AUTH_BASE_URL,
+        AUTH_REALM,
+        AUTH_CLIENT_ID,
+      }).logEnv()
 
-    cy.clearCookies();
-    cy.clearLocalStorage();
-    cy.window().then((win) => win.sessionStorage.clear())
-    
-    cy.keycloakLogin('filing')
-    cy.url().should('contains', `${AUTH_BASE_URL}filing/`)
-    cy.url().should('contains', `/institutions`)
+      cy.clearCookies()
+      cy.clearLocalStorage()
+      cy.window().then((win) => win.sessionStorage.clear())
 
+      cy.keycloakLogin('filing')
+      cy.url().should('contains', `${AUTH_BASE_URL}filing/`)
+      cy.url().should('contains', `/institutions`)
 
-    cy.viewport(1600, 900)
-  })
+      cy.viewport(1600, 900)
+    })
 
-  it('Navigate to the profile page and ensures the correct information is visible', () => {
-    cy.wait(ACTION_DELAY)
+    it('Navigate to the profile page and ensures the correct information is visible', () => {
+      cy.wait(ACTION_DELAY)
 
-    // Complete your profile page checks
-    cy.get('.profile_icon_container').click()
-    cy.get('.profile_form_container > :nth-child(1) > input').should(
-      'have.value',
-      'Cypress',
-    )
-    cy.get(':nth-child(2) > input').should('have.value', 'Test')
-    cy.get(':nth-child(3) > input').should(
-      'have.value',
-      'hmdahelp_test@cfpb.gov',
-    )
-    cy.get('.institutions_checkbox_container').should('have.length', 1)
-  })
+      // Complete your profile page checks
+      cy.get('.profile_icon_container').click()
+      cy.get('.profile_form_container > :nth-child(1) > input').should(
+        'have.value',
+        'Cypress',
+      )
+      cy.get(':nth-child(2) > input').should('have.value', 'Test')
+      cy.get(':nth-child(3) > input').should(
+        'have.value',
+        'hmdahelp_test@cfpb.gov',
+      )
+      cy.get('.institutions_checkbox_container').should('have.length', 1)
+    })
 
-  it('Removes associated institution, banner should popup saying that one associated institution is required to use the filing platform', () => {
-    cy.wait(ACTION_DELAY)
+    it('Removes associated institution, banner should popup saying that one associated institution is required to use the filing platform', () => {
+      cy.wait(ACTION_DELAY)
 
-    cy.get('.institutions_checkbox_container input[type="checkbox"]').uncheck()
-    cy.get('.profile_save_container > button').click()
-    cy.wait(1000)
+      cy.get(
+        '.institutions_checkbox_container input[type="checkbox"]',
+      ).uncheck()
+      cy.get('.profile_save_container > button').click()
+      cy.wait(1000)
 
-    cy.get('.alert-heading').contains(
-      'An institution must be associated with your account.',
-    )
-  })
+      cy.get('.alert-heading').contains(
+        'An institution must be associated with your account.',
+      )
+    })
 
-  it('User gets redirected to complete profile page due to no associated LEIs on their account', () => {
-    cy.wait(5000)
+    it('User gets redirected to complete profile page due to no associated LEIs on their account', () => {
+      cy.wait(5000)
 
-    cy.url().should('contains', '/filing/profile')
+      cy.url().should('contains', '/filing/profile')
 
-    cy.get('.institution_info_container > input').click({ multiple: true })
-    cy.get('.profile_save_container > button').click()
-    cy.wait(1000)
+      cy.get('.institution_info_container > input').click({ multiple: true })
+      cy.get('.profile_save_container > button').click()
+      cy.wait(1000)
 
-    // Back button verifies that the institution was re-added to the account
-    cy.get('.button').contains('Back')
-  })
-
-
-})
+      // Back button verifies that the institution was re-added to the account
+      cy.get('.button').contains('Back')
+    })
+  },
+)

--- a/cypress/e2e/hmda-help/institution.spec.js
+++ b/cypress/e2e/hmda-help/institution.spec.js
@@ -1,7 +1,7 @@
-import { isCI, getSelectedOptionValue, isBeta } from '../../support/helpers'
-import { getFilingYears } from '../../../src/common/constants/configHelpers'
-import { getDefaultConfig } from '../../../src/common/configUtils'
 import { onlyOn } from '@cypress/skip-test'
+import { getDefaultConfig } from '../../../src/common/configUtils'
+import { getFilingYears } from '../../../src/common/constants/configHelpers'
+import { isBeta, isCI } from '../../support/helpers'
 
 const {
   HOST,
@@ -25,7 +25,7 @@ onlyOn(isBeta(HOST), () => {
 })
 
 onlyOn(!isBeta(HOST), () => {
-  describe('HMDA Help - Institutions', () => {
+  describe('HMDA Help - Institutions', { tags: ['@auth-required'] }, () => {
     const years = getFilingYears(getDefaultConfig(HOST))
 
     it('Can update existing Institutions', () => {
@@ -53,9 +53,7 @@ onlyOn(!isBeta(HOST), () => {
 
       // Search for existing Instititution
       cy.wait(5000) // HACK TO ALLOW CASCADING FILER LIST SEARCHES
-      cy.get('#lei-select')
-        .click()
-        .type(INSTITUTION + '{enter}')
+      cy.get('#lei-select').click().type(`${INSTITUTION}{enter}`)
       cy.wait(LOCAL_ACTION_DELAY)
       cy.findAllByText('Update')
         .eq(1) // First row
@@ -82,19 +80,19 @@ onlyOn(!isBeta(HOST), () => {
 
         /**
          * Make changes to the Institution data
-         * 
+         *
          * No longer updating Quarterly Filer select as it has been disabled.
          */
 
         // Change Respondent Name [Text Field]
         cy.findByLabelText(nameLabelText)
-          .type('{selectAll}' + testName)
+          .type(`{selectAll}${testName}`)
           .blur()
           .then(() => {
             // Notes field is required on Update
             cy.findByText(updateButtonText).should('not.be.enabled')
             cy.findByLabelText('Notes')
-              .type('Cypress - Change respondent name ' + timestamp1)
+              .type(`Cypress - Change respondent name ${timestamp1}`)
               .blur()
             cy.findByText(updateButtonText)
               .should('be.enabled')
@@ -132,9 +130,7 @@ onlyOn(!isBeta(HOST), () => {
         /**
          * Revert changes to the Institution data
          */
-        cy.findByLabelText(nameLabelText)
-          .type('{selectAll}' + savedName)
-          .blur()
+        cy.findByLabelText(nameLabelText).type(`{selectAll}${savedName}`).blur()
 
         // Notes field is required on Update
         cy.findByText(updateButtonText).should('not.be.enabled')

--- a/cypress/e2e/hmda-help/publication.spec.js
+++ b/cypress/e2e/hmda-help/publication.spec.js
@@ -1,5 +1,5 @@
-import { isCI, isProd, isBeta, isDev } from '../../support/helpers'
 import { onlyOn } from '@cypress/skip-test'
+import { isBeta, isCI, isDev, isProd } from '../../support/helpers'
 
 const {
   HOST,
@@ -21,7 +21,7 @@ onlyOn(isBeta(HOST), () => {
 })
 
 onlyOn(!isBeta(HOST), () => {
-  describe('HMDA Help - Publications', () => {
+  describe('HMDA Help - Publications', { tags: ['@auth-required'] }, () => {
     it('Can trigger Publication regeneration', () => {
       cy.get({
         HOST,
@@ -50,9 +50,7 @@ onlyOn(!isBeta(HOST), () => {
 
       // Search for existing Instititution
       cy.wait(5000) // HACK TO ALLOW CASCADING FILER LIST SEARCHES
-      cy.get('#lei-select')
-        .click()
-        .type(INSTITUTION + '{enter}')
+      cy.get('#lei-select').click().type(`${INSTITUTION}{enter}`)
       cy.wait(2 * ACTION_DELAY)
       cy.findByText('Search Publications').click()
       cy.wait(ACTION_DELAY)
@@ -60,16 +58,15 @@ onlyOn(!isBeta(HOST), () => {
       // Trigger Publication regeneration
       cy.findAllByText('IRS')
         .parent('tr')
-        
+
         // dev environment's IRS publications in the older years cannot be regenerated, so we're
         // choosing the first instead of the last on dev
         .then(($tr) => {
           if (isDev(HOST)) {
-            return $tr.first();
+            return $tr.first()
           }
-          else {
-            return $tr.last();
-          }
+
+          return $tr.last()
         })
 
         .findByText('Regenerate')

--- a/cypress/e2e/load/LargeFiler.spec.js
+++ b/cypress/e2e/load/LargeFiler.spec.js
@@ -1,5 +1,5 @@
-import { isBeta, isCI } from '../../support/helpers'
 import { getDefaultConfig } from '../../../src/common/configUtils'
+import { isBeta, isCI } from '../../support/helpers'
 
 const {
   HOST,
@@ -21,7 +21,7 @@ const config = getDefaultConfig(HOST)
 const getFilename = (filingPeriod, lei) => `${filingPeriod}-${lei}-MAX.txt`
 const { filingPeriodStatus } = config
 
-describe('Large Filer', () => {
+describe('Large Filer', { tags: ['@auth-required'] }, () => {
   beforeEach(() => {
     cy.get({
       HOST,
@@ -70,7 +70,7 @@ describe('Large Filer', () => {
         cy.get(`#main-content .institution`, { timeout: 20000 })
           .then(($list) => {
             // Find target institution
-            let institution = $list
+            const institution = $list
               .toArray()
               .filter((x) => x.innerText.indexOf(INSTITUTION) > -1)[0]
 

--- a/cypress/e2e/tools/RateSpread.spec.js
+++ b/cypress/e2e/tools/RateSpread.spec.js
@@ -1,10 +1,5 @@
-import {
-  withFormData,
-  isProdDefault,
-  isCI,
-  isBeta,
-} from '../../support/helpers'
 import { onlyOn } from '@cypress/skip-test'
+import { isBeta, isCI, withFormData } from '../../support/helpers'
 
 const { HOST, TEST_DELAY, ENVIRONMENT } = Cypress.env()
 
@@ -91,7 +86,7 @@ onlyOn(!isBeta(HOST), () => {
 
           // Build up the form
           const formData = new FormData()
-          formData.set('file', blob, fileName) //adding a file to the form
+          formData.set('file', blob, fileName) // adding a file to the form
 
           // Perform the request
           withFormData(method, url, formData, function (res) {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,8 +1,10 @@
-import { logEnv, urlExists } from './helpers'
+import { register as registerCypressGrep } from '@cypress/grep'
 import '@testing-library/cypress/add-commands'
-import 'cypress-keycloak'
 import 'cypress-file-upload'
+import 'cypress-keycloak'
+import { logEnv, urlExists } from './helpers'
 
+registerCypressGrep()
 
 // ***********************************************************
 // This example support/index.js is processed and
@@ -49,36 +51,36 @@ Cypress.on('uncaught:exception', (err, runnable) => {
 // Login via Keycloak Impersonate
 Cypress.Commands.add('keycloakLogin', (app) => {
   const { USERNAME, PASSWORD, AUTH_BASE_URL, USERPATH } = Cypress.env()
-    cy.viewport(1201, 700)
-      // Visit the login page
-      cy.visit(`${AUTH_BASE_URL}${USERPATH}`)
-      cy.document().should('have.property', 'readyState', 'complete')
-      cy.get('#kc-page-title').contains('Sign in to your account')
+  cy.viewport(1201, 700)
+  // Visit the login page
+  cy.visit(`${AUTH_BASE_URL}${USERPATH}`)
+  cy.document().should('have.property', 'readyState', 'complete')
+  cy.get('#kc-page-title').contains('Sign in to your account')
 
-      // Enter username
-      cy.get('#username')
-        .type(USERNAME)
+  // Enter username
+  cy.get('#username').type(USERNAME)
 
-      // Enter password
-      cy.get('#password')
-        .type(PASSWORD)
+  // Enter password
+  cy.get('#password').type(PASSWORD)
 
-      // Click submit button
-      cy.get('#kc-login').click()
+  // Click submit button
+  cy.get('#kc-login').click()
 
-      // Verify successful login
-      cy.url().should('include', `${AUTH_BASE_URL}${USERPATH}`, { timeout: 30000 })
+  // Verify successful login
+  cy.url().should('include', `${AUTH_BASE_URL}${USERPATH}`, { timeout: 30000 })
 
-      // Select Impersonate
-      cy.get('[data-testid="action-dropdown"]').click()
-      cy.get('li').contains('Impersonate').should('be.visible').click()
+  // Select Impersonate
+  cy.get('[data-testid="action-dropdown"]').click()
+  cy.get('li').contains('Impersonate').should('be.visible').click()
 
-      // Confirm Impersonation in Modal
-      cy.get('#modal-confirm').should('be.visible').invoke('removeAttr', 'target').click({timeout: 2000})
+  // Confirm Impersonation in Modal
+  cy.get('#modal-confirm')
+    .should('be.visible')
+    .invoke('removeAttr', 'target')
+    .click({ timeout: 2000 })
 
-      // Go to App page
-      cy.visit(`${AUTH_BASE_URL}${app}/2020/institutions`)
+  // Go to App page
+  cy.visit(`${AUTH_BASE_URL}${app}/2020/institutions`)
 
-      cy.wait(10000)
-  
+  cy.wait(10000)
 })

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "yarn run cypress run",
-    "test-non-auth": "yarn run cypress run --env grepTags='-@auth-required'",
+    "test-unauthenticated": "yarn run cypress run --env grepTags='-@auth-required'",
     "test-large": "CYPRESS_YEARS=2020 yarn run cypress run --spec cypress/integration/load/LargeFiler.spec.js",
     "ci": "VITE_ENVIRONMENT=CI yarn start -p 3000",
     "ci-data": "yarn newman run cypress/ci/tests/CREATE_INSTITUTIONS.postman_collection.json -e cypress/ci/config/PLATFORM_ENV.postman_environment.json -d cypress/ci/config/institutions.json",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "yarn run cypress run",
+    "test-non-auth": "yarn run cypress run --env grepTags='-@auth-required'",
     "test-large": "CYPRESS_YEARS=2020 yarn run cypress run --spec cypress/integration/load/LargeFiler.spec.js",
     "ci": "VITE_ENVIRONMENT=CI yarn start -p 3000",
     "ci-data": "yarn newman run cypress/ci/tests/CREATE_INSTITUTIONS.postman_collection.json -e cypress/ci/config/PLATFORM_ENV.postman_environment.json -d cypress/ci/config/institutions.json",
@@ -80,6 +81,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.23.8",
     "@babel/preset-react": "^7.23.3",
+    "@cypress/grep": "^5.0.0",
     "@cypress/skip-test": "2.6.0",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@testing-library/cypress": "10.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,6 +1605,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cypress/grep@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@cypress/grep@npm:5.0.0"
+  dependencies:
+    debug: "npm:^4.3.4"
+    find-test-names: "npm:^1.28.18"
+    globby: "npm:^11.0.4"
+  peerDependencies:
+    cypress: ">=10"
+  checksum: 10c0/c8f56cb0d3fa39defc751305f32da23addfc73de946e67e08d0194653571b266c59baeac52085f99ce5613211c529b526ae974621288c887b848d4d5f624be2d
+  languageName: node
+  linkType: hard
+
 "@cypress/request@npm:^3.0.9":
   version: 3.0.9
   resolution: "@cypress/request@npm:3.0.9"
@@ -2473,14 +2486,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodelib/fs.stat@npm:2.0.5":
+"@nodelib/fs.stat@npm:2.0.5, @nodelib/fs.stat@npm:^2.0.2":
   version: 2.0.5
   resolution: "@nodelib/fs.stat@npm:2.0.5"
   checksum: 10c0/88dafe5e3e29a388b07264680dc996c17f4bda48d163a9d4f5c1112979f0ce8ec72aa7116122c350b4e7976bc5566dc3ddb579be1ceaacc727872eb4ed93926d
   languageName: node
   linkType: hard
 
-"@nodelib/fs.walk@npm:^1.2.8":
+"@nodelib/fs.walk@npm:^1.2.3, @nodelib/fs.walk@npm:^1.2.8":
   version: 1.2.8
   resolution: "@nodelib/fs.walk@npm:1.2.8"
   dependencies:
@@ -3267,7 +3280,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.9.0":
+"acorn-walk@npm:^8.2.0":
+  version: 8.3.4
+  resolution: "acorn-walk@npm:8.3.4"
+  dependencies:
+    acorn: "npm:^8.11.0"
+  checksum: 10c0/76537ac5fb2c37a64560feaf3342023dadc086c46da57da363e64c6148dc21b57d49ace26f949e225063acb6fb441eabffd89f7a3066de5ad37ab3e328927c62
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.11.0, acorn@npm:^8.9.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -3534,6 +3556,13 @@ __metadata:
   version: 1.1.0
   resolution: "array-slice@npm:1.1.0"
   checksum: 10c0/dfefd705905f428b6c4cace2a787f308b5a64db5411e33cdf8ff883b6643f1703e48ac152b74eea482f8f6765fdf78b5277e2bad7840be2b4d5c23777db3266f
+  languageName: node
+  linkType: hard
+
+"array-union@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "array-union@npm:2.1.0"
+  checksum: 10c0/429897e68110374f39b771ec47a7161fc6a8fc33e196857c0a396dc75df0b5f65e4d046674db764330b6bb66b39ef48dd7c53b6a2ee75cfb0681e0c1a7033962
   languageName: node
   linkType: hard
 
@@ -5167,6 +5196,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.3.3":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
+  languageName: node
+  linkType: hard
+
 "dedent@npm:^1.0.0":
   version: 1.6.0
   resolution: "dedent@npm:1.6.0"
@@ -5282,6 +5323,15 @@ __metadata:
     miller-rabin: "npm:^4.0.0"
     randombytes: "npm:^2.0.0"
   checksum: 10c0/ce53ccafa9ca544b7fc29b08a626e23a9b6562efc2a98559a0c97b4718937cebaa9b5d7d0a05032cc9c1435e9b3c1532b9e9bf2e0ede868525922807ad6e1ecf
+  languageName: node
+  linkType: hard
+
+"dir-glob@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "dir-glob@npm:3.0.1"
+  dependencies:
+    path-type: "npm:^4.0.0"
+  checksum: 10c0/dcac00920a4d503e38bb64001acb19df4efc14536ada475725e12f52c16777afdee4db827f55f13a908ee7efc0cb282e2e3dbaeeb98c0993dd93d1802d3bf00c
   languageName: node
   linkType: hard
 
@@ -6449,6 +6499,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-glob@npm:^3.2.9":
+  version: 3.3.3
+  resolution: "fast-glob@npm:3.3.3"
+  dependencies:
+    "@nodelib/fs.stat": "npm:^2.0.2"
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    glob-parent: "npm:^5.1.2"
+    merge2: "npm:^1.3.0"
+    micromatch: "npm:^4.0.8"
+  checksum: 10c0/f6aaa141d0d3384cf73cbcdfc52f475ed293f6d5b65bfc5def368b09163a9f7e5ec2b3014d80f733c405f58e470ee0cc451c2937685045cddcdeaa24199c43fe
+  languageName: node
+  linkType: hard
+
 "fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
@@ -6592,6 +6655,24 @@ __metadata:
   version: 1.1.0
   resolution: "find-root@npm:1.1.0"
   checksum: 10c0/1abc7f3bf2f8d78ff26d9e00ce9d0f7b32e5ff6d1da2857bcdf4746134c422282b091c672cde0572cac3840713487e0a7a636af9aa1b74cb11894b447a521efa
+  languageName: node
+  linkType: hard
+
+"find-test-names@npm:^1.28.18":
+  version: 1.29.18
+  resolution: "find-test-names@npm:1.29.18"
+  dependencies:
+    "@babel/parser": "npm:^7.27.2"
+    "@babel/plugin-syntax-jsx": "npm:^7.27.1"
+    acorn-walk: "npm:^8.2.0"
+    debug: "npm:^4.3.3"
+    globby: "npm:^11.0.4"
+    simple-bin-help: "npm:^1.8.0"
+  bin:
+    find-test-names: bin/find-test-names.js
+    print-tests: bin/print-tests.js
+    update-test-count: bin/update-test-count.js
+  checksum: 10c0/68cdb66ec55247e7d0c768bd00ef1d0cf6b7af005c880d57089da55083f5e168f25b64485346b1ded420bb6404a2cb232dd645f6d53677927e1a1420863058fb
   languageName: node
   linkType: hard
 
@@ -7040,6 +7121,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globby@npm:^11.0.4":
+  version: 11.1.0
+  resolution: "globby@npm:11.1.0"
+  dependencies:
+    array-union: "npm:^2.1.0"
+    dir-glob: "npm:^3.0.1"
+    fast-glob: "npm:^3.2.9"
+    ignore: "npm:^5.2.0"
+    merge2: "npm:^1.4.1"
+    slash: "npm:^3.0.0"
+  checksum: 10c0/b39511b4afe4bd8a7aead3a27c4ade2b9968649abab0a6c28b1a90141b96ca68ca5db1302f7c7bd29eab66bf51e13916b8e0a3d0ac08f75e1e84a39b35691189
+  languageName: node
+  linkType: hard
+
 "glogg@npm:^2.2.0":
   version: 2.2.0
   resolution: "glogg@npm:2.2.0"
@@ -7352,6 +7447,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.23.8"
     "@babel/preset-react": "npm:^7.23.3"
     "@cfpb/cfpb-analytics": "npm:^0.3.2"
+    "@cypress/grep": "npm:^5.0.0"
     "@cypress/skip-test": "npm:2.6.0"
     "@docsearch/react": "npm:3.6.0"
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
@@ -9363,7 +9459,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4":
+"merge2@npm:^1.3.0, merge2@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "merge2@npm:1.4.1"
+  checksum: 10c0/254a8a4605b58f450308fc474c82ac9a094848081bf4c06778200207820e5193726dc563a0d2c16468810516a5c97d9d3ea0ca6585d23c58ccfff2403e8dbbeb
+  languageName: node
+  linkType: hard
+
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -11944,6 +12047,13 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
+  languageName: node
+  linkType: hard
+
+"simple-bin-help@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "simple-bin-help@npm:1.8.0"
+  checksum: 10c0/baf17cdfa407b0b2ae3c5380e7c22cca058eb34dfa0909a70f892049b5e6a8b3f6f171cc318be8910111bfa75b48c5c6b84faf45028fd9634a39b4ff1b8f9cf3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There's a lot of automatic linting fixes, view the diff with [whitespace ignored](https://github.com/cfpb/hmda-frontend/pull/2616/files?diff=split&w=1).

Adds an `@auth-required` tag to cypress tests that require keycloak authentication. Non-auth tests can be run utilizing cypress' [grep package](https://github.com/cypress-io/cypress/tree/develop/npm/grep) by passing `--env grepTags='-@auth-required'` which is saved as a script called `yarn test-non-auth`.

I also created a github workflow to run the tests on pull requests.

Fixes https://github.com/cfpb/hmda-frontend/issues/2604

## Changes

- Adds a tag to tests that require authentication to run.
- Creates an npm script targeting non-auth tests.
- Adds a github test workflow.

## Testing

1. The brand new pull request workflow below should pass

## Notes

- I'm open to other naming conventions, `non-auth` is kind of a weird phrase.
