### PR TITLE
fix(profile): improve UX/a11y of profile page save functionality

### DIFF
--- a/cypress/e2e/filing/Profile.spec.js
+++ b/cypress/e2e/filing/Profile.spec.js
@@ -102,5 +102,24 @@ describe(
       cy.get('.profile_error_code_box').should('be.visible')
       cy.get('.copy_profile_error_button').contains('Copy error to clipboard')
     })
+
+    it('Shows spinner dots in save button during save', () => {
+      cy.visit(`${AUTH_BASE_URL}filing/profile`)
+      cy.wait(ACTION_DELAY)
+
+      cy.get('.profile_form_container > :nth-child(2) > input').clear().type('party')
+
+      // Make the form submission really slow to have time to check for the spinner
+      cy.intercept('PUT', '**/hmda-auth/users/**', {
+        delay: 2000,
+        statusCode: 200,
+        body: {},
+      }).as('saveProfile')
+
+      cy.get('.profile_save_container > button').click()
+      cy.get('.spinner-dots--centered').should('exist')
+      cy.wait('@saveProfile')
+      cy.get('.spinner-dots--centered').should('not.exist')
+    })
   },
 )

--- a/src/app.css
+++ b/src/app.css
@@ -381,7 +381,7 @@ button:visited:disabled,
 input[type='submit']:disabled,
 input[type='submit']:visited:disabled {
   background-color: #d6d7d9;
-  color: #ffffff;
+  color: #454545;
   pointer-events: none;
 }
 button:disabled:hover,
