### PR TITLE
fix(deps): bump lodash from 4.17 to 4.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jspdf": "4.2.1",
     "jwt-decode": "^3.1.2",
     "keycloak-js": "25.0.6",
+    "lodash": "4.18.1",
     "mapbox-gl": "1.13.3",
     "mark.js": "^8.11.1",
     "normalize.css": "8.0.1",
@@ -147,7 +148,8 @@
     "cipher-base": ">=1.0.5",
     "cheerio": "1.0.0-rc.10",
     "qs": ">=6.14.0",
-    "minimatch": "10.2.3"
+    "minimatch": "10.2.3",
+    "lodash": "4.18.1"
   },
   "packageManager": "yarn@4.1.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8028,6 +8028,7 @@ __metadata:
     jspdf: "npm:4.2.1"
     jwt-decode: "npm:^3.1.2"
     keycloak-js: "npm:25.0.6"
+    lodash: "npm:4.18.1"
     mapbox-gl: "npm:1.13.3"
     mark.js: "npm:^8.11.1"
     normalize.css: "npm:8.0.1"
@@ -9955,17 +9956,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump the lodash version to 4.18.1.

Before this PR, lodash was being used via a transitive dependency in cypress. Instead of importing the library via another library, we're now making it a real dependency and ensuring all deps use this newer version.

## Changes

- updates lodash from `4.17.21`/`4.17.23` to `4.18.1`

## Testing

1. Do the tests still pass? Yes!
<img width="467" height="49" alt="Screenshot 2026-04-20 at 9 28 44 AM" src="https://github.com/user-attachments/assets/7a9ed00d-80b3-42c1-a184-720209362c08" />
