### PR TITLE
fix(announcements): double time between autoadvances

### DIFF
--- a/src/homepage/AnnouncementBanner.jsx
+++ b/src/homepage/AnnouncementBanner.jsx
@@ -166,7 +166,7 @@ export function AnnouncementBanner({
     <OptionCarousel
       id='oc-homepage-banner'
       options={announcements}
-      cycleTime={5}
+      cycleTime={10}
       hideIcon
       showControls
     />


### PR DESCRIPTION
## Changes

- just makes the time longer between the announcement carousel advancements so that people have a chance to read it a bit more (5 seconds to 10 seconds)

## Testing

1. How does it look on staging? Good! (tagged on staging as `staging-data-publication-rc-2`)
2. Do the tests still pass? Yes!
<img width="470" height="32" alt="Screenshot 2026-06-23 at 4 29 54 AM" src="https://github.com/user-attachments/assets/302a75cb-9957-4c3d-bd18-1fd04868b1d1" />

## Notes

- We can tune this value more in the future, but this is a good start.

## Screenshots
<img width="1080" height="396" alt="Screenshot 2026-06-23 at 4 27 01 AM" src="https://github.com/user-attachments/assets/36ddd743-8078-419a-8b18-04ad4d76e097" />


