### PR TITLE
feat(nav): make filing button in main nav auth-aware

### DIFF
--- a/cypress/e2e/common-features/navigation.spec.js
+++ b/cypress/e2e/common-features/navigation.spec.js
@@ -47,4 +47,17 @@ onlyOn(!isBeta(HOST), () => {
     })
   })
 
+  describe('Main header nav', { tags: ['@smoke'] }, () => {
+    it('Links to the filing login page when not logged in', { tags: '@localhost' }, () => {
+      cy.visit(baseURLToVisit)
+
+      cy.get('header.usa-header--basic')
+        .contains('.usa-nav__primary-item > a.usa-nav__link', /^Filing$/)
+        .as('filingLink')
+
+      cy.get('@filingLink').click()
+      cy.location('pathname').should('match', /\/filing\/\d{4}\/?$/)
+    })
+  })
+
 })

--- a/cypress/e2e/common-features/navigation.spec.js
+++ b/cypress/e2e/common-features/navigation.spec.js
@@ -55,7 +55,7 @@ onlyOn(!isBeta(HOST), () => {
         .contains('.usa-nav__primary-item > a.usa-nav__link', /^Filing$/)
         .as('filingLink')
 
-      cy.get('@filingLink').click()
+      cy.get('@filingLink').click({force: true})
       cy.location('pathname').should('match', /\/filing\/\d{4}\/?$/)
     })
   })

