### PR TITLE
fix(deps): bump axios from 1.13.6 to 1.15.1

### DIFF
--- a/scripts/lar/setup.sh
+++ b/scripts/lar/setup.sh
@@ -1,2 +1,2 @@
 # Pinned the axios version to ensure a good version, but can be updated as needed
-yarn add axios@v1.13.6
+yarn add axios@v1.15.1


### PR DESCRIPTION
Let's bump this axios version in the old fixture generating script for Lamin 🚀

## Changes

- bump axios version from `1.13.6` to `1.15.1` in the lar generating script

## Testing

1. Do the tests still pass? Yes!
<img width="447" height="52" alt="Screenshot 2026-04-20 at 9 54 44 AM" src="https://github.com/user-attachments/assets/eca0c94a-6ccc-46ef-92fe-42da8c9b8647" />

