### PR TITLE
fix(homepage): update 2024 supplementary guide link for quarterly filers to 2025

### DIFF
--- a/src/homepage/ForFilers/FilingGuides.jsx
+++ b/src/homepage/ForFilers/FilingGuides.jsx
@@ -1,6 +1,4 @@
-import { LATEST_FIG_YEAR } from '../../common/constants/years'
 import { ExternalLink } from '../../common/ExternalLink'
-import { ExpandableCard } from '../ExpandableCard'
 import NewIndicator from '../NewIndicator'
 
 const figUpdates = {
@@ -37,8 +35,8 @@ export function FilingGuides() {
               <NewIndicator />
             </li>
             <li>
-              <a href='/documentation/fig/2024/supplemental-guide-for-quarterly-filers'>
-                Online Supplemental Guide for Quarterly Filers for 2024
+              <a href='/documentation/fig/2025/supplemental-guide-for-quarterly-filers'>
+                Online Supplemental Guide for Quarterly Filers for 2025
               </a>
               <NewIndicator />
             </li>


### PR DESCRIPTION
🚀 Currently on Dev as of 1:35 PT as 5167-update-fig-link 🚀

## Changes

- We're updating the link for the Online Supplemental Guide for Quarterly Filers for 2024 to 2025 before the FIG update. For context see ENT #5167 for context.

## Testing

1. Does the homepage show the new link?
<img width="437" height="80" alt="Screenshot 2025-09-29 at 8 28 46 AM" src="https://github.com/user-attachments/assets/960a5180-903f-406d-a30b-a8db95e72931" />

2. Do the tests still pass?
