### PR TITLE
feat(profile): display form submission errors to user when updating profile

### DIFF
--- a/cypress/e2e/filing/Profile.spec.js
+++ b/cypress/e2e/filing/Profile.spec.js
@@ -102,5 +102,24 @@ describe(
       cy.get('.profile_error_code_box').should('be.visible')
       cy.get('.copy_profile_error_button').contains('Copy error to clipboard')
     })
+
+    it('Shows spinner dots in save button during save', () => {
+      cy.visit(`${AUTH_BASE_URL}filing/profile`)
+      cy.wait(ACTION_DELAY)
+
+      cy.get('.profile_form_container > :nth-child(2) > input').clear().type('party')
+
+      // Make the form submission really slow to have time to check for the spinner
+      cy.intercept('PUT', '**/hmda-auth/users/**', {
+        delay: 2000,
+        statusCode: 200,
+        body: {},
+      }).as('saveProfile')
+
+      cy.get('.profile_save_container > button').click()
+      cy.get('.spinner-dots--centered').should('exist')
+      cy.wait('@saveProfile')
+      cy.get('.spinner-dots--centered').should('not.exist')
+    })
   },
 )

--- a/cypress/e2e/filing/Profile.spec.js
+++ b/cypress/e2e/filing/Profile.spec.js
@@ -87,5 +87,20 @@ describe(
       // Back button verifies that the institution was re-added to the account
       cy.get('.button').contains('Back')
     })
+
+    it('Displays an error when the profile fails to save', () => {
+      cy.wait(ACTION_DELAY)
+
+      cy.url().should('contains', '/filing/profile')
+
+      // Submitting non-alphanumeric characters causes the API to return a 500 error
+      cy.get('.profile_form_container > :nth-child(2) > input').type('hooray!')
+      cy.get('.profile_save_container > button').click()
+      cy.wait(1000)
+
+      cy.get('.alert-heading').contains('Sorry, an error has occurred.')
+      cy.get('.profile_error_code_box').should('be.visible')
+      cy.get('.copy_profile_error_button').contains('Copy error to clipboard')
+    })
   },
 )

--- a/src/app.css
+++ b/src/app.css
@@ -381,7 +381,7 @@ button:visited:disabled,
 input[type='submit']:disabled,
 input[type='submit']:visited:disabled {
   background-color: #d6d7d9;
-  color: #ffffff;
+  color: #454545;
   pointer-events: none;
 }
 button:disabled:hover,
