### PR TITLE
fix(cache): replace hardcoded asset preload URLs with source URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,6 @@
       type="font/woff2"
       crossorigin="anonymous"
     />
-    <link rel="modulepreload" href="/src/common/uswds/js/uswds-init.min.js" />
-    <link rel="modulepreload" href="/src/common/uswds/js/uswds.min.js" />
     <!--
       Notice the use of  in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/index.html
+++ b/index.html
@@ -33,13 +33,13 @@
     />
     <link
       rel="preload"
-      href="/assets/uswds-init.min-D1tzE0C5.js"
+      href="/src/common/uswds/js/uswds-init.min.js"
       as="script"
       crossorigin="anonymous"
     />
     <link
       rel="preload"
-      href="/assets/uswds.min-BjNqw5Kx.js"
+      href="/src/common/uswds/js/uswds.min.js"
       as="script"
       crossorigin="anonymous"
     />

--- a/index.html
+++ b/index.html
@@ -31,19 +31,8 @@
       type="font/woff2"
       crossorigin="anonymous"
     />
-    <link
-      rel="preload"
-      href="/src/common/uswds/js/uswds-init.min.js"
-      as="script"
-      crossorigin="anonymous"
-    />
-    <link
-      rel="preload"
-      href="/src/common/uswds/js/uswds.min.js"
-      as="script"
-      crossorigin="anonymous"
-    />
-
+    <link rel="modulepreload" href="/src/common/uswds/js/uswds-init.min.js" />
+    <link rel="modulepreload" href="/src/common/uswds/js/uswds.min.js" />
     <!--
       Notice the use of  in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
Vite replaces the URLs at build time with hashed minified versions.

See https://vite.dev/guide/assets.html
See https://vite.dev/guide/#index-html-and-project-root

## Changes

- Replace hardcoded USWDS asset URLs with their source URLs.

## Testing

1. Run `yarn build` and `yarn start` locally and check out the generated `index.html` file in the `/dist` dir.

