### PR TITLE
fix(security): update pcre2 library to at least 10.46-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM node:20-alpine3.22 as build-stage
 WORKDIR /usr/src/app
 ARG DOCKER_TAG="latest"
 
+# updates pcre2 library to fix CVE-2025-58050 in alpine base image by updating it to at least 10.46-r0
+RUN apk update && apk upgrade pcre2>=10.46
+
 RUN --mount=type=secret,id=env_vars \
   cp /run/secrets/env_vars .env
 
@@ -25,6 +28,10 @@ RUN echo "{ \"version\": \"${DOCKER_TAG}\" }" > ./src/common/constants/release.j
 RUN yarn build
 
 FROM nginx:alpine3.22
+
+# updates pcre2 library to fix CVE-2025-58050 in alpine base image by updating it to at least 10.46-r0
+RUN apk update && apk upgrade pcre2>=10.46
+
 ENV NGINX_USER=svc_nginx_hmda
 RUN apk update && apk upgrade
 RUN rm -rf /etc/nginx/conf.d


### PR DESCRIPTION
## Changes

- Updates pcre2 regex library to at least `10.46-r0` to address CVE-2025-58050 in our alpine image

## Testing

1. Does it run on Dev? Yep! It's on Dev currently as `v3.2.20-rc2` 🚀
2. Do the e2e tests pass? Yes! ✅
3. Is Lamin happy with the changes? Yes! Ran his checks against Dev and the CVE is resolved 🥳
