### PR TITLE
fix(dockerfile): bump curl, remove pcre bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ RUN apk add ca-certificates --no-cache --no-check-certificate && \
     cp /etc/ssl/certs/ca-certificates.crt /usr/src/app/ca-certificates.crt
 ARG NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/zscaler-root-public.cert
 
-# updates pcre2 library to fix CVE-2025-58050 in alpine base image by updating it to at least 10.46-r0
-RUN apk update && apk upgrade pcre2>=10.46
-
 RUN --mount=type=secret,id=env_vars \
   cp /run/secrets/env_vars .env
 
@@ -37,8 +34,11 @@ RUN yarn build
 FROM nginx:alpine3.23
 COPY --from=build-stage  /usr/src/app/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-# updates pcre2 library to fix CVE-2025-58050 in alpine base image by updating it to at least 10.46-r0
-RUN apk update && apk upgrade pcre2>=10.46
+# Temporary fix for vulnerability CVE-2026-3805 (curl, fix currently on edge only)
+# More info at: GHE #5550
+RUN echo "@edge https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+    apk update && \
+    apk add --no-cache curl@edge libcurl@edge
 
 ENV NGINX_USER=svc_nginx_hmda
 RUN apk update && apk upgrade


### PR DESCRIPTION
Right now on `nginx:alpine3.23`, `curl` has vulnerabilities that haven't made it into the newest release yet, at least in a way that prisma cloud is happy with.

It's a little tricky to update `curl` manually, but I think it's worth it for now (with a follow-up ticket GHE #5550 to remove this temporary patch down the road if we want to).

The update we need for `curl` is only in the alpine edge repository.

I'm also taking the moment to remove the `pcre2` temporary fix, since it's been updated in the latest version of the docker image.

## Changes
- updates `curl` from the alpine edge repository (and their peer deps)
- removes the old `pcre2` patch that is no longer needed (prisma now passes without it)

## Testing
- Does this resolve the vulnerabilities to prisma's satisfaction? Yes!

<img width="1374" height="276" alt="hmda-frontend" src="https://github.com/user-attachments/assets/53f1c5b6-8579-4281-aaab-9abf63f39dd6" />

- Does it look good on staging? Yes!