### PR TITLE
e2e(mlar): update staging cases, test checked state

### DIFF
--- a/cypress/e2e/data-publication/ModifiedLAR.spec.js
+++ b/cypress/e2e/data-publication/ModifiedLAR.spec.js
@@ -1,5 +1,5 @@
 import { onlyOn } from '@cypress/skip-test';
-import { isBeta, isDev } from '../../support/helpers';
+import { isBeta, isDev, isStaging } from '../../support/helpers';
 const { HOST, YEARS } = Cypress.env()
 
 const downloadsFolder = Cypress.config('downloadsFolder')
@@ -12,7 +12,7 @@ const years = (YEARS && YEARS.toString().split(',')) || [
 const testCases = 
   years.map(year => {
 
-    // special case for 2017 on both dev and prod
+    // special case for 2017 on both dev, staging, and prod
     if (year === 2017) {
       return {
         year,
@@ -21,8 +21,8 @@ const testCases =
       }
     }
 
-    // special case for 2018 on prod
-    if (year === 2018 && !isDev(HOST)) {
+    // special case for 2018 on prod or staging
+    if (year === 2018 && (isStaging(HOST) || !isDev(HOST))) {
       return {
         year,
         name: 'cypress bank, state savings bank',
@@ -30,13 +30,30 @@ const testCases =
       }
     }
 
-    // default case for all other years for dev and prod
-    return {
+  const getDefaultCaseInstitution = () => {
+    const prodTestInstitution = {
       year,
-      name: isDev(HOST) ? 'FRONTEND TEST BANK' : 'cypress bank, ssb',
-      institution: isDev(HOST) ? 'FRONTENDTESTBANK9999' : '549300I4IUWMEMGLST06',
+      name: 'cypress bank, ssb',
+      institution: '549300I4IUWMEMGLST06',
     }
-  })
+    const devTestInstitution = {
+      year,
+      name: 'FRONTEND TEST BANK',
+      institution: 'FRONTENDTESTBANK9999',
+    }
+
+    // explicitly set staging to have prod instead of dev data
+    if (isStaging(HOST)) return prodTestInstitution
+    if (isDev(HOST)) return devTestInstitution
+    return prodTestInstitution
+  }
+
+  return {
+    year,
+    ...getDefaultCaseInstitution(),
+  }
+})
+
 
 onlyOn(isBeta(HOST), () => {
   describe('Modified LAR', function () {
@@ -78,7 +95,7 @@ onlyOn(!isBeta(HOST), () => {
 
         // Ticking the "Include Header" option updates download link appropriately
         cy.get('#inclHeader').click()
-        cy.get('#inclHeader').check('true')
+        cy.get('#inclHeader').should('be.checked')
 
         cy.get(
           '#main-content .SearchList > .Results > li > .font-small',

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -2,6 +2,7 @@ export const cleanHost = (host) => host.replace(/^https?:\/\//, '')
 export const isCI = (env) => env === 'CI'
 export const isProd = (host) => !!cleanHost(host).match(/^ffiec(\.beta)?\.cfpb/)
 export const isBeta = (host) => !!cleanHost(host).match(/beta/)
+export const isStaging = (host) => !!cleanHost(host).match(/staging/)
 export const isDev = (host) => !isProd(host)
 export const isDevBeta = (host) => isDev(host) && isBeta(host)
 export const isProdBeta = (host) => isProd(host) && isBeta(host)


### PR DESCRIPTION
To get mlar tests going again on staging again, we'll want to explicitly set the test cases for the staging environment to the same cases as prod. We also fix the "with headers" checkbox test after we fixed [the behavior over here](https://github.com/cfpb/hmda-frontend/pull/2729).

## Changes

- cypress/e2e/data-publication/ModifiedLAR.spec.js 
  - sets staging environment to use the same test cases as prod
  - makes a changes `cy.get('#inclHeader').check('true')` to `cy.get('#inclHeader').should('be.checked')` since we no longer have to manually set the checkbox to true [after I fixed it over here](https://github.com/cfpb/hmda-frontend/pull/2729). Instead we just do a quick assertion to make sure the checkbox is checked.
- cypress/support/helpers.js
  - add a `isStaging` helper function 

## Testing

1. Do the mlar tests pass on staging now? Yes!
<img width="884" height="140" alt="passes-on-staging" src="https://github.com/user-attachments/assets/74992e0b-6783-4482-95fc-387c5691f40e" />

2. Are the unit tests passing? Yep!

<img width="458" height="41" alt="Screenshot 2026-04-15 at 10 09 42 AM" src="https://github.com/user-attachments/assets/a711c4eb-0044-48e6-b3e9-c1164967ead1" />
