### PR TITLE
chore(deps): bump brace-expansion from 5.0.3 to 5.0.6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4499,11 +4499,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.2":
-  version: 5.0.3
-  resolution: "brace-expansion@npm:5.0.3"
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/e474d300e581ec56851b3863ff1cf18573170c6d06deb199ccbd03b2119c36975f6ce2abc7b770f5bebddc1ab022661a9fea9b4d56f33315d7bef54d8793869e
+  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Quick security vulnerability fix

## Changes

- bumps brace-expansion from 5.0.3 to 5.0.6.

## Testing

1. Do the tests pass?

## Notes

-
