### PR TITLE
Cancel Maintenance Announcement for April 9 2026

### DIFF
--- a/src/common/constants/prod-beta-config.json
+++ b/src/common/constants/prod-beta-config.json
@@ -1,22 +1,10 @@
 {
   "name": "prod-beta",
-  "announcement": [
-    {
-      "message": "We will be performing scheduled system maintenance on April 9 from 8PM - 11PM EST. During this time users will be unable to log in to the Filing application or create new accounts.",
-      "type": "warning",
-      "heading": "Scheduled Maintenance",
-      "link": null
-    }
-  ],
+  "announcement": [],
   "fileServerDomain": "https://files.ffiec.cfpb.gov",
   "publicationReleaseYear": "2020",
   "maintenanceMode": false,
-  "filingAnnouncement": {
-    "message": "We will be performing scheduled system maintenance on April 9 from 8PM - 11PM EST. During this time users will be unable to log in to the Filing application or create new accounts.",
-    "type": "warning",
-    "heading": "Scheduled Maintenance",
-    "endDate": null
-  },
+  "filingAnnouncement": null,
   "ffvtAnnouncement": null,
   "dataPublicationYears": {
     "shared": [

--- a/src/common/constants/prod-config.json
+++ b/src/common/constants/prod-config.json
@@ -2,12 +2,6 @@
   "name": "prod",
   "announcement": [
     {
-      "message": "We will be performing scheduled system maintenance on April 9 from 8PM - 11PM EST. During this time users will be unable to log in to the Filing application or create new accounts.",
-      "type": "warning",
-      "heading": "Scheduled Maintenance",
-      "link": null
-    },
-    {
       "heading": "2025 Modified LAR Data Release",
       "message": "On March 31, 2026, the 2025 Modified LAR was released. A combined file containing all LAR records in a single file is also available. These files can be accessed via the ",
       "type": "info",
@@ -42,12 +36,7 @@
   "publicationReleaseYear": "2024",
   "mlarReleaseYear": "2025",
   "maintenanceMode": false,
-  "filingAnnouncement": {
-    "message": "We will be performing scheduled system maintenance on April 9 from 8PM - 11PM EST. During this time users will be unable to log in to the Filing application or create new accounts.",
-    "type": "warning",
-    "heading": "Scheduled Maintenance",
-    "endDate": null
-  },
+  "filingAnnouncement": null,
   "ffvtAnnouncement": null,
   "dataPublicationYears": {
     "shared": [


### PR DESCRIPTION
We're going to cancel the April 9th maintenance announcement to be rescheduled soon.

## Changes

- This reverts commit b3b7ad23c8e79bca110e9e7324e3755b7fd626bf.

## Testing

- Are tests passing? Yes!