### PR TITLE
fix(update-notes): wrap scrollTo useEffect in func

### DIFF
--- a/src/filing/institutions/details/InstitutionDetails.jsx
+++ b/src/filing/institutions/details/InstitutionDetails.jsx
@@ -17,7 +17,9 @@ export function InstitutionDetails({ data }) {
     isFetching,
   } = data
 
-  useEffect(() => window.scrollTo(0, 0), [])
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
 
   if (isFetching) return wrapLoading()
 

--- a/src/updates-notes/FilterBar.jsx
+++ b/src/updates-notes/FilterBar.jsx
@@ -125,7 +125,9 @@ function FilterPill({ option, filter }) {
   const [wasClicked, setWasClicked] = useState(false)
 
   // Scroll to page top on initial load
-  useEffect(() => window.scrollTo(0, 0), [])
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
 
   // Keep Filter Bar in view on filter change
   useEffect(() => {


### PR DESCRIPTION
Fixes a pretty tricky little bug with newer versions of Chrome.

[Chrome has introduced](https://developer.chrome.com/blog/new-in-web-ui-io26#22_awaitable_programmatic_scrolling) new programmatic scroll methods including the `ScrollTo()` implementation that returns a promise instead of only returning `undefined`. This causes some real headaches for any `useEffects` that have `scrollTo()`, `scrollBy()`, etc. 

You can check this difference out yourself by comparing what happens in the browser console when you type in `window.scrollTo(0, 0)` in Firefox vs the new Chrome.

<img width="165" height="250" alt="Screenshot 2026-07-17 at 3 02 11 PM" src="https://github.com/user-attachments/assets/c8ffcb35-db35-4a22-bd6a-7879cd8fa8dd" />

<img width="173" height="228" alt="Screenshot 2026-07-17 at 3 01 10 PM" src="https://github.com/user-attachments/assets/0aba9ec8-b07d-4a1c-a9e6-2e912dc6dff4" />

With this change, `scrollTo()` now returns a promise instead of returning `undefined`. For some of our `useEffect`s, we didn't put curly braces around the `useEffect`'s function and instead just used an arrow function which returned the function's result. Like this one in the `FilterBar` for News and Updates:

https://github.com/cfpb/hmda-frontend/blob/2ceb32bf919ad63f4d971ed742109415ab8bdc23/src/updates-notes/FilterBar.jsx#L127-L128

When the component that used a `useEffect` like this gets unmounted, react will [try to call what was previously returned](https://medium.com/geekculture/react-uncaught-typeerror-destroy-is-not-a-function-192738a6e79b) by that `useEffect` as its cleanup function unless its `undefined`. With this change to `ScrollTo` where it now returns a promise instead of `undefined`, when React tries to call the promise like a function, we get an error. 


## Changes

- A lot of research and pain for a super simple change: wrap the `useEffect` functions that include `scrollTo` in curly braces to stop them from returning anything other than `undefined`.
  - `filing/institutions/details/InstitutionDetails.jsx`
  - `src/updates-notes/FilterBar.jsx`

## Testing

1. Does News and Updates crash on staging? No, looks good! (tagged as `5711-fix-scrollto-use-effects` on staging)
2. Does the institution details page not crash on staging when you navigate to the details page and then try navigate away from it by clicking the back button? No, looks good! Here's the page I'm referring to when you click this `i` tooltip.
<img width="1047" height="568" alt="Screenshot 2026-07-17 at 3 20 53 PM" src="https://github.com/user-attachments/assets/1417a504-5be5-4638-b887-259c611a9532" />
<img width="792" height="422" alt="Screenshot 2026-07-17 at 3 22 29 PM" src="https://github.com/user-attachments/assets/4e522cb4-27ff-4c46-b855-9b92a4dacf70" />
3. Do the tests still pass? Yes!