### PR TITLE
fix(security): bump dompurify, form-data, js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,13 +140,13 @@
     "tough-cookie": ">=4.1.3",
     "word-wrap": ">=1.2.4",
     "browserify-sign": ">=4.2.2",
-    "dompurify": ">=3.4.11",
+    "dompurify": "^3.4.11",
     "esbuild": "0.25.0",
     "canvg": "3.0.11",
     "elliptic": "6.6.1",
     "cross-spawn": ">=7.0.6",
     "glob": ">=11.1.0",
-    "form-data": ">=4.0.6",
+    "form-data": "^4.0.6",
     "sha.js": ">=2.4.12",
     "cipher-base": ">=1.0.5",
     "cheerio": "1.0.0-rc.10",
@@ -157,8 +157,9 @@
     "picomatch@3": ">=3.0.2",
     "picomatch@4": ">=4.0.4",
     "uuid": ">=11.1.1",
-    "js-yaml@3": ">=3.15.0",
-    "js-yaml@4": ">=4.2.0"
+    "js-yaml@^3.13.1": "^3.15.0",
+    "js-yaml@^4.1.0": "^4.2.0",
+    "vite@^5.0.0 || ^6.0.0 || ^7.0.0-0": "^7.3.6"
   },
   "packageManager": "yarn@4.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -140,13 +140,13 @@
     "tough-cookie": ">=4.1.3",
     "word-wrap": ">=1.2.4",
     "browserify-sign": ">=4.2.2",
-    "dompurify": "3.4.5",
+    "dompurify": ">=3.4.11",
     "esbuild": "0.25.0",
     "canvg": "3.0.11",
     "elliptic": "6.6.1",
     "cross-spawn": ">=7.0.6",
     "glob": ">=11.1.0",
-    "form-data": ">=4.0.4",
+    "form-data": ">=4.0.6",
     "sha.js": ">=2.4.12",
     "cipher-base": ">=1.0.5",
     "cheerio": "1.0.0-rc.10",
@@ -156,7 +156,9 @@
     "picomatch@2": ">=2.3.2",
     "picomatch@3": ">=3.0.2",
     "picomatch@4": ">=4.0.4",
-    "uuid": ">=11.1.1"
+    "uuid": ">=11.1.1",
+    "js-yaml@3": ">=3.15.0",
+    "js-yaml@4": ">=4.2.0"
   },
   "packageManager": "yarn@4.1.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6226,7 +6226,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:>=3.4.11":
+"dompurify@npm:^3.4.11":
   version: 3.4.11
   resolution: "dompurify@npm:3.4.11"
   dependencies:
@@ -7646,7 +7646,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:>=4.0.6":
+"form-data@npm:^4.0.6":
   version: 4.0.6
   resolution: "form-data@npm:4.0.6"
   dependencies:
@@ -9873,26 +9873,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
+"js-yaml@npm:^3.15.0":
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
+  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:^4.2.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 
@@ -15039,11 +15039,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0":
-  version: 7.3.3
-  resolution: "vite@npm:7.3.3"
+"vite@npm:^7.3.6":
+  version: 7.3.6
+  resolution: "vite@npm:7.3.6"
   dependencies:
-    esbuild: "npm:^0.27.0"
+    esbuild: "npm:^0.27.0 || ^0.28.0"
     fdir: "npm:^6.5.0"
     fsevents: "npm:~2.3.3"
     picomatch: "npm:^4.0.3"
@@ -15090,7 +15090,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/44fed2591d5d0a9d1f6313e0a4330659b7f1eec57e542558f12a924c53b450a84b9fad6d57ac28ec739eca1cf5ff0f62e41b965e3806c47eefdbbe13b74ec9ae
+  checksum: 10c0/c6d359f84ad362f5c97ff7988b77c90add04162c60cdf6059375a7d9e3217848c53a8cb6b6c48517bef84b6bba4c9bc85319a889b5236acb7d5a2bc8cb7b9a8d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6226,15 +6226,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.4.5":
-  version: 3.4.5
-  resolution: "dompurify@npm:3.4.5"
+"dompurify@npm:>=3.4.11":
+  version: 3.4.11
+  resolution: "dompurify@npm:3.4.11"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/4bcc953b0f33c61f07fd1b928342dd301dd94401a6058bff7cb47abd57892c797abe6d03118aa8056b36ea067bfe460324bea37fcaf57c0d906ed48e7ac32020
+  checksum: 10c0/31439481c7e8fc3805d40c376936fd66936620fb1b1a31a2ec097f6165412c37f2d868e082c9ceba62bb37661c1ea132a5db4d5213434317e30df68d4aca9cc9
   languageName: node
   linkType: hard
 
@@ -7646,16 +7646,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:>=4.0.4":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
+"form-data@npm:>=4.0.6":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
   languageName: node
   linkType: hard
 
@@ -8227,6 +8227,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/f5eb28c3fd0d3e4facd821c1eeee3836c37b70ab0b0fc532e8a39976e18fef43652415dadc52f8c7a5ff6d5ac93b7bef128789aa6f90f4e9b9a9083dce74ab38
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -10888,7 +10897,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:~2.1.19":
+"mime-types@npm:^2.1.35, mime-types@npm:~2.1.19":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:


### PR DESCRIPTION
Bumps a few dependencies to patch a few vulnerabilities.

## Changes

Resolution changes:
- update `dompurify` `3.4.5` to `>=3.4.11`
- update `form-data` `>=4.0.4` to `>=4.0.6`

New resolutions:
- add `js-yaml@3` at `>=3.15.0`
- add `js-yaml@4` at `>=4.2.0`
- add very specific vite resolution to target only a vulnerable version used in `vitest` at  `vite@^5.0.0 || ^6.0.0 || ^7.0.0-0` at `^7.3.6`

## Testing

1. Do the test still pass? Yes!
2. How do things look on staging? Good! (on staging as `5661-and-5671-security-and-aggregate-reports`)

## Notes
- I think we should switch things over to `^` rather than the norm of `>=` for resolutions. It was kind of an anomaly in some of the hmda-frontend resolutions, and I don't want to keep adding to the weirdness. There's some weirdness that can happen with `>=` which can cause issues if one of the resolutions had to be re-resolved or we ever had to regenerate the lock file. So I've added a bullet to this existing resolution cleanup issue GHE #5579, and we can clear these security issues first and put it in the TODO column for next sprint. 