### PR TITLE
Add news update about FIG edit link format change

### DIFF
--- a/src/updates-notes/change-log.md
+++ b/src/updates-notes/change-log.md
@@ -3,7 +3,7 @@ date: 04/30/26
 type: update
 product: documentation
 ---
-The format of links to individual edits in our Filing Instructions Guides have changed. The new links can be found by clicking the `#` next to the edit ID in a FIG, e.g. https://ffiec.cfpb.gov/documentation/fig/2026/overview#edit-S302
+To optimize filers' user experience workflow, we have implemented contextual deep links between the filing application and the Filing Instructions Guides. Triggered edits now link directly to their descriptions in the FIG. The new links can be found by clicking the **#** next to the edit ID in a FIG, e.g. [https://ffiec.cfpb.gov/documentation/fig/2026/overview#edit-S302](https://ffiec.cfpb.gov/documentation/fig/2026/overview#edit-S302)
 
 ---
 date: 04/13/26

--- a/src/updates-notes/change-log.md
+++ b/src/updates-notes/change-log.md
@@ -1,4 +1,11 @@
 ---
+date: 04/30/26
+type: update
+product: documentation
+---
+The format of links to individual edits in our Filing Instructions Guides have changed. The new links can be found by clicking the `#` next to the edit ID in a FIG, e.g. https://ffiec.cfpb.gov/documentation/fig/2026/overview#edit-S302
+
+---
 date: 04/13/26
 type: update
 product: mlar

--- a/src/updates-notes/change-log.md
+++ b/src/updates-notes/change-log.md
@@ -3,7 +3,7 @@ date: 04/30/26
 type: update
 product: documentation
 ---
-To optimize filers' user experience workflow, we have implemented contextual deep links between the filing application and the Filing Instructions Guides. Triggered edits now link directly to their descriptions in the FIG. The new links can be found by clicking the **#** next to the edit ID in a FIG, e.g. [https://ffiec.cfpb.gov/documentation/fig/2026/overview#edit-S302](https://ffiec.cfpb.gov/documentation/fig/2026/overview#edit-S302)
+To optimize filers' user experience workflow, we have added links between the filing application and the Filing Instructions Guides. Triggered edits now link directly to their descriptions in the FIG. The new links can be found by clicking the **#** next to the edit ID in a FIG, e.g. [https://ffiec.cfpb.gov/documentation/fig/2026/overview#edit-S302](https://ffiec.cfpb.gov/documentation/fig/2026/overview#edit-S302)
 
 ---
 date: 04/13/26


### PR DESCRIPTION
The edit links in the FIGs changed from `/documentation/fig/${year}/overview#table${X}-${id}` to `/documentation/fig/${year}/overview#edit-${id}`. Should I include these exact details in the news update? It felt too technical for our readership. 🤷 