### PR TITLE
fix(github-actions): pin action versions

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -24,13 +24,13 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Deploy PR preview
         id: preview-step
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1
         with:
           source-dir: ./dist
           preview-branch: gh-pages
@@ -57,7 +57,7 @@ jobs:
 
       - name: Update sticky preview comment
         if: steps.preview-step.outputs.deployment-action == 'deploy'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: pr-preview
           message: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
 


### PR DESCRIPTION
Due to some recent supply chain attacks, Lamin would prefer if we locked the github actions to SHAs instead of just the version number. I used the same script that cf.gov [used over here](https://github.cfpb.gov/Design-Development/cfgov/issues/4673#issuecomment-375885), thanks @chosak!

## Changes

- Instead of using a version number, locks github actions to SHAs

## Testing

1. Do the github actions still work? Yes!
2. Do the tests still pass? Yes!
