### PR TITLE
test(profile): remove redirect start to fix loading test

### DIFF
--- a/cypress/e2e/filing/Profile.spec.js
+++ b/cypress/e2e/filing/Profile.spec.js
@@ -104,7 +104,6 @@ describe(
     })
 
     it('Shows spinner dots in save button during save', () => {
-      cy.visit(`${AUTH_BASE_URL}filing/profile`)
       cy.wait(ACTION_DELAY)
 
       cy.get('.profile_form_container > :nth-child(2) > input').clear().type('party')


### PR DESCRIPTION
## Changes

- the loading test was failing for me against staging because the initial redirect to the profile page via url only redirected the test to filing home

## Testing

1. Does the test now work against staging? Yes!
<img width="213" height="731" alt="Screenshot 2026-06-23 at 6 33 05 AM" src="https://github.com/user-attachments/assets/3120d792-3ff9-4bf9-80d7-5184d51a7635" />


## Notes
- if the intention was to keep the tests isolated, maybe we can click the profile link between tests?