@@ -403,7 +403,7 @@ input[type='submit']:visited:disabled:hover,
 input[type='submit']:visited:disabled:focus,
 input[type='submit']:visited:disabled:active {
   background-color: #d6d7d9;
-  color: #ffffff;
+  color: #454545;
 }
 
 .nowrap {

--- a/src/common/SpinnerDots.css
+++ b/src/common/SpinnerDots.css
@@ -1,0 +1,74 @@
+@keyframes spinner-dot-one {
+  0% { transform: scale(0); }
+  25% { transform: scale(1); }
+  50% { transform: scale(0); }
+}
+
+@keyframes spinner-dot-two {
+  0% { transform: scale(0); }
+  20% { transform: scale(0); }
+  45% { transform: scale(1); }
+  70% { transform: scale(0); }
+}
+
+@keyframes spinner-dot-three {
+  0% { transform: scale(0); }
+  40% { transform: scale(0); }
+  65% { transform: scale(1); }
+  90% { transform: scale(0); }
+}
+
+.spinner-dots {
+  width: 46px;
+  height: 12px;
+  display: flex;
+}
+
+.spinner-dots--centered {
+  pointer-events: none;
+  margin-top: -6px;
+  margin-left: -23px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+}
+
+button:has(.spinner-dots--centered) {
+  position: relative;
+}
+
+.spinner-dots__dot {
+  width: 12px;
+  height: 12px;
+  margin-left: 5px;
+}
+
+.spinner-dots__dot:after {
+  content: '';
+  background-color: currentColor;
+  border-radius: 50%;
+  width: 100%;
+  height: 100%;
+  animation-duration: 1.25s;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  animation-delay: 10ms;
+  display: block;
+  transform: scale(0);
+}
+
+.spinner-dots__dot:first-child {
+  margin-left: 0;
+}
+
+.spinner-dots__dot:first-child:after {
+  animation-name: spinner-dot-one;
+}
+
+.spinner-dots__dot:nth-child(2):after {
+  animation-name: spinner-dot-two;
+}
+
+.spinner-dots__dot:nth-child(3):after {
+  animation-name: spinner-dot-three;
+}

--- a/src/common/SpinnerDots.jsx
+++ b/src/common/SpinnerDots.jsx
@@ -1,0 +1,17 @@
+import './SpinnerDots.css'
+
+function SpinnerDots({ centered, className }) {
+  let cls = 'spinner-dots'
+  if (centered) cls += ' spinner-dots--centered'
+  if (className) cls += ` ${className}`
+
+  return (
+    <span className={cls} aria-hidden='true'>
+      <span className='spinner-dots__dot'></span>
+      <span className='spinner-dots__dot'></span>
+      <span className='spinner-dots__dot'></span>
+    </span>
+  )
+}
+
+export default SpinnerDots

--- a/src/filing/institutions/MissingInstitutionsBanner.jsx
+++ b/src/filing/institutions/MissingInstitutionsBanner.jsx
@@ -1,16 +1,11 @@
-import React from 'react'
-import Alert from '../../common/Alert.jsx'
 
 export function MissingInstitutionsBanner({ leis = [] }) {
   const hasMissingLeis = leis.length > 0
   const bannerType = hasMissingLeis ? 'warning' : 'info'
 
   return (
-    <Alert
-      heading='Missing an institution?'
-      type={bannerType}
-      headingType='small'
-    >
+    <div className='missing_insitutions_container'>
+      <h2>Missing an institution?</h2>
       <div>
         <MissingLeiList leis={leis} />
         <p>
@@ -25,7 +20,7 @@ export function MissingInstitutionsBanner({ leis = [] }) {
           your information.
         </p>
       </div>
-    </Alert>
+    </div>
   )
 }
 

--- a/src/filing/profile/CompleteProfile.jsx
+++ b/src/filing/profile/CompleteProfile.jsx
@@ -133,7 +133,7 @@ const CompleteProfile = (props) => {
         })
         .then(async () => {
           setDisplayNotification(true)
-          setProfileSaveError(false)
+          setProfileSaveError('')
           setSaving(false)
           await forceRefreshToken()
           let newToken = jwtDecode(AccessToken.get())

--- a/src/filing/profile/CompleteProfile.jsx
+++ b/src/filing/profile/CompleteProfile.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, Prompt, Redirect } from 'react-router-dom'
 import Heading from '../../common/Heading'
 import InputAndLabel from '../../common/InputAndLabel'
+import SpinnerDots from '../../common/SpinnerDots'
 import AssociatedInstitutions from './AssociatedInstitutions'
 import SearchAssociatedInstitutions from './SearchAssociatedInstitutions'
 
@@ -41,6 +42,7 @@ const CompleteProfile = (props) => {
   const [copiedAuthToken, setCopiedAuthToken] = useState(false)
   const [copiedProfileSaveError, setCopiedProfileSaveError] = useState(false)
   const [showSettingsMenu, setShowSettingsMenu] = useState(false)
+  const [saving, setSaving] = useState(false)
 
   if (!user) {
     return <Redirect to={`/filing/${props.config.defaultPeriod}`} />
@@ -117,6 +119,7 @@ const CompleteProfile = (props) => {
         body: JSON.stringify(body),
       }
 
+      setSaving(true)
       fetch(endpoint, request)
         .then(async (response) => {
           if (!response.ok) {
@@ -131,6 +134,7 @@ const CompleteProfile = (props) => {
         .then(async () => {
           setDisplayNotification(true)
           setProfileSaveError(false)
+          setSaving(false)
           await forceRefreshToken()
           let newToken = jwtDecode(AccessToken.get())
           setAccessTokenDecoded(newToken)
@@ -139,6 +143,7 @@ const CompleteProfile = (props) => {
         })
         .catch((error) => {
           setDisplayNotification(false)
+          setSaving(false)
           setProfileSaveError(btoa(error))
         })
     }
@@ -285,8 +290,13 @@ const CompleteProfile = (props) => {
             </div>
 
             <div className='profile_save_container'>
-              <button type='submit' disabled={!userIsEditingForm}>
-                Save
+              <button type='submit' disabled={!userIsEditingForm || saving}>
+                <span style={{ opacity: saving ? 0 : 1 }}>
+                  Save changes
+                </span>
+                {saving && (
+                  <SpinnerDots centered />
+                )}
               </button>
 
               <div

--- a/src/filing/profile/CompleteProfile.jsx
+++ b/src/filing/profile/CompleteProfile.jsx
@@ -1,25 +1,25 @@
-import React, { useEffect, useState } from 'react'
-import { Link, Redirect, Prompt } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Link, Prompt, Redirect } from 'react-router-dom'
 import Heading from '../../common/Heading'
 import InputAndLabel from '../../common/InputAndLabel'
 import AssociatedInstitutions from './AssociatedInstitutions'
 import SearchAssociatedInstitutions from './SearchAssociatedInstitutions'
 
-import './Profile.css'
 import { useDispatch, useSelector } from 'react-redux'
 import { ShowUserName } from '../../common/ShowUserName'
 import { getKeycloak } from '../../common/api/Keycloak'
 import { runFetch } from '../../data-browser/api'
+import './Profile.css'
 import { createAssociatedInstitutionsList } from './utils'
 
-import * as AccessToken from '../../common/api/AccessToken'
+import jwtDecode from 'jwt-decode'
 import Alert from '../../common/Alert'
 import LoadingIcon from '../../common/LoadingIcon'
-import jwtDecode from 'jwt-decode'
-import { forceRefreshToken } from '../utils/keycloak'
+import * as AccessToken from '../../common/api/AccessToken'
+import Icon from '../../common/uswds/components/Icon'
 import { shouldFetchInstitutions } from '../actions/shouldFetchInstitutions'
 import { MissingInstitutionsBanner } from '../institutions/MissingInstitutionsBanner'
-import Icon from '../../common/uswds/components/Icon'
+import { forceRefreshToken } from '../utils/keycloak'
 
 const CompleteProfile = (props) => {
   const dispatch = useDispatch()
@@ -36,8 +36,10 @@ const CompleteProfile = (props) => {
   const [unregisteredInstitutions, setUnregisteredInstitutions] = useState([])
   const [loading, setLoading] = useState(false)
   const [displayNotification, setDisplayNotification] = useState(false)
+  const [profileSaveError, setProfileSaveError] = useState('')
   const [errorFromAPI, setErrorFromAPI] = useState(false)
   const [copiedAuthToken, setCopiedAuthToken] = useState(false)
+  const [copiedProfileSaveError, setCopiedProfileSaveError] = useState(false)
   const [showSettingsMenu, setShowSettingsMenu] = useState(false)
 
   if (!user) {
@@ -116,16 +118,29 @@ const CompleteProfile = (props) => {
       }
 
       fetch(endpoint, request)
-        .then((response) => response.json())
+        .then(async (response) => {
+          if (!response.ok) {
+            const responseBody = await response.text()
+            const saveError = new Error(
+              `Failed to update user profile (${response.status}: ${responseBody})`,
+            )
+            throw saveError
+          }
+          return response.json()
+        })
         .then(async () => {
           setDisplayNotification(true)
+          setProfileSaveError(false)
           await forceRefreshToken()
           let newToken = jwtDecode(AccessToken.get())
           setAccessTokenDecoded(newToken)
           dispatch(shouldFetchInstitutions(true))
           setUserIsEditingForm(false)
         })
-        .catch((error) => console.log(error))
+        .catch((error) => {
+          setDisplayNotification(false)
+          setProfileSaveError(btoa(error))
+        })
     }
   }
 
@@ -134,6 +149,15 @@ const CompleteProfile = (props) => {
       setCopiedAuthToken(true)
       setTimeout(() => {
         setCopiedAuthToken(false)
+      }, 2000)
+    })
+  }
+
+  const copyProfileSaveError = () => {
+    navigator.clipboard.writeText(profileSaveError).then(() => {
+      setCopiedProfileSaveError(true)
+      setTimeout(() => {
+        setCopiedProfileSaveError(false)
       }, 2000)
     })
   }
@@ -188,6 +212,33 @@ const CompleteProfile = (props) => {
                 <p>Your information was updated!</p>
               </Alert>
             )}
+
+            {profileSaveError && (
+              <Alert type='error' heading='Sorry, an error has occurred.'>
+                <div>
+                  <ul>
+                    <li>Your request could not be completed. Please try again.</li>
+                    <li>
+                      If the problem persists, please contact <a href="https://hmdahelp.consumerfinance.gov/accounthelp/">HMDA Help</a>{' '}
+                      and share the error code below.
+                    </li>
+                  </ul>
+
+                  <pre className='profile_error_code_box'>{profileSaveError}</pre>
+
+                  <button
+                    type='button'
+                    className='copy_profile_error_button'
+                    onClick={copyProfileSaveError}
+                  >
+                    {copiedProfileSaveError
+                      ? 'Error copied to clipboard'
+                      : 'Copy error to clipboard'}
+                  </button>
+                </div>
+              </Alert>
+            )}
+
             <InputAndLabel
               labelName='First name'
               value={firstName || ''}

--- a/src/filing/profile/Profile.css
+++ b/src/filing/profile/Profile.css
@@ -133,6 +133,22 @@ a:hover {
   margin-top: 0;
 }
 
+.profile_form_container .profile_error_code_box {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding: 0.85rem;
+  border: 1px solid #a2a3a4;
+  background-color: #f1f1f1;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: 10rem;
+  overflow-y: auto;
+}
+
+.profile_form_container .copy_profile_error_button {
+  margin-top: 0;
+}
+
 .no_institutions_associated {
   max-width: 85rem !important;
 }

--- a/src/filing/profile/Profile.css
+++ b/src/filing/profile/Profile.css
@@ -58,13 +58,15 @@
   font-size: 16px;
 }
 
-/* Associated Instutions CSS */
-.associated_insitutions_container h2 {
+/* Associated Instutions and Missing Institutions CSS */
+.associated_insitutions_container h2,
+.missing_insitutions_container h2 {
   font-size: 18px;
   font-weight: normal !important;
 }
 
-.associated_insitutions_container p {
+.associated_insitutions_container p,
+.missing_insitutions_container p {
   font-size: 16px;
   font-weight: normal;
   margin: 0;


### PR DESCRIPTION
When a user saves their institution profile, they don't see any errors if there is a failure, including the recent login.gov issues. This PR adds an error notification if the attempt to submit the profile form fails.

See [#5544](https://github.local/HMDA-Operations/hmda-devops/issues/5544)

## Changes

- The profile form now throws an error if the fetch is not `ok` (not a status in the range 200-299).
- The error is caught and displayed in an `Alert` notification at the top of the form with the error status and body serialized and base64-encoded.

## Testing

1. Head over to staging and force a 500 response from our `users/` endpoint by submitting a name change that includes a non-alphanumeric character.
2. Confirm that you can decode the error message by passing it to `atob()` in the browser console.

## Screenshots

https://github.com/user-attachments/assets/13d45083-6be0-4885-9d7d-f1cb44a5c87e

## Notes

Should the encoded error message have different text? Maybe the URL that returned the bad status code should be included in the message?