### PR TITLE
fix(500-pages): update error copy

### DIFF
--- a/public/akamai/500-with-apor-files.html
+++ b/public/akamai/500-with-apor-files.html
@@ -751,8 +751,8 @@
             <h1 class="hero-heading">HMDA Platform Temporarily Unavailable</h1>
 
             <div class="hero-subheading">
-              <p>We're experiencing a technical issue that has taken the HMDA platform offline. We are working to resolve the issue as quickly as possible.</p>
-              <p>While the HMDA platform is unavailable, you can still access current rate spread data on the Average Prime Offer Rates (APOR) tables:</p>
+              <p>We are working to resolve the issue as quickly as possible.</p>
+              <p>You can still access current rate spread data on the Average Prime Offer Rates (APOR) tables:</p>
               <ul>
                 <li><a href="https://files.ffiec.cfpb.gov/apor/YieldTableFixed.txt">Rate Spread Fixed Table</a></li>
                 <li><a href="https://files.ffiec.cfpb.gov/apor/YieldTableAdjustable.txt">Rate Spread Adjustable Table</a></li>

--- a/public/akamai/500.html
+++ b/public/akamai/500.html
@@ -751,7 +751,7 @@
             <h1 class="hero-heading">HMDA Platform Temporarily Unavailable</h1>
 
             <div class="hero-subheading">
-              <p>We're experiencing a technical issue that has taken the HMDA platform offline. We are working to resolve the issue as quickly as possible.</p>
+              <p>We are working to resolve the issue as quickly as possible.</p>
               <p>For additional assistance, please contact our support team at <a href="mailto:HMDAHelp@cfpb.gov">HMDAHelp@cfpb.gov</a>.</p>
             </div>
           </div>


### PR DESCRIPTION
Still in draft while I wait for the tests to pass.

## Changes

- update error copy on the error pages, both with and without APOR files
- the only difference from the @zencircle version is the sentence kept in about the rate spread calculator and that I added "still" in "You can still access current rate spread data on the Average Prime Offer Rates (APOR) tables:"

## Testing

1. How does it look?

#### With APOR files

<img width="1264" height="1175" alt="Screenshot 2026-05-07 at 9 31 00 AM" src="https://github.com/user-attachments/assets/2a69a269-708a-4705-bb09-83a20fb9d5b1" />

#### Without APOR files

<img width="1264" height="1175" alt="Screenshot 2026-05-07 at 9 31 07 AM" src="https://github.com/user-attachments/assets/e39c913e-e811-442c-99f0-7a08463c4b4c" />
