### PR TITLE
fix(mlar): persist header settings across searches

### DIFF
--- a/src/data-publication/reports/Results.jsx
+++ b/src/data-publication/reports/Results.jsx
@@ -125,7 +125,7 @@ class Results extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.inputValue !== this.props.inputValue) {
-      this.setState(defaultState)
+      this.setState({ showAll: false })
     }
   }
 


### PR DESCRIPTION
Fixes some weird UX where if a user checks the "with header" checkbox on the [mlar page](https://ffiec.cfpb.gov/data-publication/modified-lar/2025), it would not persist this preference after doing other searches.


https://github.com/user-attachments/assets/af0557e7-b055-4b91-8ae9-66094b6757a9



## Changes

- The defaultState has two props: 
```
const defaultState = {
  showAll: false,
  withHeader: false,
}
```

`showAll `-> a button that lets a user see all the search results instead of the first 10
`withHeader` -> does a user want to download mlar with headers

`componentWillReceiveProps` is currently resetting the entire `defaultState` every time the component is receiving new props (like search parameters).

```
  componentWillReceiveProps(nextProps) {
    if (nextProps.inputValue !== this.props.inputValue) {
      this.setState(defaultState)
    }
  }
  ```


But we don't want to reset the entire state when new props hit: only the `showAll` prop needs to be reset (to show all institutions) not the `withHeader` prop.

```
this.setState({ showAll: false })
```

## Testing

1. Do the tests pass? Yes!
2. How does it look on staging? Yes! (tagged as `4967-fix-mlar-with-header-across-searches`)