### PR TITLE
fix(institution-details): hide additional info no longer maintained

### DIFF
--- a/src/filing/institutions/details/InstitutionDetails.jsx
+++ b/src/filing/institutions/details/InstitutionDetails.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react'
 import { agencyCodes } from '../constants'
 import { Input } from './InstitutionInput'
-import { OtherFields } from './OtherFields'
 import { wrapLoading } from '../wrapLoading'
 import ProfileIcon from '../../profile/ProfileIcon'
 
@@ -47,7 +46,8 @@ export function InstitutionDetails({ data }) {
           value={`${agency} - ${agencyCodes[agency]}`}
         />
       </div>
-      <OtherFields data={data} />
+      {/* Additional institution fields below disabled as per GHE #5675 */}
+      {/* <OtherFields data={data} /> */}
     </form>
   )
 }


### PR DESCRIPTION
After our change to [no longer allow changes via HMDA Help](https://github.com/cfpb/hmda-frontend/pull/2801) to the additional institution information fields, we should also hide that information that is often innaccurate from the obscure page "Institutional Details."

You can access this page by clicking this `i` tooltip.
<img width="1047" height="568" alt="Screenshot 2026-07-17 at 3 20 53 PM" src="https://github.com/user-attachments/assets/1417a504-5be5-4638-b887-259c611a9532" />
<img width="792" height="422" alt="Screenshot 2026-07-17 at 3 22 29 PM" src="https://github.com/user-attachments/assets/4e522cb4-27ff-4c46-b855-9b92a4dacf70" />

## Changes

- comments out "Show additional fields" button that reveals additional institution information that can be inaccurate 

## Testing

1. How does it look on staging? Good! (tagged on staging as `5711-fix-scrollto-use-effects-and-hide-additional-institution-info-2`)
2. Do the tests still pass? Yes!

## Screenshots

### Institution Details Page Before
<img width="1072" height="434" alt="Screenshot 2026-07-17 at 3 51 45 PM" src="https://github.com/user-attachments/assets/73e391f9-da5a-4c23-ab19-5760d513eeb5" />


### Institution Details Page After
<img width="1081" height="422" alt="Screenshot 2026-07-17 at 3 53 42 PM" src="https://github.com/user-attachments/assets/540fd7f0-de9a-49e0-9d9c-2ebd5891873d" />
