### PR TITLE
fix(cypress): add cypress-visual-regression to cypress/package.json

### DIFF
--- a/cypress/package.json
+++ b/cypress/package.json
@@ -5,7 +5,8 @@
     "@testing-library/cypress": "10.1.0",
     "cypress": "15.12.0",
     "cypress-file-upload": "5.0.8",
-    "cypress-keycloak": "2.0.2"
+    "cypress-keycloak": "2.0.2",
+    "cypress-visual-regression": "^5.3.0"
   },
   "browser": {
     "../../../src/**/*": "../src",


### PR DESCRIPTION
I was seeing some errors when trying to cypress tests in a container, with `Error: Cannot find module 'cypress-visual-regression'`. Just added it into the package.json that's used in the image.

## Changes

- add the same version of `cypress-visual-regression` into `cypress/package.json` as the one in the main `package.json`

## Testing

1. Does it work in a container now? Yes!

<img width="772" height="1122" alt="Screenshot 2026-06-23 at 9 34 15 AM" src="https://github.com/user-attachments/assets/6b5ac5c0-b96c-423f-98a4-d82304ba88e7" />