@@ -403,7 +403,7 @@ input[type='submit']:visited:disabled:hover,
 input[type='submit']:visited:disabled:focus,
 input[type='submit']:visited:disabled:active {
   background-color: #d6d7d9;
-  color: #ffffff;
+  color: #454545;
 }
 
 .nowrap {

--- a/src/common/SpinnerDots.css
+++ b/src/common/SpinnerDots.css
@@ -1,0 +1,74 @@
+@keyframes spinner-dot-one {
+  0% { transform: scale(0); }
+  25% { transform: scale(1); }
+  50% { transform: scale(0); }
+}
+
+@keyframes spinner-dot-two {
+  0% { transform: scale(0); }
+  20% { transform: scale(0); }
+  45% { transform: scale(1); }
+  70% { transform: scale(0); }
+}
+
+@keyframes spinner-dot-three {
+  0% { transform: scale(0); }
+  40% { transform: scale(0); }
+  65% { transform: scale(1); }
+  90% { transform: scale(0); }
+}
+
+.spinner-dots {
+  width: 46px;
+  height: 12px;
+  display: flex;
+}
+
+.spinner-dots--centered {
+  pointer-events: none;
+  margin-top: -6px;
+  margin-left: -23px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+}
+
+button:has(.spinner-dots--centered) {
+  position: relative;
+}
+
+.spinner-dots__dot {
+  width: 12px;
+  height: 12px;
+  margin-left: 5px;
+}
+
+.spinner-dots__dot:after {
+  content: '';
+  background-color: currentColor;
+  border-radius: 50%;
+  width: 100%;
+  height: 100%;
+  animation-duration: 1.25s;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  animation-delay: 10ms;
+  display: block;
+  transform: scale(0);
+}
+
+.spinner-dots__dot:first-child {
+  margin-left: 0;
+}
+
+.spinner-dots__dot:first-child:after {
+  animation-name: spinner-dot-one;
+}
+
+.spinner-dots__dot:nth-child(2):after {
+  animation-name: spinner-dot-two;
+}
+
+.spinner-dots__dot:nth-child(3):after {
+  animation-name: spinner-dot-three;
+}

--- a/src/common/SpinnerDots.jsx
+++ b/src/common/SpinnerDots.jsx
@@ -1,0 +1,17 @@
+import './SpinnerDots.css'
+
+function SpinnerDots({ centered, className }) {
+  let cls = 'spinner-dots'
+  if (centered) cls += ' spinner-dots--centered'
+  if (className) cls += ` ${className}`
+
+  return (
+    <span className={cls} aria-hidden='true'>
+      <span className='spinner-dots__dot'></span>
+      <span className='spinner-dots__dot'></span>
+      <span className='spinner-dots__dot'></span>
+    </span>
+  )
+}
+
+export default SpinnerDots

--- a/src/filing/institutions/MissingInstitutionsBanner.jsx
+++ b/src/filing/institutions/MissingInstitutionsBanner.jsx
@@ -1,16 +1,11 @@
-import React from 'react'
-import Alert from '../../common/Alert.jsx'
 
 export function MissingInstitutionsBanner({ leis = [] }) {
   const hasMissingLeis = leis.length > 0
   const bannerType = hasMissingLeis ? 'warning' : 'info'
 
   return (
-    <Alert
-      heading='Missing an institution?'
-      type={bannerType}
-      headingType='small'
-    >
+    <div className='missing_insitutions_container'>
+      <h2>Missing an institution?</h2>
       <div>
         <MissingLeiList leis={leis} />
         <p>
@@ -25,7 +20,7 @@ export function MissingInstitutionsBanner({ leis = [] }) {
           your information.
         </p>
       </div>
-    </Alert>
+    </div>
   )
 }
 

--- a/src/filing/profile/CompleteProfile.jsx
+++ b/src/filing/profile/CompleteProfile.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, Prompt, Redirect } from 'react-router-dom'
 import Heading from '../../common/Heading'
 import InputAndLabel from '../../common/InputAndLabel'
+import SpinnerDots from '../../common/SpinnerDots'
 import AssociatedInstitutions from './AssociatedInstitutions'
 import SearchAssociatedInstitutions from './SearchAssociatedInstitutions'
 
@@ -41,6 +42,7 @@ const CompleteProfile = (props) => {
   const [copiedAuthToken, setCopiedAuthToken] = useState(false)
   const [copiedProfileSaveError, setCopiedProfileSaveError] = useState(false)
   const [showSettingsMenu, setShowSettingsMenu] = useState(false)
+  const [saving, setSaving] = useState(false)
 
   if (!user) {
     return <Redirect to={`/filing/${props.config.defaultPeriod}`} />
@@ -117,6 +119,7 @@ const CompleteProfile = (props) => {
         body: JSON.stringify(body),
       }
 
+      setSaving(true)
       fetch(endpoint, request)
         .then(async (response) => {
           if (!response.ok) {
@@ -131,6 +134,7 @@ const CompleteProfile = (props) => {
         .then(async () => {
           setDisplayNotification(true)
           setProfileSaveError(false)
+          setSaving(false)
           await forceRefreshToken()
           let newToken = jwtDecode(AccessToken.get())
           setAccessTokenDecoded(newToken)
@@ -139,6 +143,7 @@ const CompleteProfile = (props) => {
         })
         .catch((error) => {
           setDisplayNotification(false)
+          setSaving(false)
           setProfileSaveError(btoa(error))
         })
     }
@@ -285,8 +290,13 @@ const CompleteProfile = (props) => {
             </div>
 
             <div className='profile_save_container'>
-              <button type='submit' disabled={!userIsEditingForm}>
-                Save
+              <button type='submit' disabled={!userIsEditingForm || saving}>
+                <span style={{ opacity: saving ? 0 : 1 }}>
+                  Save changes
+                </span>
+                {saving && (
+                  <SpinnerDots centered />
+                )}
               </button>
 
               <div

--- a/src/filing/profile/Profile.css
+++ b/src/filing/profile/Profile.css
@@ -58,13 +58,15 @@
   font-size: 16px;
 }
 
-/* Associated Instutions CSS */
-.associated_insitutions_container h2 {
+/* Associated Instutions and Missing Institutions CSS */
+.associated_insitutions_container h2,
+.missing_insitutions_container h2 {
   font-size: 18px;
   font-weight: normal !important;
 }
 
-.associated_insitutions_container p {
+.associated_insitutions_container p,
+.missing_insitutions_container p {
   font-size: 16px;
   font-weight: normal;
   margin: 0;


### PR DESCRIPTION
Improvements to the filing app profile page save functionality.

See [#5543](https://github.local/HMDA-Operations/hmda-devops/issues/5543)

## Changes

- Updates the text color of our disabled buttons (throughout the site) to make them 508-compliant. They now use `#454545` which is what USWDS recommends.
- Adds a new `SpinnerDots` component with CSS copied from [login.gov](https://github.com/18F/identity-idp/blob/46ec27d430f90d7b128d4e6be57d34478f8002a3/app/assets/stylesheets/components/_spinner-dots.scss)
- Moves the missing institutions banner out of the `Alert` component to prevent banner blindness.

## Testing

1. PR tests should pass.
2. Head over to staging and update your profile and see how it looks.

## Notes

- The missing institutions banner also appears at the bottom of the [institutions landing page](https://github.com/cfpb/hmda-frontend/blob/6bd0e090d98a0ca8f7523e50aab9195ac19edb2e/src/filing/institutions/index.jsx#L243) so this change will also change its appearance on that page. IMHO this is good because there are already multiple alerts on that page and the goal is to avoid banner blindness.

## Screenshots

https://github.com/user-attachments/assets/251a30c3-12fa-4b39-9a46-e7e04e5eced5