### PR TITLE
feat(reports): show notice when all values are zero

### DIFF
--- a/cypress/e2e/data-publication/ZeroValueReportNotice.spec.js
+++ b/cypress/e2e/data-publication/ZeroValueReportNotice.spec.js
@@ -1,0 +1,41 @@
+import { onlyOn } from '@cypress/skip-test'
+import { isBeta } from '../../support/helpers'
+
+const { HOST } = Cypress.env()
+
+// setting this to something in the 2025 data publication for now to match data that will be shared
+// between staging and prod
+const INSTITUTION = '549300I4IUWMEMGLST06'
+const MSA_MD = '19124'
+
+const ALL_ZERO_REPORT = `${HOST}/data-publication/disclosure-reports/2025/${INSTITUTION}/${MSA_MD}/2`
+const REPORT_WITH_DATA = `${HOST}/data-publication/disclosure-reports/2025/${INSTITUTION}/${MSA_MD}/1`
+
+onlyOn(isBeta(HOST), () => {
+  describe('Zero Value Report Notice', function () {
+    it('Does not run in Beta environments', () => {})
+  })
+})
+
+onlyOn(!isBeta(HOST), () => {
+  describe('Zero Value Report Notice', { defaultCommandTimeout: 45000 }, () => {
+    it('Shows the notice when a report contains only zeros', () => {
+      cy.get({ HOST }).logEnv()
+      cy.viewport(1680, 916)
+      cy.visit(ALL_ZERO_REPORT)
+
+      cy.get('.all-zero-data-notice')
+        .should('be.visible')
+        .should('contain', 'All values in the table below are 0')
+    })
+
+    it('Does not show the notice when a report contains any data', () => {
+      cy.get({ HOST }).logEnv()
+      cy.viewport(1680, 916)
+      cy.visit(REPORT_WITH_DATA)
+
+      cy.get('.Report table').should('exist')
+      cy.get('.all-zero-data-notice').should('not.exist')
+    })
+  })
+})

--- a/src/data-publication/reports/Report.css
+++ b/src/data-publication/reports/Report.css
@@ -27,6 +27,10 @@
 .Report .heading p {
   margin-bottom: 0;
 }
+.Report .heading .all-zero-data-notice {
+  margin-top: 3rem;
+  margin-bottom: -3rem;
+}
 
 .Report table {
   font-size: 0.75em;

--- a/src/data-publication/reports/Report.jsx
+++ b/src/data-publication/reports/Report.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { getDefaultConfig, isProd } from '../../common/configUtils'
 import Heading from '../../common/Heading.jsx'
 import LoadingIcon from '../../common/LoadingIcon.jsx'
+import { areAllReportValuesZero } from './reportUtils.js'
 import {
   buildCSVRowsAggregate1,
   buildCSVRowsAggregate2,
@@ -27,26 +28,6 @@ class Report extends React.Component {
     this.generateCSV = this.generateCSV.bind(this)
     this.tableRef = React.createRef()
     this.tableTwoRef = React.createRef()
-  }
-
-  hasNonZeroValue(node) {
-    if (!node || typeof node !== 'object') return false
-    return Object.entries(node).some(([key, value]) =>
-      /(count|value)$/i.test(key)
-        ? typeof value === 'number' && value !== 0
-        : this.hasNonZeroValue(value),
-    )
-  }
-
-  areAllMetricValuesZero(report) {
-    if (report.table === 'IRSCSV') return false
-    if (report.table === 'I') return false
-    try {
-      return !this.hasNonZeroValue(report)
-    } catch (error) {
-      console.log(error)
-      return false
-    }
   }
 
   generateCSV() {
@@ -197,7 +178,7 @@ class Report extends React.Component {
           this.setState({
             isLoaded: true,
             report: result,
-            hasZeroValuesOnly: this.areAllMetricValuesZero(result),
+            hasZeroValuesOnly: areAllReportValuesZero(result),
           })
         }
       })

--- a/src/data-publication/reports/Report.jsx
+++ b/src/data-publication/reports/Report.jsx
@@ -20,12 +20,32 @@ class Report extends React.Component {
       error: false,
       isLoaded: false,
       report: null,
+      hasZeroValuesOnly: false,
     }
 
     this.selectReport = this.selectReport.bind(this)
     this.generateCSV = this.generateCSV.bind(this)
     this.tableRef = React.createRef()
     this.tableTwoRef = React.createRef()
+  }
+
+  hasNonZeroValue(node) {
+    if (!node || typeof node !== 'object') return false
+    return Object.entries(node).some(([key, value]) =>
+      /(count|value)$/i.test(key)
+        ? typeof value === 'number' && value !== 0
+        : this.hasNonZeroValue(value),
+    )
+  }
+
+  areAllMetricValuesZero(report) {
+    if (report.table === 'IRSCSV') return false
+    try {
+      return !this.hasNonZeroValue(report)
+    } catch (error) {
+      console.log(error)
+      return false
+    }
   }
 
   generateCSV() {
@@ -176,6 +196,7 @@ class Report extends React.Component {
           this.setState({
             isLoaded: true,
             report: result,
+            hasZeroValuesOnly: this.areAllMetricValuesZero(result),
           })
         }
       })
