### PR TITLE
fix(security): update libpng >=1.6.58-r1, remove libxml2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,12 @@ RUN echo "@edge https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/rep
 # More info at: GHE #5575
 RUN apk update && apk add 'libpng>=1.6.58-r1'
 
+# Temporary fix for CVE-2026-6732 (libxml2 < 2.15.3)
+# We don't use the two nginx modules (xslt and njs) that use the vulnerable libxml2. So we can delete
+# them, then we can remove libxml2 too.
+# More info at: GHE #5576
+RUN apk del --no-network nginx-module-xslt nginx-module-njs libxslt libxml2
+
 ENV NGINX_USER=svc_nginx_hmda
 RUN apk update && apk upgrade
 RUN rm -rf /etc/nginx/conf.d

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,10 @@ RUN echo "@edge https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/rep
     apk update && \
     apk add --no-cache curl@edge libcurl@edge
 
+# Temporary fix for CVE-2026-40930 (libpng < 1.6.58-r1)
+# More info at: GHE #5575
+RUN apk update && apk add 'libpng>=1.6.58-r1'
+
 ENV NGINX_USER=svc_nginx_hmda
 RUN apk update && apk upgrade
 RUN rm -rf /etc/nginx/conf.d


### PR DESCRIPTION
We got two new CVEs (see GHE #5574) to clear in the `libpng` and `libxml2` libraries.

For `libpng` we can do a straight update to at least `1.6.58-r1`. For `libxml2` we're a little stuck, since forcing an update breaks a few nginx modules (`xslt` and `njs`). But... we don't even use these nginx modules? So I'm removing those modules, then removing `libxml2`, then celebrating.

## Changes
- update `libpng` to at least `1.6.58-r1`
- remove `nginx-module-xslt`, `nginx-module-njs`, `libxslt`, `libxml2` (used the `--no-network` flag because we don't need to connect to the repositories to remove these packages and it can cause some issues / the internet told me so)

## Testing
- Do the tests pass? Yes!
- How does the frontend look on staging? Good! (tagged as `5574-update-libpng-remove-libxml2`)

<img width="1185" height="638" alt="Screenshot 2026-05-18 at 10 39 26 AM" src="https://github.com/user-attachments/assets/b042d0f6-8ce6-4c29-b63c-9e9d7c675f34" />


## Notes
- I made follow-up tickets to remove these temp fixes later and added them to a future sprint: GHE #5575, GHE #5576