### PR TITLE
fix(mlar): tie the checkbox to the withHeader state

### DIFF
--- a/src/data-publication/reports/Results.jsx
+++ b/src/data-publication/reports/Results.jsx
@@ -149,7 +149,7 @@ class Results extends React.Component {
           type='checkbox'
           name='inclHeader'
           id='inclHeader'
-          value={this.state.withHeader}
+          checked={this.state.withHeader}
           onChange={(e) => this.setState({ withHeader: e.target.checked })}
         />
       </p>


### PR DESCRIPTION
Discovering a bug... under the other bug. 🐛🐜

The checkbox's `checked` visual state wasn't actually tied to the state of the component.

Check out this code:
```
  renderIncludeFileHeader() {
    return (
      <p>
        Include File Header{' '}
        <input
          type='checkbox'
          name='inclHeader'
          id='inclHeader'
          value={this.state.withHeader}
          onChange={(e) => this.setState({ withHeader: e.target.checked })}
        />
      </p>
    )
  }
  ```

Checking the box would change the state of `withHeader` via the `onChange` event. But only the `value` of the checkbox would be changed, but that doesn't affect the appearance of the checkbox that `checked` would do (also we don't need the `value` at all since we're not submitting a form or anything, since it's the `onChange` doing the work here.)

## Changes

- tie the `checked` state of the with headers button to the `withHeaders` state

## Testing

1. How does it look on staging? Good! (tagged as `4967-fix-mlar-with-header-across-searches`)
2. Do the tests pass? Yes!
3. Does Chynna approve of it? Yes!

## Notes

- I'll do a follow-up PR for the accessibility stuff someday, because there are several that might need to get tweaked.
