### PR TITLE
fix(deps): bump uuid to 11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
     "postcss": ">=8.5.10",
     "picomatch@2": ">=2.3.2",
     "picomatch@3": ">=3.0.2",
-    "picomatch@4": ">=4.0.4"
+    "picomatch@4": ">=4.0.4",
+    "uuid": ">=11.1.1"
   },
   "packageManager": "yarn@4.1.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14540,12 +14540,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "uuid@npm:7.0.3"
+"uuid@npm:>=11.1.1":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/2eee5723b0fcce8256f5bfd3112af6c453b5471db00af9c3533e3d5a6e57de83513f9a145a570890457bd7abf2c2aa05797291d950ac666e5a074895dc63168b
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/a57ae7794c45005c1a9208989196c5baf79a7679c30f43c1bee9033a2c4d113a2cea216fa6fcc9663b08b0d55635df1a7c6eb7e7f3d21c3e50688c698fa39a50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Lil' security bump for uuid.

## Changes

- bumps `uuid` to at least `>=11.1.1`

## Testing

1. How does it look on staging? Good! (tagged as `v3.4.2-rc1`)
2. Do the tests still pass? Yes!
<img width="533" height="58" alt="Screenshot 2026-05-26 at 4 36 09 PM" src="https://github.com/user-attachments/assets/718e2bda-556b-429d-a774-6b96a8595b37" />
