### PR TITLE
fix(notifications): double time for autoadvancing news carousel

### DIFF
--- a/src/homepage/AnnouncementBanner.jsx
+++ b/src/homepage/AnnouncementBanner.jsx
@@ -166,7 +166,7 @@ export function AnnouncementBanner({
     <OptionCarousel
       id='oc-homepage-banner'
       options={announcements}
-      cycleTime={5}
+      cycleTime={10}
       hideIcon
       showControls
     />


### PR DESCRIPTION
## Changes

- just makes the time longer between the news carousel advancing so that people have a chance to read it a bit more

## Testing

1. How does it look on staging?

## Notes

- We can tune this value more in the future.