--- a/cypress/e2e/filing/Filing.spec.js
+++ b/cypress/e2e/filing/Filing.spec.js
@@ -51,6 +51,17 @@ describe(
     const THIS_IS_BETA = isBeta(HOST)
     const testVsOfficial = THIS_IS_BETA ? 'test' : 'official'
 
+    it('Sends users to the institution page when logged in and clicking the Filing nav item', () => {
+      cy.visit(`${AUTH_BASE_URL}filing/2020/institutions`)
+      cy.wait(ACTION_DELAY)
+      cy.get('header.usa-header--basic')
+        .contains('.usa-nav__primary-item > a.usa-nav__link', /^Filing$/)
+        .as('filingLink')
+
+      cy.get('@filingLink').click()
+      cy.contains('Collection of 2020 HMDA data has ended.').should('exist')
+    })
+
     years.forEach((filingPeriod, index) => {
       it(`${filingPeriod}`, { tags: ['@smoke'] }, function () {
         const status = filingPeriodStatus[filingPeriod]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,22 +1,21 @@
-import React, { useEffect, useState } from 'react'
-import { Switch, Route, useLocation } from 'react-router-dom'
-import Header from './common/Header'
-import NotFound from './common/NotFound'
-import Footer from './common/Footer'
+import { useEffect, useState } from 'react'
+import { Route, Switch, useLocation } from 'react-router-dom'
+import { AppContext } from './common/appContextHOC'
 import Beta, { isBeta } from './common/Beta'
-import makeAsyncComponent from './common/makeAsyncComponent.jsx'
-import { useEnvironmentConfig } from './common/useEnvironmentConfig'
 import {
   betaLinks,
   defaultLinks,
-  updateFilingLink,
 } from './common/constants/links'
-import { AppContext } from './common/appContextHOC'
+import Footer from './common/Footer'
+import Header from './common/Header'
+import makeAsyncComponent from './common/makeAsyncComponent.jsx'
+import NotFound from './common/NotFound'
+import { useEnvironmentConfig } from './common/useEnvironmentConfig'
 
 import './app.css'
+import ScrollToTop from './common/ScrollToTop'
 import { isFilingHomeOrYear } from './filing/utils/pages'
 import { useViewport } from './filing/utils/useViewport'
-import ScrollToTop from './common/ScrollToTop'
 
 const Homepage = makeAsyncComponent(
   () => import('./homepage'),
@@ -85,7 +84,7 @@ const App = () => {
 
   const headerLinks = isBeta()
     ? betaLinks
-    : updateFilingLink(config, defaultLinks)
+    : defaultLinks
 
   return (
     <AppContext.Provider value={{ config }}>

--- a/src/common/Header.jsx
+++ b/src/common/Header.jsx
@@ -1,15 +1,15 @@
-import React, { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { isBeta } from '../common/Beta'
 import BannerUSA from './BannerUSA'
 import { defaultLinks } from './constants/links'
-import { isBeta } from '../common/Beta'
 
-import './uswds/css/styles.css'
 import logo from './images/ffiec-logo.svg'
+import './uswds/css/styles.css'
 import closeBtn from './uswds/img/usa-icons/close.svg'
 
-import { DocSearch } from '@docsearch/react'
 import '@docsearch/css'
+import { DocSearch } from '@docsearch/react'
 
 export const hideHeaderFooter = (path) => {
   const parts = path && path.split('/')
@@ -86,12 +86,12 @@ const Header = ({ location: { pathname }, links = defaultLinks, ...props }) => {
         <div className='usa-nav-container'>
           <div className='usa-navbar'>
             <div className='usa-logo' id='logo'>
-              <a className='nav-link' href='/' aria-label='Home'>
+              <Link className='nav-link' to='/' aria-label='Home'>
                 <img alt='FFIEC' src={logo} height='32' />
                 <span className='usa-logo__text'>
                   Home Mortgage Disclosure Act
                 </span>
-              </a>
+              </Link>
             </div>
             <button type='button' className='usa-menu-btn'>
               Menu

--- a/src/common/constants/links.js
+++ b/src/common/constants/links.js
@@ -50,11 +50,3 @@ export const defaultLinks = [
     ]
   }
 ]
-
-export const updateFilingLink = (config, links) => {
-  return links.map(link => {
-    if(link.name !== 'Filing') return link
-    link.href = `/filing/${config.defaultDocsPeriod}/`
-    return link
-  })
-}

--- a/src/filing/App.jsx
+++ b/src/filing/App.jsx
@@ -8,6 +8,7 @@ import { ShowUserName } from '../common/ShowUserName'
 import * as AccessToken from '../common/api/AccessToken.js'
 import { getKeycloak, initKeycloak } from '../common/api/Keycloak.js'
 import { PERIODS } from '../deriveConfig'
+import { USER_FOUND, USER_SIGNED_OUT } from './constants'
 import isRedirecting from './actions/isRedirecting.js'
 import updateFilingPeriod from './actions/updateFilingPeriod.js'
 import { splitYearQuarter } from './api/utils.js'
@@ -97,15 +98,20 @@ function AppContainer({
         setAuthenticationAttempted(true)
 
         if (keycloak.authenticated) {
+          dispatch({ type: USER_FOUND, payload: keycloak })
           AccessToken.set(keycloak.token)
           refresh()
           if (redirecting) {
             dispatch(isRedirecting(false))
           }
         } else if (!isHome()) {
+          dispatch({ type: USER_SIGNED_OUT })
           login(location.pathname)
+        } else {
+          dispatch({ type: USER_SIGNED_OUT })
         }
       } catch (error) {
+        dispatch({ type: USER_SIGNED_OUT })
         setAuthenticationAttempted(true)
         console.error('Failed to initialize Keycloak:', error)
         history.replace(`/filing/${config.defaultPeriod}/`)

--- a/src/filing/App.jsx
+++ b/src/filing/App.jsx
@@ -1,21 +1,21 @@
+import { detect } from 'detect-browser'
+import 'normalize.css'
 import React, { useEffect, useState } from 'react'
 import { connect } from 'react-redux'
-import { detect } from 'detect-browser'
-import ConfirmationModal from './modals/confirmationModal/container.jsx'
-import BrowserBlocker from './common/BrowserBlocker.jsx'
+import '../common/Header.css'
 import Loading from '../common/LoadingIcon.jsx'
+import { ShowUserName } from '../common/ShowUserName'
 import * as AccessToken from '../common/api/AccessToken.js'
-import { refresh, login } from './utils/keycloak.js'
 import { getKeycloak, initKeycloak } from '../common/api/Keycloak.js'
+import { PERIODS } from '../deriveConfig'
 import isRedirecting from './actions/isRedirecting.js'
 import updateFilingPeriod from './actions/updateFilingPeriod.js'
-import { FilingAnnouncement } from './common/FilingAnnouncement'
 import { splitYearQuarter } from './api/utils.js'
-import { PERIODS } from '../deriveConfig'
-import { ShowUserName } from '../common/ShowUserName'
-import 'normalize.css'
 import './app.css'
-import '../common/Header.css'
+import BrowserBlocker from './common/BrowserBlocker.jsx'
+import { FilingAnnouncement } from './common/FilingAnnouncement'
+import ConfirmationModal from './modals/confirmationModal/container.jsx'
+import { login, refresh } from './utils/keycloak.js'
 
 const browser = detect()
 
@@ -140,7 +140,6 @@ function AppContainer({
     location.pathname,
     match.params.filingPeriod,
     maintenanceMode,
-    filingPeriod,
   ])
 
   // Scroll to top on pathname change

--- a/src/filing/home/HomeContainer.jsx
+++ b/src/filing/home/HomeContainer.jsx
@@ -1,9 +1,9 @@
-import { getKeycloak } from '../../common/api/Keycloak.js'
+import { useSelector } from 'react-redux'
 import InstitutionsContainer from '../institutions/container.jsx'
 import Home from './index.jsx'
 
 function HomeContainer({ config, ...props }) {
-  const isLoggedIn = getKeycloak()?.authenticated
+  const isLoggedIn = Boolean(useSelector((state) => state.app.user?.oidc))
   const { filingPeriods, maintenanceMode, announcement } = config
 
   if (!isLoggedIn || maintenanceMode) {

--- a/src/filing/home/HomeContainer.jsx
+++ b/src/filing/home/HomeContainer.jsx
@@ -1,18 +1,19 @@
-import React from 'react'
-import { useSelector } from 'react-redux'
-import Home from './index.jsx'
+import { getKeycloak } from '../../common/api/Keycloak.js'
 import InstitutionsContainer from '../institutions/container.jsx'
+import Home from './index.jsx'
 
-function HomeContainer({ config }) {
-  const user = useSelector((state) => state.app.user.oidc)
+function HomeContainer({ config, ...props }) {
+  const isLoggedIn = getKeycloak()?.authenticated
   const { filingPeriods, maintenanceMode, announcement } = config
 
-  if (user === null || maintenanceMode) {
+  if (!isLoggedIn || maintenanceMode) {
     return <Home maintenanceMode={maintenanceMode} />
   }
 
   return (
     <InstitutionsContainer
+      {...props}
+      config={config}
       filingPeriods={filingPeriods}
       announcement={announcement}
     />

--- a/src/filing/index.jsx
+++ b/src/filing/index.jsx
@@ -1,22 +1,21 @@
-import 'react-app-polyfill/ie11' // For IE 11 support
 import 'core-js/es/array'
+import 'react-app-polyfill/ie11'; // For IE 11 support
 
-import React from 'react'
-import { createStore, combineReducers, applyMiddleware } from 'redux'
 import { Provider } from 'react-redux'
+import { applyMiddleware, combineReducers, createStore } from 'redux'
 import thunkMiddleware from 'redux-thunk'
 
-import { Switch, Route, Redirect } from 'react-router-dom'
+import { composeWithDevTools } from '@redux-devtools/extension'
+import { Redirect, Route, Switch } from 'react-router-dom'
+import { initKeycloak } from '../common/api/Keycloak'
+import { withAppContext } from '../common/appContextHOC'
 import AppContainer from './App.jsx'
 import HomeContainer from './home/HomeContainer.jsx'
 import InstitutionContainer from './institutions/container.jsx'
-import SubmissionRouter from './submission/router.jsx'
-import { initKeycloak } from '../common/api/Keycloak'
-import { setStore } from './utils/store.js'
-import appReducer from './reducers'
-import { withAppContext } from '../common/appContextHOC'
-import { composeWithDevTools } from '@redux-devtools/extension'
 import CompleteProfile from './profile/CompleteProfile'
+import appReducer from './reducers'
+import SubmissionRouter from './submission/router.jsx'
+import { setStore } from './utils/store.js'
 
 initKeycloak()
 const middleware = [thunkMiddleware]
@@ -41,6 +40,7 @@ if (import.meta.env.MODE !== 'production') {
 setStore(store)
 
 const Filing = ({ config }) => {
+  const getFilingPeriod = () => store.getState()?.app?.filingPeriod || config.defaultPeriod
   return (
     <div className='App Filing'>
       <Provider store={store}>
@@ -55,11 +55,7 @@ const Filing = ({ config }) => {
               )
             }}
           />
-          <Redirect
-            exact
-            from='/filing'
-            to={`/filing/${config.defaultPeriod}/`}
-          />
+          <Redirect exact from='/filing' to={`/filing/${getFilingPeriod()}/`} />
           <Route
             exact
             path={'/filing/:filingPeriod/'}

--- a/src/filing/institutions/container.jsx
+++ b/src/filing/institutions/container.jsx
@@ -1,15 +1,15 @@
-import React, { Component } from 'react'
+import jwtDecode from 'jwt-decode'
+import { Component } from 'react'
 import { connect } from 'react-redux'
-import requestInstitutions from '../actions/requestInstitutions.js'
-import fetchEachInstitution from '../actions/fetchEachInstitution.js'
-import getFilingPeriodOptions from '../actions/getFilingPeriodOptions'
-import Institutions from './index.jsx'
-import InstitutionDetailsWrapper from './details/InstitutionDetailsWrapper'
-import { getKeycloak } from '../../common/api/Keycloak.js'
 import { Redirect } from 'react-router-dom'
 import * as AccessToken from '../../common/api/AccessToken'
-import jwtDecode from 'jwt-decode'
+import { getKeycloak } from '../../common/api/Keycloak.js'
+import fetchEachInstitution from '../actions/fetchEachInstitution.js'
+import getFilingPeriodOptions from '../actions/getFilingPeriodOptions'
+import requestInstitutions from '../actions/requestInstitutions.js'
 import { shouldFetchInstitutions } from '../actions/shouldFetchInstitutions.js'
+import InstitutionDetailsWrapper from './details/InstitutionDetailsWrapper'
+import Institutions from './index.jsx'
 
 export class InstitutionContainer extends Component {
   constructor(props) {
@@ -87,7 +87,7 @@ export class InstitutionContainer extends Component {
       return <Redirect to='/filing/profile' />
     }
 
-    if (this.props.match.params.institution)
+    if (this.props.match?.params?.institution)
       return <InstitutionDetailsWrapper {...this.props} />
 
     return <Institutions {...this.props} />

--- a/src/filing/utils/keycloak.js
+++ b/src/filing/utils/keycloak.js
@@ -1,10 +1,10 @@
 /* eslint no-restricted-globals: 0 */
-import { error } from './log.js'
-import { getStore } from './store.js'
+import * as AccessToken from '../../common/api/AccessToken.js'
+import { getKeycloak } from '../../common/api/Keycloak'
 import isRedirecting from '../actions/isRedirecting.js'
 import { USER_FOUND } from '../constants'
-import { getKeycloak } from '../../common/api/Keycloak'
-import * as AccessToken from '../../common/api/AccessToken.js'
+import { error } from './log.js'
+import { getStore } from './store.js'
 
 const login = (path) => {
   const keycloak = getKeycloak()
@@ -95,7 +95,7 @@ const logout = (queryString = '') => {
 
   const logoutUrl =
     `${keycloak.authServerUrl}/realms/${keycloak.realm}/protocol/openid-connect/logout` +
-    `?client_id=${keycloak.clientId}` + // Use client_id instead of id_token_hint
+    `?id_token_hint=${encodeURIComponent(keycloak.idToken)}` +
     `&post_logout_redirect_uri=${postLogoutRedirectUri}`
 
   // Perform logout and redirect
@@ -103,4 +103,5 @@ const logout = (queryString = '') => {
   window.location.href = logoutUrl
 }
 
-export { register, login, logout, refresh, forceRefreshToken }
+export { forceRefreshToken, login, logout, refresh, register }
+

--- a/src/filing/utils/keycloak.js
+++ b/src/filing/utils/keycloak.js
@@ -26,6 +26,7 @@ const refresh = () => {
     console.error('Keycloak is not initialized')
     return
   }
+const store = getStore()
 
   const updateKeycloak = () => {
     setTimeout(

--- a/src/filing/utils/keycloak.js
+++ b/src/filing/utils/keycloak.js
@@ -57,6 +57,7 @@ const forceRefreshToken = async () => {
     console.error('Keycloak is not initialized')
     return
   }
+const store = getStore()
 
   try {
     const refreshed = await keycloak.updateToken(55000)

--- a/src/filing/utils/keycloak.js
+++ b/src/filing/utils/keycloak.js
@@ -2,6 +2,7 @@
 import { error } from './log.js'
 import { getStore } from './store.js'
 import isRedirecting from '../actions/isRedirecting.js'
+import { USER_FOUND } from '../constants'
 import { getKeycloak } from '../../common/api/Keycloak'
 import * as AccessToken from '../../common/api/AccessToken.js'
 
@@ -34,6 +35,7 @@ const refresh = () => {
           .then((refreshed) => {
             if (refreshed) {
               AccessToken.set(keycloak.token)
+              store.dispatch({ type: USER_FOUND, payload: keycloak })
             }
             updateKeycloak()
           })
@@ -59,6 +61,7 @@ const forceRefreshToken = async () => {
     const refreshed = await keycloak.updateToken(55000)
     if (refreshed) {
       AccessToken.set(keycloak.token)
+      store.dispatch({ type: USER_FOUND, payload: keycloak })
     }
     refresh()
   } catch (error) {


### PR DESCRIPTION
When a user visits `/filing`, check their auth state and send them to either the filing "home" screen (the login page) or the institutions screen that lists their institutions.

This logic was already in the app but was incomplete. Currently, `HomeContainer.jsx` checks the app's state for the presence of an [open ID connect value](https://github.com/cfpb/hmda-frontend/blob/ab613603125eea12da34906c1a72636562de57bf/src/filing/home/HomeContainer.jsx#L7), which would indicate that the user has authenticated. The user is sent to the login screen if that [oidc value is `null`](https://github.com/cfpb/hmda-frontend/blob/master/src/filing/home/HomeContainer.jsx#L10-L12). However, it's always `null` because there's no code anywhere in the codebase that defines it. There's a [`USER_FOUND`](https://github.com/cfpb/hmda-frontend/blob/master/src/filing/reducers/user.js#L29-L34) action type that defines it but it's not used anywhere. This PR dispatches that action at the appropriate times and includes the user's keycloak info as the payload.

## Changes

- Dispatch `USER_FOUND` (via `userFound` action creator) when the filing app checks for `keycloak.authenticated` and it's `true`.
- Dispatch `USER_SIGNED_OUT` (via `userSignedOut` action creator) when authentication is not found by the filing app.
- In the `HomeContainer` component is the user's oidc property set?
  - No? Render the home component (this is the login page with the login.gov button).
  - Yes? Render the institutions component.
- Replace the logo anchor link with a `<Link>` to keep the entire nav within react router.

## Testing

1. e2e tests should pass.
2. When you click `Filing` and you're not logged in, does it show the login.gov page? After logging in, try clicking around the site and then clicking the `Filing` nav item. Does it take you directly to your institutions screen?

## Notes

- Redux's state is stored in memory so if you leave the app (e.g. by clicking over to the documentation site or refreshing the page), the `oidc` value will be cleared and the user will have to click the login.gov button again when visiting the filing page.
