### PR TITLE
feat(filing): add markdown support to filing descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "redux": "4.2.1",
     "redux-logger": "3.0.6",
     "redux-thunk": "2.4.2",
+    "rehype-external-links": "^3.0.0",
     "sass": "1.77.8",
     "split2": "3.2.2",
     "streamsaver": "2.0.6",

--- a/src/filing/submission/edits/Table.css
+++ b/src/filing/submission/edits/Table.css
@@ -42,6 +42,12 @@
   margin-bottom: 0;
 }
 
+.EditsTable caption .markdown-description,
+.EditsTable .caption .markdown-description {
+  color: #323a45;
+  font-weight: normal;
+}
+
 .EditsTable:last-of-type {
   margin-bottom: 2em;
 }
@@ -69,5 +75,10 @@
 
 #Q666 caption p,
 #Q666 .caption p {
+  color: #212121;
+}
+
+#Q666 caption .markdown-description,
+#Q666 .caption .markdown-description {
   color: #212121;
 }

--- a/src/filing/submission/edits/Table.jsx
+++ b/src/filing/submission/edits/Table.jsx
@@ -96,13 +96,13 @@ export const renderTableCaption = (props) => {
     captionHeader = 'Review your loan/application IDs'
   }
 
-  const { description } = props.edit
+  const cleanDescription = props.edit.description.replace(/^"|"$/g, '')
 
   if (shouldSuppressTable(props)) {
     return (
       <div className='caption'>
         <h3>{captionHeader}</h3>
-        {renderDescription(description)}
+        {renderDescription(cleanDescription)}
         {name === 'S040' ? (
           <p>
             Please check your file or system of record for duplicate
@@ -116,7 +116,7 @@ export const renderTableCaption = (props) => {
   return (
     <caption>
       <h3>{captionHeader}</h3>
-      {renderDescription(description)}
+      {renderDescription(cleanDescription)}
     </caption>
   )
 }

--- a/src/filing/submission/edits/Table.jsx
+++ b/src/filing/submission/edits/Table.jsx
@@ -1,4 +1,6 @@
 import PropTypes from 'prop-types'
+import Markdown from 'react-markdown'
+import rehypeExternalLinks from 'rehype-external-links'
 import Loading from '../../../common/LoadingIcon.jsx'
 import { splitEditPart, splitYearQuarter } from '../../api/utils.js'
 import Pagination from '../../pagination/container.jsx'
@@ -65,7 +67,13 @@ export const renderTableCaption = (props) => {
   const [edit] = splitEditPart(name)
 
   const linkedName = (
-    <a href={`/documentation/fig/${year}/overview#edit-${edit}`} target='_blank' rel='noopener noreferrer'>{name}</a>
+    <a
+      href={`/documentation/fig/${year}/overview#edit-${edit}`}
+      target='_blank'
+      rel='noopener noreferrer'
+    >
+      {name}
+    </a>
   )
   let captionHeader
 
@@ -88,13 +96,13 @@ export const renderTableCaption = (props) => {
     captionHeader = 'Review your loan/application IDs'
   }
 
-  const description = props.edit.description.replace(/"/g, '')
+  const { description } = props.edit
 
   if (shouldSuppressTable(props)) {
     return (
       <div className='caption'>
         <h3>{captionHeader}</h3>
-        {description ? <p>{description}</p> : null}
+        {renderDescription(description)}
         {name === 'S040' ? (
           <p>
             Please check your file or system of record for duplicate
@@ -108,8 +116,27 @@ export const renderTableCaption = (props) => {
   return (
     <caption>
       <h3>{captionHeader}</h3>
-      {description ? <p>{description}</p> : null}
+      {renderDescription(description)}
     </caption>
+  )
+}
+
+export const renderDescription = (description) => {
+  if (!description) return null
+
+  return (
+    <div className='markdown-description'>
+      <Markdown
+        rehypePlugins={[
+          [
+            rehypeExternalLinks,
+            { target: '_blank', rel: ['noopener', 'noreferrer'] },
+          ],
+        ]}
+      >
+        {description}
+      </Markdown>
+    </div>
   )
 }
 
@@ -133,11 +160,7 @@ export const makeTable = (props) => {
   className += props.paginationFade ? ' fadeOut' : ''
 
   return (
-    <table
-      width='100%'
-      className={className}
-      summary={`Report for edit ${edit.edit} - ${edit.description}`}
-    >
+    <table width='100%' className={className}>
       {caption}
       <thead>{renderHeader(edit, rowObj.rows, type)}</thead>
       <tbody>{renderBody(edit, rowObj.rows, type)}</tbody>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8239,6 +8239,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-is-element@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "hast-util-is-element@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+  checksum: 10c0/f5361e4c9859c587ca8eb0d8343492f3077ccaa0f58a44cd09f35d5038f94d65152288dcd0c19336ef2c9491ec4d4e45fde2176b05293437021570aa0bc3613b
+  languageName: node
+  linkType: hard
+
 "hast-util-to-jsx-runtime@npm:^2.0.0":
   version: 2.3.6
   resolution: "hast-util-to-jsx-runtime@npm:2.3.6"
@@ -8390,6 +8399,7 @@ __metadata:
     redux: "npm:4.2.1"
     redux-logger: "npm:3.0.6"
     redux-thunk: "npm:2.4.2"
+    rehype-external-links: "npm:^3.0.0"
     sass: "npm:1.77.8"
     serialize-javascript: "npm:7.0.5"
     split2: "npm:3.2.2"
@@ -8700,6 +8710,13 @@ __metadata:
   version: 5.4.0
   resolution: "iobuffer@npm:5.4.0"
   checksum: 10c0/1b3f9a5ea158bc63f038b374b42832acdb9db13ea9cfa4ed78723f30894986442f6c033dff4ae2fdf34724bf0fe432e3b86c11ca82049568c58b8d7fb47a6ac2
+  languageName: node
+  linkType: hard
+
+"is-absolute-url@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "is-absolute-url@npm:4.0.1"
+  checksum: 10c0/6f8f603945bd9f2c6031758bbc12352fc647bd5d807cad10d96cc6300fd0e15240cc091521a61db767e4ec0bacff257b4f1015fd5249c147bbb4a4497356c72e
   languageName: node
   linkType: hard
 
@@ -12627,6 +12644,20 @@ __metadata:
   bin:
     regjsparser: bin/parser
   checksum: 10c0/1276c983f00de49e37ef76b181df4390699b46e3666fbe6b8b5512bd75919112574cf023f28ac720d427be158af60dba6a77cce9a8aaff14967263636e667356
+  languageName: node
+  linkType: hard
+
+"rehype-external-links@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "rehype-external-links@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@ungap/structured-clone": "npm:^1.0.0"
+    hast-util-is-element: "npm:^3.0.0"
+    is-absolute-url: "npm:^4.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+    unist-util-visit: "npm:^5.0.0"
+  checksum: 10c0/486b5db73d8fe72611d62b4eb0b56ec71025ea32bba764ad54473f714ca627be75e057ac29243763f85a77c3810f31727ce3e03c975b3803c1c98643d038e9ae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Let's add markdown for edit descriptions! This PR adds basic markdown formatting particularly necessary for links, with the potential to add support for further markdown features later.

## Changes
_src/filing/submission/edits/Table.css_
- adds CSS for the `markdown-description` wrapper to mimic the existing two rules [here](https://github.com/cfpb/hmda-frontend/pull/2815/changes#diff-67d473742f7a5f19711d8ec0fbc7684c32f91d6f8a8776b0bf87e7773e783851R39-R40) and [here](https://github.com/cfpb/hmda-frontend/pull/2815/changes#diff-67d473742f7a5f19711d8ec0fbc7684c32f91d6f8a8776b0bf87e7773e783851R78) to avoid everything being bolded or the wrong color

_src/filing/submission/edits/Table.jsx_
- lints [these lines](https://github.com/cfpb/hmda-frontend/pull/2815/changes#diff-f0418b333d12607045516ff3ad5fe9969a70b43e246c3c5bd8e811ee84e0f551R70-R76) with no substantive changes
- strip out only the beginning and ending quotes, instead of all quotes
- render the edits with markdown using `rehype-external-links` to open in a new tab
- remove the summary property that [was deprecated awhile ago](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableElement/summary) in favor of just using the caption which we already do and would render weird markdown now

_package.json_
- adds `rehype-external-links` so we can open links in edit descriptions in new tabs

## Testing
- How does it look on staging? Good! (currently on staging as `2806-add-markdown-parsing-for-filing-app-1`) I rendered every unique description since 2018 and compared it to the new markdown version. Looks good! There are a few edits that are a little spicy like Q660-3 that includes `*`, it's separated by commas so doesn't trigger any markdown styling.

<img width="1247" height="355" alt="Screenshot 2026-09-17 at 3 22 33 PM" src="https://github.com/user-attachments/assets/f05b09ba-f545-4270-ac7d-717e600f2b1b" />

We'll want to test out any new edits with this new markdown support.

I ran some image diffing on the before and after the markdown changes. You can view every one of the edits rendered in [this pdf](https://github.com/user-attachments/files/32358232/MD.Test.-.All.Markdown.Edits.Since.2018.pdf) if you want to take a look. You can also deploy it to staging again if you want to, it's tagged as `markdown-support-demo-2`

- Do the tests still pass? Yes!

