### PR TITLE
fix(vscode): stop prettier from overriding eslint on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "diffEditor.ignoreTrimWhitespace": false,
   "editor.codeActionsOnSave": [
     "source.addMissingImports",
-    "source.fixAll",
+    "source.fixAll.eslint",
     "source.organizeImports"
   ],
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",


### PR DESCRIPTION
So we have vscode set to `source.fixAll` on save in `settings.json`, but that includes eslint AND also separately prettier. We run prettier rules through eslint already via `eslint-plugin-prettier` to avoid conflicts... but then `fixAll` goes ahead and runs prettier and eslint anyway. We only need eslint.

But what about stylelint though for our css you might ask? Good news: it doesn't work right now anyway. We have `  "stylelint.validate": ["css"],` in the `settings.json`, which probably worked for older versions of stylelint's vscode extension, but not the newer versions. We'll have to set up a new config for stylelint... but that's for another day (see: GHE #5636)

## Changes

- changes `"source.fixAll",` => `"source.fixAll.eslint",`

## Testing

1. Try changing a variable from `const` to `let` [in publications-by-year.js](https://github.com/cfpb/hmda-frontend/blob/stop-eslint-prettier-fights-on-save/src/data-publication/constants/publications-by-year.js#L40) then save and see if it switches back to `const`
2. Try changing the indents of [this line](https://github.com/cfpb/hmda-frontend/blob/stop-eslint-prettier-fights-on-save/src/data-publication/constants/publications-by-year.js#L44) in `publications-by-year.js` for one of the objects in the array to trigger a prettier rule violation, and then see if it snaps back correctly on save now
<img width="580" height="377" alt="Screenshot 2026-06-17 at 9 48 08 PM" src="https://github.com/user-attachments/assets/9224cbe0-1d7d-4aa3-9715-28d74cf3f961" />


