### PR TITLE
test: update cypress tests to match new institution names and data

### DIFF
--- a/cypress/e2e/common-features/navigation.spec.js
+++ b/cypress/e2e/common-features/navigation.spec.js
@@ -56,7 +56,8 @@ onlyOn(!isBeta(HOST), () => {
         .as('filingLink')
 
       cy.get('@filingLink').click({force: true})
-      cy.location('pathname').should('match', /\/filing\/\d{4}\/?$/)
+      // Match /filing/YYYY-Q[1-3] and not just /filing/YYYY
+      cy.location('pathname').should('match', /\/filing\/\d{4}(?:-[Q1-3]+)?\/?$/)
     })
   })
 

--- a/cypress/e2e/data-browser/graphs.spec.js
+++ b/cypress/e2e/data-browser/graphs.spec.js
@@ -50,7 +50,7 @@ onlyOn(!isBeta(HOST), () => {
       )
     })
 
-    it('Institution level data is correct for 2022-2024', () => {
+    it('Institution level data is correct for 2023-2025', () => {
       // Using Bank of America as the test institution
       const institutionDetails = {
         name: 'BANK OF AMERICA, NATIONAL ASSOCIATION',
@@ -59,9 +59,9 @@ onlyOn(!isBeta(HOST), () => {
       }
 
       const yearData = [
+        { year: '2025', count: '245,091' },
         { year: '2024', count: '233,637' },
         { year: '2023', count: '271,974' },
-        { year: '2022', count: '348,961' },
       ]
 
       cy.visit(`${baseURLToVisit}/data-browser/graphs/quarterly/info/filers`)
@@ -87,12 +87,12 @@ onlyOn(!isBeta(HOST), () => {
       })
     })
 
-    it('Total of Quarterly Filers counts appear for 2022-2024', () => {
+    it('Total of Quarterly Filers counts appear for 2023-2025', () => {
       // Data ordered from newest to oldest year to match table layout
       const yearData = [
+        { year: '2025', count: '6,327,055' },
         { year: '2024', count: '5,654,177' },
         { year: '2023', count: '5,045,979' },
-        { year: '2022', count: '6,641,433' },
       ]
 
       cy.visit(`${baseURLToVisit}/data-browser/graphs/quarterly/info/filers`)
@@ -111,12 +111,12 @@ onlyOn(!isBeta(HOST), () => {
       })
     })
 
-    it('Total of All Filers counts appear for 2022-2024', () => {
+    it('Total of All Filers counts appear for 2023-2025', () => {
       // Data ordered from newest to oldest year to match table layout
       const yearData = [
+        { year: '2025', count: '13,543,606' },
         { year: '2024', count: '12,259,199' },
         { year: '2023', count: '11,564,155' },
-        { year: '2022', count: '16,125,975' },
       ]
 
       cy.visit(`${baseURLToVisit}/data-browser/graphs/quarterly/info/filers`)

--- a/cypress/e2e/data-publication/DisclosureReports.spec.js
+++ b/cypress/e2e/data-publication/DisclosureReports.spec.js
@@ -13,7 +13,7 @@ onlyOn(!isBeta(HOST), () => {
   // extending the timeout to account for slower API calls
   describe('Disclosure Reports', { defaultCommandTimeout: 45000 }, () => {
     it('Fetches a 2025 Applications by Tract Report', () => {
-      const institution = 'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06'
+      const institution = 'CYPRESS BANK STATE SAVINGS BANK'
       const institutionName = institution.split(' - ')[0]
       const msaMd = 'Dallas-Plano-Irving, TX - 19124'
       const msaMdCityOnly = msaMd.split(', ')[0]
@@ -78,7 +78,7 @@ onlyOn(!isBeta(HOST), () => {
     })
 
     it('Fetches a 2024 Applications by Tract Report', () => {
-      const institution = 'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06'
+      const institution = 'CYPRESS BANK STATE SAVINGS BANK'
       const institutionName = institution.split(' - ')[0]
       const msaMd = 'Dallas-Plano-Irving, TX - 19124'
       const msaMdCityOnly = msaMd.split(', ')[0]
@@ -140,8 +140,7 @@ onlyOn(!isBeta(HOST), () => {
     })
 
     it('Fetches a 2023 Applications by Tract Report', () => {
-      const institution =
-        'LIBERTYVILLE BANK & TRUST COMPANY, N.A. - 01ERPZV3DOLNXY2MLB90'
+      const institution = 'LIBERTYVILLE BANK & TRUST NA'
       const institutionName = institution.split(' - ')[0]
       const msaMd = 'Chicago-Naperville-Evanston, IL - 16984'
       const msaMdCityOnly = msaMd.split(', ')[0]

--- a/cypress/e2e/data-publication/ModifiedLAR.spec.js
+++ b/cypress/e2e/data-publication/ModifiedLAR.spec.js
@@ -30,6 +30,14 @@ const testCases =
       }
     }
 
+    if ([2025, 2024, 2023].includes(year) && !isDev(HOST)) {
+      return {
+        year,
+        name: 'cypress bank state savings bank',
+        institution: '549300I4IUWMEMGLST06',
+      }
+    }
+
   const getDefaultCaseInstitution = () => {
     const prodTestInstitution = {
       year,


### PR DESCRIPTION
2023-2025 institution data fields were updated this morning from their relevant transmittal sheets, causing our cypress tests to need new selectors.

## Testing

1. Run cypress against ffiec.cfpb.gov and it should be green.