### PR TITLE
chore(docs): update FIG documentation links on homepage

### DIFF
--- a/src/homepage/ForFilers/FilingGuides.jsx
+++ b/src/homepage/ForFilers/FilingGuides.jsx
@@ -30,15 +30,15 @@ function FilingGuides() {
           </a>
           <ul>
             <li>
-              <a href='/documentation/fig/2024/overview'>2024 Online FIG</a>
+              <a href='/documentation/fig/2025/overview'>2025 Online FIG</a>
             </li>
             <li>
-              <a href='/documentation/fig/2025/overview'>2025 Online FIG</a>
+              <a href='/documentation/fig/2026/overview'>2026 Online FIG</a>
               <NewIndicator />
             </li>
             <li>
-              <a href='/documentation/fig/2024/supplemental-guide-for-quarterly-filers'>
-                Online Supplemental Guide for Quarterly Filers for 2024
+              <a href='/documentation/fig/2026/supplemental-guide-for-quarterly-filers'>
+                Online Supplemental Guide for Quarterly Filers for 2026
               </a>
               <NewIndicator />
             </li>


### PR DESCRIPTION
Updating the FIG links on the homepage. See [#5547](https://github.local/HMDA-Operations/hmda-devops/issues/5547).
