### PR TITLE
fix(hmda-help): hide additional institution information toggle

### DIFF
--- a/cypress/e2e/hmda-help/institution.spec.js
+++ b/cypress/e2e/hmda-help/institution.spec.js
@@ -228,11 +228,12 @@ onlyOn(!isBeta(HOST), () => {
         .select('true')
         .should('have.value', 'true')
 
-      cy.findByText('Show other fields').click()
-      cy.findByLabelText('RSSD').type('-1')
-      cy.findByLabelText('Parent ID RSSD').type('-1')
-      cy.findByLabelText('Assets').type('-1')
-      cy.findByLabelText('Top Holder ID RSSD').type('-1')
+      // Additional institution fields below disabled as per GHE #5675
+      // cy.findByText('Show other fields').click()
+      // cy.findByLabelText('RSSD').type('-1')
+      // cy.findByLabelText('Parent ID RSSD').type('-1')
+      // cy.findByLabelText('Assets').type('-1')
+      // cy.findByLabelText('Top Holder ID RSSD').type('-1')
 
       cy.findByText('Add the Institution').should('be.enabled').click()
 

--- a/src/hmda-help/institution/index.jsx
+++ b/src/hmda-help/institution/index.jsx
@@ -402,13 +402,14 @@ class Institution extends Component {
             />
           )}
 
-          <button
+          {/* Additional institution fields below disabled as per GHE #5675 */}
+          {/* <button
             className='button-link toggleButton'
             type='button'
             onClick={this.toggleShowOtherFields}
           >
             {this.state.showOtherFields ? 'Hide' : 'Show'} other fields
-          </button>
+          </button> */}
 
           {this.state.showOtherFields ? (
             <OtherFields

--- a/src/hmda-help/search/SearchResultActions.jsx
+++ b/src/hmda-help/search/SearchResultActions.jsx
@@ -58,13 +58,14 @@ function SearchResultActions({
             <button className='delete' onClick={() => toggleAreYouSure(index)}>
               Delete
             </button>
-            <button
+            {/* Additional institution fields below disabled as per GHE #5675 */}
+            {/* <button
               onClick={() => handleViewMoreClick(index)}
               ref={(element) => buttonsRef.current.set(index, element)}
               className='showOtherFields'
             >
               Show other fields
-            </button>
+            </button> */}
           </div>
           <div className='areYouSure hidden' id={`areYouSure${index}`}>
             <span>Are you sure?</span>{' '}

--- a/src/hmda-help/search/SearchResultActions.jsx
+++ b/src/hmda-help/search/SearchResultActions.jsx
@@ -1,9 +1,9 @@
+import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
-import { useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 
-import Loading from '../../common/LoadingIcon.jsx'
 import Alert from '../Alert'
+import Loading from '../../common/LoadingIcon.jsx'
 
 import './SearchResults.css'
 

--- a/src/hmda-help/search/SearchResultActions.jsx
+++ b/src/hmda-help/search/SearchResultActions.jsx
@@ -1,9 +1,9 @@
-import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
+import { useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 
-import Alert from '../Alert'
 import Loading from '../../common/LoadingIcon.jsx'
+import Alert from '../Alert'
 
 import './SearchResults.css'
 


### PR DESCRIPTION
We're no longer going to be allowing changes via HMDA Help to the additional institution information that can be edited when "Show other fields" is clicked.

## Changes

- comments out "Show other fields" button that reveals additional institution information in HMDA Help in both searches and edits
- comments out related part of the HMDA Help e2e test (the test itself is already skipped as per [the code comment,](https://github.com/cfpb/hmda-frontend/blob/master/cypress/e2e/hmda-help/institution.spec.js#L157-L166) but I figured I'd update it anyway)

## Testing

1. How does it look on staging? Good! (tagged on staging as `5661-and-5675-update-msamd-list-for-aggregate-reports-and-hmda-help-4`)
2. Do the tests still pass? Yes!

## Screenshots

### Search Before
<img width="1081" height="271" alt="Screenshot 2026-06-29 at 11 54 04 AM" src="https://github.com/user-attachments/assets/f694c7e2-f7be-417a-bc50-5cd19893ed75" />

### Search After
<img width="1070" height="215" alt="Screenshot 2026-06-29 at 11 57 07 AM" src="https://github.com/user-attachments/assets/740a7597-d06b-4b11-861e-5e0a32e6024e" />

### Institution Edit/Create Before
<img width="598" height="271" alt="Screenshot 2026-06-29 at 11 53 53 AM" src="https://github.com/user-attachments/assets/c623ff7e-4f8e-4c99-bba9-27e76b6d8003" />

### Institution Edit/Create After
<img width="643" height="173" alt="Screenshot 2026-06-29 at 11 52 50 AM" src="https://github.com/user-attachments/assets/2d01dd0b-9d56-4aa2-a62b-0e63e5da4533" />
