### PR TITLE
fix: open FIG edit links in new tab

### DIFF
--- a/src/filing/submission/edits/Table.jsx
+++ b/src/filing/submission/edits/Table.jsx
@@ -65,7 +65,7 @@ export const renderTableCaption = (props) => {
   const [edit] = splitEditPart(name)
 
   const linkedName = (
-    <a href={`/documentation/fig/${year}/overview#edit-${edit}`}>{name}</a>
+    <a href={`/documentation/fig/${year}/overview#edit-${edit}`} target='_blank' rel='noopener noreferrer'>{name}</a>
   )
   let captionHeader
 


### PR DESCRIPTION
## Changes

- Links to the FIG now open in a new tab.

## Notes

- I added `noopener noreferrer` to appease cyber scanners

<img width="373" height="63" alt="fig-links-after" src="https://github.com/user-attachments/assets/7622bd14-26e2-40bb-84c3-7fd0b06fa0c6" />