@@ -312,7 +333,7 @@ class Report extends React.Component {
     let reportType = 'disclosure'
     if (this.props.match.params.stateId) reportType = 'aggregate'
 
-    const { report } = this.state
+    const { report, hasZeroValuesOnly } = this.state
     const headingText = this.makeHeadingText(report)
 
     return (
@@ -335,6 +356,12 @@ class Report extends React.Component {
             <p>Nationwide</p>
           )}
           <button onClick={this.generateCSV}>Save as CSV</button>
+          {hasZeroValuesOnly ? (
+            <p className='all-zero-data-notice'>
+              All values in the table below are 0. This is valid data and not an
+              error.
+            </p>
+          ) : null}
         </Heading>
 
         {this.selectReport(report, reportType)}

--- a/src/data-publication/reports/Report.jsx
+++ b/src/data-publication/reports/Report.jsx
@@ -40,6 +40,7 @@ class Report extends React.Component {
 
   areAllMetricValuesZero(report) {
     if (report.table === 'IRSCSV') return false
+    if (report.table === 'I') return false
     try {
       return !this.hasNonZeroValue(report)
     } catch (error) {

--- a/src/data-publication/reports/__tests__/reportUtils.test.js
+++ b/src/data-publication/reports/__tests__/reportUtils.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { areAllReportValuesZero, hasNonZeroValue } from '../reportUtils'
+
+const makeReport = (values, overrides = {}) => ({
+  table: '1',
+  tracts: [
+    {
+      tract: 'Collin County/Texas/031101',
+      dispositions: [
+        {
+          title: 'Loans Originated',
+          values,
+          titleForSorting: 'Loans Originated - (A)',
+        },
+      ],
+    },
+  ],
+  ...overrides,
+})
+
+const allZeroValues = [
+  { dispositionName: 'FHA, FSA/RHS & VA (A)', count: 0, value: 0 },
+  { dispositionName: 'Conventional (B)', count: 0, value: 0 },
+]
+
+const nonZeroValues = [
+  { dispositionName: 'FHA, FSA/RHS & VA (A)', count: 0, value: 0 },
+  { dispositionName: 'Conventional (B)', count: 1, value: 665000 },
+]
+
+describe('Reports should give notice to users when all values are zero', () => {
+  describe('hasNonZeroValue', () => {
+    it('returns false when all count/value keys are 0', () => {
+      const node = makeReport(allZeroValues)
+
+      expect(hasNonZeroValue(node)).toBe(false)
+    })
+
+    it('returns true when a count/value key is non-zero', () => {
+      const node = makeReport(nonZeroValues)
+
+      expect(hasNonZeroValue(node)).toBe(true)
+    })
+  })
+
+  describe('areAllReportValuesZero', () => {
+    it('returns false for IRS and "I" reports even when all values are zero', () => {
+      const irsReport = makeReport(allZeroValues, { table: 'IRSCSV' })
+      const institutionsReport = makeReport(allZeroValues, { table: 'I' })
+
+      expect(areAllReportValuesZero(irsReport)).toBe(false)
+      expect(areAllReportValuesZero(institutionsReport)).toBe(false)
+    })
+
+    it('returns true when the report only contains zero metrics', () => {
+      const report = makeReport(allZeroValues)
+
+      expect(areAllReportValuesZero(report)).toBe(true)
+    })
+
+    it('returns false when the report contains a non-zero metric', () => {
+      const report = makeReport(nonZeroValues)
+
+      expect(areAllReportValuesZero(report)).toBe(false)
+    })
+  })
+})

--- a/src/data-publication/reports/reportUtils.js
+++ b/src/data-publication/reports/reportUtils.js
@@ -1,0 +1,34 @@
+/**
+ * A cute recursive function to dig through and exit early if it finds a non-zero
+ * value for keys containing "count" or "value"
+ * @param {*} node - The report object or nested object to search for non-zero values
+ * @returns {boolean} True if a non-zero value is found, otherwise false
+ */
+export const hasNonZeroValue = (node) => {
+  if (!node || typeof node !== 'object') return false
+  return Object.entries(node).some(([key, value]) =>
+    /(count|value)$/i.test(key)
+      ? typeof value === 'number' && value !== 0
+      : hasNonZeroValue(value),
+  )
+}
+
+/**
+ * Runs hasNonZeroValue for any given report except those without numerical values like the
+ * IRS and Reporting Financial Institutions ("I") report
+ * @param {object} report - A report object to check for non-zero values
+ * @returns {boolean} True if every value is zero, otherwise false
+ */
+export const areAllReportValuesZero = (report) => {
+  if (report.table === 'IRSCSV') return false
+  if (report.table === 'I') return false
+  try {
+    return !hasNonZeroValue(report)
+  } catch (error) {
+    // not sure what to do other than log it for a poor dev
+    console.log(error)
+
+    // if there's an error, return false to not show the notice just to be safe
+    return false
+  }
+}

--- a/src/data-publication/reports/reportUtils.js
+++ b/src/data-publication/reports/reportUtils.js
@@ -7,6 +7,8 @@
 export const hasNonZeroValue = (node) => {
   if (!node || typeof node !== 'object') return false
   return Object.entries(node).some(([key, value]) =>
+    // the following regex grabs "values" and "counts" but also weird ones like "firstLienValue"
+    // the $ ends with helps weed out "values" that sometimes contain an array of values
     /(count|value)$/i.test(key)
       ? typeof value === 'number' && value !== 0
       : hasNonZeroValue(value),


### PR DESCRIPTION
This one was fun: when a report's table is only filled with zeroes, we wanted to be able to show a notice to the user instead of having them hunt for a non-zero value. I think this is a pretty clean frontend-only solution. Definitely worth a little sleep deprivation.

## Changes

- Report.css
  - adds a little CSS for the notice (I generally avoid negative margins, but the way the table is laid out made this a cleaner solution)
- Report.jsx
  - adds hasNonZeroValue: a cute recursive function to dig through and exit early if it finds a non-zero value for keys containing `count` or `value` which covers the different reports we have
  - adds areAllMetricValuesZero: change the state of `hasNonZeroValue` if a non-zero value is found, otherwise on error don't display anything. Skip IRS reports since they always have something and have a different format.
  - adds the notice to the table header: there are better ways of doing tables for accessibility, but that's for another day 

## Testing

1. Check out a report that only contains zeros, try `[STAGING]/data-publication/disclosure-reports/2024/5493007KLU19FK8PG279/38060/2` and see if the notice appears
2. Check out a report that has data, try `[STAGING]/data-publication/disclosure-reports/2024/5493007KLU19FK8PG279/11694/1`
3. Are the new unit tests passing? Yes!
    <img width="559" height="177" alt="Screenshot 2026-06-21 at 12 24 53 PM" src="https://github.com/user-attachments/assets/00c1e374-3a1b-456d-bf2b-6734e97319a7" />

4. Are the new e2e tests passing against staging? Yes!
    <img width="388" height="180" alt="Screenshot 2026-06-21 at 12 25 00 PM" src="https://github.com/user-attachments/assets/c61a7499-2aa9-4cb3-b255-f8c4ff4fb9c3" />


## Notes

- Having now dug through these tables, there's a lot of helpful accessibility improvements that could be done on them someday.

## Screenshots
<img width="1127" height="633" alt="Screenshot 2026-06-18 at 1 55 03 AM" src="https://github.com/user-attachments/assets/2ea3463c-b763-4e56-8b4a-4be218c9c12e" />

