### PR TITLE
test: point localhost API to prod for e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,12 @@ jobs:
         env:
           CYPRESS_ENVIRONMENT: CI
         run: yarn test-localhost
+
+      - name: Upload Cypress Artifacts on Failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-error-artifacts
+          path: |
+            cypress/screenshots
+            cypress/videos

--- a/cypress/e2e/common-features/redirection.spec.js
+++ b/cypress/e2e/common-features/redirection.spec.js
@@ -1,6 +1,6 @@
+import { onlyOn } from '@cypress/skip-test'
 import config from '../../../src/common/constants/prod-config.json'
 import { isBeta } from '../../support/helpers'
-import { onlyOn } from '@cypress/skip-test'
 const years = config.dataPublicationYears
 
 const { HOST } = Cypress.env()
@@ -102,7 +102,7 @@ onlyOn(isBeta(HOST), () => {
 })
 
 onlyOn(!isBeta(HOST), () => {
-  describe('withYearValidation', () => {
+  describe('withYearValidation', { tags: ['@localhost'] }, () => {
     FromTo.forEach(({ from, to, description }) => {
       const testDescription = description || `Auto-redirects from ${from}`
       it(testDescription, () => {

--- a/cypress/e2e/data-browser/dataset-filtering.spec.js
+++ b/cypress/e2e/data-browser/dataset-filtering.spec.js
@@ -1,6 +1,8 @@
 import {
+  addLocalhostIntercepts,
   dbURL,
   isBeta,
+  isCI,
   isProd,
   openSelector,
   waitUpto2Mins,
@@ -14,192 +16,200 @@ const years = (YEARS && YEARS.toString().split(',')) || [
 const { HOST, ENVIRONMENT } = Cypress.env()
 const dbUrl = dbURL.bind(null, HOST)
 
-describe(`Data Browser - Dataset Filtering`, () => {
-  if (!isProd(HOST) || isBeta(HOST)) it('Only runs in Production')
-  else {
-    years.forEach((year) => {
-      describe(`${year} Dataset Filtering`, () => {
-        it('State/Institution/PropertyType', { tags: ['@smoke'] }, () => {
-          cy.get({ HOST, ENVIRONMENT }).logEnv()
-          cy.viewport(1000, 1400)
-          cy.visit(dbUrl(`${year}?category=states`))
+describe(`Data Browser - Dataset Filtering`, { tags: ['@localhost'] }, () => {
+  const shouldRun = isCI(ENVIRONMENT) || (isProd(HOST) && !isBeta(HOST))
 
-          // Wait for the Institutions selector to load because it can steal focus when trying to enter data in another input field.
-          openSelector('#lei-item-select')
+  if (!shouldRun) {
+    it('Only runs in Production or CI', () => {})
+    return
+  }
 
-          // Select Geography
-          cy.get('#ItemSelector').type('alabama{enter}')
-          cy.get('#ItemSelector').type('alaska{enter}')
-          cy.url().should('include', '?category=states&items=AL,AK')
+  beforeEach(() => {
+    addLocalhostIntercepts()
+  })
 
-          // Select Institutions
-          openSelector('#lei-item-select')
-          cy.get('#lei-item-select').type('bank of america{enter}')
-          cy.get('#lei-item-select').type('chase bank{enter}')
-          cy.url().should(
-            'include',
-            'leis=B4TYDEB6GKMZO031MB27,7H6GLXDRUGQFU57RNE97',
-          )
+  years.forEach((year) => {
+    describe(`${year} Dataset Filtering`, () => {
+      it('State/Institution/PropertyType', { tags: ['@smoke'] }, () => {
+        cy.get({ HOST, ENVIRONMENT }).logEnv()
+        cy.viewport(1000, 1400)
+        cy.visit(dbUrl(`${year}?category=states`))
 
-          // Variables
-          cy.get('#VariableSelector').type('dwelling{enter}')
-          cy.findByText('Single Family (1-4 Units):Site-Built').click()
-          cy.url().should(
-            'include',
-            '&dwelling_categories=Single%20Family%20(1-4%20Units)%3ASite-Built',
-          )
+        // Wait for the Institutions selector to load because it can steal focus when trying to enter data in another input field.
+        openSelector('#lei-item-select')
 
-          // View Summary Table
-          cy.findByText('View Summary Table').click()
-          cy.get('.Aggregations', waitUpto2Mins).should('exist')
-          cy.get('.Aggregations :nth-child(1) > .sublist > li').should(
-            'have.text',
-            'ALABAMA, ALASKA',
-          )
-          cy.get('.Aggregations :nth-child(2) > .sublist > li').then(($li) => {
-            let text = $li.text().toLowerCase()
-            cy.wrap(text).should('contain', 'bank of america')
-            cy.wrap(text).should('contain', 'chase bank')
-          })
-          cy.get('.Aggregations :nth-child(3) > .sublist > li').should(
-            'have.text',
-            'Single Family (1-4 Units):Site-Built',
-          )
-          cy.get('.Error').should('not.exist')
+        // Select Geography
+        cy.get('#ItemSelector').type('alabama{enter}')
+        cy.get('#ItemSelector').type('alaska{enter}')
+        cy.url().should('include', '?category=states&items=AL,AK')
+
+        // Select Institutions
+        openSelector('#lei-item-select')
+        cy.get('#lei-item-select').type('bank of america{enter}')
+        cy.get('#lei-item-select').type('chase bank{enter}')
+        cy.url().should(
+          'include',
+          'leis=B4TYDEB6GKMZO031MB27,7H6GLXDRUGQFU57RNE97',
+        )
+
+        // Variables
+        cy.get('#VariableSelector').type('dwelling{enter}')
+        cy.findByText('Single Family (1-4 Units):Site-Built').click()
+        cy.url().should(
+          'include',
+          '&dwelling_categories=Single%20Family%20(1-4%20Units)%3ASite-Built',
+        )
+
+        // View Summary Table
+        cy.findByText('View Summary Table').click()
+        cy.get('.Aggregations', waitUpto2Mins).should('exist')
+        cy.get('.Aggregations :nth-child(1) > .sublist > li').should(
+          'have.text',
+          'ALABAMA, ALASKA',
+        )
+        cy.get('.Aggregations :nth-child(2) > .sublist > li').then(($li) => {
+          const text = $li.text().toLowerCase()
+          cy.wrap(text).should('contain', 'bank of america')
+          cy.wrap(text).should('contain', 'chase bank')
         })
+        cy.get('.Aggregations :nth-child(3) > .sublist > li').should(
+          'have.text',
+          'Single Family (1-4 Units):Site-Built',
+        )
+        cy.get('.Error').should('not.exist')
+      })
 
-        it('Nationwide/Institution/LienStatus', () => {
-          cy.get({ HOST, ENVIRONMENT }).logEnv()
-          cy.viewport(1000, 1400)
-          cy.visit(dbUrl(`${year}?category=nationwide`))
+      it('Nationwide/Institution/LienStatus', () => {
+        cy.get({ HOST, ENVIRONMENT }).logEnv()
+        cy.viewport(1000, 1400)
+        cy.visit(dbUrl(`${year}?category=nationwide`))
 
-          // Select Institutions
-          openSelector('#lei-item-select')
-          cy.get('#lei-item-select').type('bank of america{enter}')
-          cy.get('#lei-item-select').type('chase bank{enter}')
-          cy.url().should(
-            'include',
-            'leis=B4TYDEB6GKMZO031MB27,7H6GLXDRUGQFU57RNE97',
-          )
+        // Select Institutions
+        openSelector('#lei-item-select')
+        cy.get('#lei-item-select').type('bank of america{enter}')
+        cy.get('#lei-item-select').type('chase bank{enter}')
+        cy.url().should(
+          'include',
+          'leis=B4TYDEB6GKMZO031MB27,7H6GLXDRUGQFU57RNE97',
+        )
 
-          // Variables
-          cy.get('#VariableSelector').type('lien status{enter}')
-          cy.findByText('Secured By First Lien').click()
-          cy.url().should('include', '&lien_statuses=1')
+        // Variables
+        cy.get('#VariableSelector').type('lien status{enter}')
+        cy.findByText('Secured By First Lien').click()
+        cy.url().should('include', '&lien_statuses=1')
 
-          // View Summary Table
-          cy.findByText('View Summary Table').click({ force: true })
-          cy.get('.Aggregations', waitUpto2Mins).should('exist')
-          cy.get('.Aggregations :nth-child(1) > .sublist > li').then(($li) => {
-            let text = $li.text().toLowerCase()
-            cy.wrap(text).should('contain', 'bank of america')
-            cy.wrap(text).should('contain', 'chase bank')
-          })
-          cy.get('.Aggregations :nth-child(2) > .sublist > li').should(
-            'have.text',
-            'Secured By First Lien',
-          )
-          cy.get('.Error').should('not.exist')
+        // View Summary Table
+        cy.findByText('View Summary Table').click({ force: true })
+        cy.get('.Aggregations', waitUpto2Mins).should('exist')
+        cy.get('.Aggregations :nth-child(1) > .sublist > li').then(($li) => {
+          const text = $li.text().toLowerCase()
+          cy.wrap(text).should('contain', 'bank of america')
+          cy.wrap(text).should('contain', 'chase bank')
         })
+        cy.get('.Aggregations :nth-child(2) > .sublist > li').should(
+          'have.text',
+          'Secured By First Lien',
+        )
+        cy.get('.Error').should('not.exist')
+      })
 
-        it('County/Institution/Action&Purpose', () => {
-          cy.get({ HOST, ENVIRONMENT }).logEnv()
-          cy.viewport(1000, 1400)
-          cy.visit(dbUrl(`${year}?category=counties`))
+      it('County/Institution/Action&Purpose', () => {
+        cy.get({ HOST, ENVIRONMENT }).logEnv()
+        cy.viewport(1000, 1400)
+        cy.visit(dbUrl(`${year}?category=counties`))
 
-          // Wait for the Institutions selector to load because it can steal focus when trying to enter data in another input field.
-          openSelector('#lei-item-select')
+        // Wait for the Institutions selector to load because it can steal focus when trying to enter data in another input field.
+        openSelector('#lei-item-select')
 
-          // Select Geography
-          cy.get('#ItemSelector').type('autauga county{enter}')
-          cy.get('#ItemSelector').type('baldwin county{enter}')
-          cy.url().should('include', '?category=counties&items=01001,01003')
+        // Select Geography
+        cy.get('#ItemSelector').type('autauga county{enter}')
+        cy.get('#ItemSelector').type('baldwin county{enter}')
+        cy.url().should('include', '?category=counties&items=01001,01003')
 
-          // Select Institutions
-          openSelector('#lei-item-select')
-          cy.get('#lei-item-select').type('bank of america{enter}')
-          cy.get('#lei-item-select').type('chase bank{enter}')
-          cy.url().should(
-            'include',
-            'leis=B4TYDEB6GKMZO031MB27,7H6GLXDRUGQFU57RNE97',
-          )
+        // Select Institutions
+        openSelector('#lei-item-select')
+        cy.get('#lei-item-select').type('bank of america{enter}')
+        cy.get('#lei-item-select').type('chase bank{enter}')
+        cy.url().should(
+          'include',
+          'leis=B4TYDEB6GKMZO031MB27,7H6GLXDRUGQFU57RNE97',
+        )
 
-          // Variables
-          cy.get('#VariableSelector').type('total units{enter}')
-          cy.findByText('25-49').click()
-          cy.url().should('include', '&total_units=25-49')
+        // Variables
+        cy.get('#VariableSelector').type('total units{enter}')
+        cy.findByText('25-49').click()
+        cy.url().should('include', '&total_units=25-49')
 
-          // View Summary Table
-          cy.findByText('View Summary Table').click()
-          cy.get('.Aggregations', waitUpto2Mins).should('exist')
-          cy.get('.Aggregations :nth-child(1) > .sublist > li').should(
-            'have.text',
-            'AUTAUGA COUNTY, BALDWIN COUNTY',
-          )
-          cy.get('.Aggregations :nth-child(2) > .sublist > li').then(($li) => {
-            let text = $li.text().toLowerCase()
-            cy.wrap(text).should('contain', 'bank of america')
-            cy.wrap(text).should('contain', 'chase bank')
-          })
-          cy.get('.Aggregations :nth-child(3) > .sublist > li').should(
-            'have.text',
-            '25-49',
-          )
-          cy.get('.Error').should('not.exist')
+        // View Summary Table
+        cy.findByText('View Summary Table').click()
+        cy.get('.Aggregations', waitUpto2Mins).should('exist')
+        cy.get('.Aggregations :nth-child(1) > .sublist > li').should(
+          'have.text',
+          'AUTAUGA COUNTY, BALDWIN COUNTY',
+        )
+        cy.get('.Aggregations :nth-child(2) > .sublist > li').then(($li) => {
+          const text = $li.text().toLowerCase()
+          cy.wrap(text).should('contain', 'bank of america')
+          cy.wrap(text).should('contain', 'chase bank')
         })
+        cy.get('.Aggregations :nth-child(3) > .sublist > li').should(
+          'have.text',
+          '25-49',
+        )
+        cy.get('.Error').should('not.exist')
+      })
 
-        it('MSA/Institution/PropertyType', () => {
-          cy.get({ HOST, ENVIRONMENT }).logEnv()
-          cy.viewport(1000, 1400)
-          cy.visit(dbUrl(`${year}?category=msamds`))
+      it('MSA/Institution/PropertyType', () => {
+        cy.get({ HOST, ENVIRONMENT }).logEnv()
+        cy.viewport(1000, 1400)
+        cy.visit(dbUrl(`${year}?category=msamds`))
 
-          // Wait for the Institutions selector to load because it can steal focus when trying to enter data in another input field.
-          openSelector('#lei-item-select')
+        // Wait for the Institutions selector to load because it can steal focus when trying to enter data in another input field.
+        openSelector('#lei-item-select')
 
-          // Select Geography
-          cy.get('#ItemSelector').type('11500{enter}')
-          cy.get('#ItemSelector').type('12220{enter}')
-          cy.url().should('include', '?category=msamds&items=11500,12220')
+        // Select Geography
+        cy.get('#ItemSelector').type('11500{enter}')
+        cy.get('#ItemSelector').type('12220{enter}')
+        cy.url().should('include', '?category=msamds&items=11500,12220')
 
-          // Select Institutions
-          openSelector('#lei-item-select')
-          cy.get('#lei-item-select').type('bank of america{enter}')
-          cy.get('#lei-item-select').type('chase bank{enter}')
-          cy.url().should(
-            'include',
-            'leis=B4TYDEB6GKMZO031MB27,7H6GLXDRUGQFU57RNE97',
-          )
+        // Select Institutions
+        openSelector('#lei-item-select')
+        cy.get('#lei-item-select').type('bank of america{enter}')
+        cy.get('#lei-item-select').type('chase bank{enter}')
+        cy.url().should(
+          'include',
+          'leis=B4TYDEB6GKMZO031MB27,7H6GLXDRUGQFU57RNE97',
+        )
 
-          // Variables
-          cy.get('#VariableSelector').type('loan type{enter}')
-          cy.findByText('Conventional').click({ force: true })
-          cy.url().should('include', '&loan_types=1')
+        // Variables
+        cy.get('#VariableSelector').type('loan type{enter}')
+        cy.findByText('Conventional').click({ force: true })
+        cy.url().should('include', '&loan_types=1')
 
-          // View Summary Table
-          cy.findByText('View Summary Table').click({ force: true })
-          cy.get('.Aggregations', waitUpto2Mins).should('exist')
+        // View Summary Table
+        cy.findByText('View Summary Table').click({ force: true })
+        cy.get('.Aggregations', waitUpto2Mins).should('exist')
 
-          const msa_text =
-            year === 2018
-              ? '11500\u00A0-\u00A0ANNISTON-OXFORD-JACKSONVILLE, 12220\u00A0-\u00A0AUBURN-OPELIKA'
-              : '11500\u00A0-\u00A0ANNISTON-OXFORD, 12220\u00A0-\u00A0AUBURN-OPELIKA'
+        const msa_text =
+          year === 2018
+            ? '11500\u00A0-\u00A0ANNISTON-OXFORD-JACKSONVILLE, 12220\u00A0-\u00A0AUBURN-OPELIKA'
+            : '11500\u00A0-\u00A0ANNISTON-OXFORD, 12220\u00A0-\u00A0AUBURN-OPELIKA'
 
-          cy.get('.Aggregations :nth-child(1) > .sublist > li').should(
-            'have.text',
-            msa_text,
-          )
-          cy.get('.Aggregations :nth-child(2) > .sublist > li').then(($li) => {
-            let text = $li.text().toLowerCase()
-            cy.wrap(text).should('contain', 'bank of america')
-            cy.wrap(text).should('contain', 'chase bank')
-          })
-          cy.get('.Aggregations :nth-child(3) > .sublist > li').should(
-            'have.text',
-            'Conventional',
-          )
-          cy.get('.Error').should('not.exist')
+        cy.get('.Aggregations :nth-child(1) > .sublist > li').should(
+          'have.text',
+          msa_text,
+        )
+        cy.get('.Aggregations :nth-child(2) > .sublist > li').then(($li) => {
+          const text = $li.text().toLowerCase()
+          cy.wrap(text).should('contain', 'bank of america')
+          cy.wrap(text).should('contain', 'chase bank')
         })
+        cy.get('.Aggregations :nth-child(3) > .sublist > li').should(
+          'have.text',
+          'Conventional',
+        )
+        cy.get('.Error').should('not.exist')
       })
     })
-  }
+  })
 })

--- a/cypress/e2e/data-browser/graphs.spec.js
+++ b/cypress/e2e/data-browser/graphs.spec.js
@@ -1,8 +1,9 @@
 import { onlyOn } from '@cypress/skip-test'
-import { isBeta, isCI } from '../../support/helpers'
+import { addLocalhostIntercepts, isBeta, isCI } from '../../support/helpers'
+
 const { HOST, ENVIRONMENT } = Cypress.env()
 
-let baseURLToVisit = isCI(ENVIRONMENT) ? 'http://localhost:3000' : HOST
+const baseURLToVisit = isCI(ENVIRONMENT) ? 'http://localhost:3000' : HOST
 
 onlyOn(isBeta(HOST), () => {
   describe('HMDA Graphs', function () {
@@ -11,7 +12,10 @@ onlyOn(isBeta(HOST), () => {
 })
 
 onlyOn(!isBeta(HOST), () => {
-  describe('General Tests', () => {
+  describe('General Tests', { tags: ['@localhost'] }, () => {
+    beforeEach(() => {
+      addLocalhostIntercepts()
+    })
     it('Checks <GraphsHeader/> component if overview props was not sent to the component', () => {
       cy.visit(`${baseURLToVisit}/data-browser/graphs/quarterly`).contains(
         'The following graphs show current and historic quarterly HMDA data for these institutions.',
@@ -19,7 +23,7 @@ onlyOn(!isBeta(HOST), () => {
     })
 
     it('Checks <GraphsHeader/> component if data from API succeedes then it checks if numbered financial institutions show in the header', () => {
-      let institutionCountRx = '[0-9]{1,3}'
+      const institutionCountRx = '[0-9]{1,3}'
       const financialInstitutionsRx = new RegExp(
         `^${institutionCountRx} financial institutions`,
       )
@@ -37,7 +41,10 @@ onlyOn(!isBeta(HOST), () => {
     })
   })
 
-  describe('Filer Info tab tests', () => {
+  describe('Filer Info tab tests', { tags: ['@localhost'] }, () => {
+    beforeEach(() => {
+      addLocalhostIntercepts()
+    })
     it('Starts on Graph tab and then switches to filer tab', () => {
       cy.visit(`${baseURLToVisit}/data-browser/graphs/quarterly`)
       cy.wait(1000)
@@ -136,7 +143,10 @@ onlyOn(!isBeta(HOST), () => {
     })
   })
 
-  describe('Graph Specific tests', () => {
+  describe('Graph Specific tests', { tags: ['@localhost'] }, () => {
+    beforeEach(() => {
+      addLocalhostIntercepts()
+    })
     it('Visits graph page and checks that the url contains correct query parameters', () => {
       cy.visit(`${baseURLToVisit}/data-browser/graphs/quarterly`)
       cy.wait(2000)
@@ -208,7 +218,7 @@ onlyOn(!isBeta(HOST), () => {
       })
     })
 
-    it('De-select and re-select a series, UI and URL updates',() => {
+    it('De-select and re-select a series, UI and URL updates', () => {
       // let urlUpdate
       cy.visit(`${baseURLToVisit}/data-browser/graphs/quarterly`)
       // De-select 'Conventional Conforming' from series

--- a/cypress/e2e/data-browser/maps.spec.js
+++ b/cypress/e2e/data-browser/maps.spec.js
@@ -1,5 +1,10 @@
 import { onlyOn } from '@cypress/skip-test'
-import { isBeta, mapsURL, openSelector } from '../../support/helpers'
+import {
+  addLocalhostIntercepts,
+  isBeta,
+  mapsURL,
+  openSelector,
+} from '../../support/helpers'
 
 const { HOST, ENVIRONMENT } = Cypress.env()
 const ACTION_DELAY = 8000 // milliseconds
@@ -12,6 +17,9 @@ onlyOn(isBeta(HOST), () => {
 
 onlyOn(!isBeta(HOST), () => {
   describe('Maps', { tags: '@localhost' }, () => {
+    beforeEach(() => {
+      addLocalhostIntercepts()
+    })
     it('State 2025', { tags: ['@smoke'] }, () => {
       cy.get({ HOST, ENVIRONMENT }).logEnv()
       cy.viewport(1000, 940)

--- a/cypress/e2e/data-publication/AggregateReports.spec.js
+++ b/cypress/e2e/data-publication/AggregateReports.spec.js
@@ -1,6 +1,11 @@
 import { onlyOn } from '@cypress/skip-test'
-import { isBeta, openSelector } from '../../support/helpers'
-const { HOST } = Cypress.env()
+import {
+  addLocalhostIntercepts,
+  isBeta,
+  openSelector,
+} from '../../support/helpers'
+
+const { HOST, ENVIRONMENT } = Cypress.env()
 
 // TODO: Test CSV Download
 
@@ -12,6 +17,9 @@ onlyOn(isBeta(HOST), () => {
 
 onlyOn(!isBeta(HOST), () => {
   describe('Aggregate Reports', () => {
+    beforeEach(() => {
+      addLocalhostIntercepts()
+    })
     it('2025', { tags: ['@smoke', '@localhost'] }, () => {
       cy.get({ HOST }).logEnv()
       cy.viewport(1680, 867)
@@ -78,9 +86,7 @@ onlyOn(!isBeta(HOST), () => {
       // Select geography and report
       cy.findByRole('combobox').type('Arizona{enter}')
       cy.findByRole('combobox').type('Phoenix{enter}')
-      cy.findByRole('combobox').type(
-        'Applications by Ethnicity and Sex{enter}',
-      )
+      cy.findByRole('combobox').type('Applications by Ethnicity and Sex{enter}')
 
       // Report Content
       cy.get('tbody > :nth-child(3) > :nth-child(2)').should(
@@ -129,7 +135,7 @@ onlyOn(!isBeta(HOST), () => {
         '42300000',
       )
     })
-  
+
     it('2023', () => {
       cy.get({ HOST }).logEnv()
       cy.viewport(1680, 867)
@@ -138,9 +144,7 @@ onlyOn(!isBeta(HOST), () => {
       // Select geography and report
       cy.findByRole('combobox').type('Arizona{enter}')
       cy.findByRole('combobox').type('Phoenix{enter}')
-      cy.findByRole('combobox').type(
-        'Applications by Ethnicity and Sex{enter}',
-      )
+      cy.findByRole('combobox').type('Applications by Ethnicity and Sex{enter}')
 
       // Report Content
       cy.get('tbody > :nth-child(3) > :nth-child(2)').should(
@@ -198,9 +202,7 @@ onlyOn(!isBeta(HOST), () => {
       // Select geography and report
       cy.findByRole('combobox').type('Arizona{enter}')
       cy.findByRole('combobox').type('Phoenix{enter}')
-      cy.findByRole('combobox').type(
-        'Applications by Ethnicity and Sex{enter}',
-      )
+      cy.findByRole('combobox').type('Applications by Ethnicity and Sex{enter}')
 
       // Report Content
       cy.get('tbody > :nth-child(3) > :nth-child(2)').should(
@@ -258,9 +260,7 @@ onlyOn(!isBeta(HOST), () => {
       // Select geography and report
       cy.findByRole('combobox').type('Arizona{enter}')
       cy.findByRole('combobox').type('Phoenix{enter}')
-      cy.findByRole('combobox').type(
-        'Applications by Ethnicity and Sex{enter}',
-      )
+      cy.findByRole('combobox').type('Applications by Ethnicity and Sex{enter}')
 
       // Report Content
       cy.get('tbody > :nth-child(3) > :nth-child(2)').should(
@@ -322,9 +322,7 @@ onlyOn(!isBeta(HOST), () => {
       // Select geography and report
       cy.findByRole('combobox').type('Arizona{enter}')
       cy.findByRole('combobox').type('Phoenix{enter}')
-      cy.findByRole('combobox').type(
-        'Applications by Ethnicity and Sex{enter}',
-      )
+      cy.findByRole('combobox').type('Applications by Ethnicity and Sex{enter}')
 
       // Report Content
       cy.get('tbody > :nth-child(3) > :nth-child(2)').should(
@@ -383,9 +381,7 @@ onlyOn(!isBeta(HOST), () => {
       // Select geography and report
       cy.findByRole('combobox').type('Arizona{enter}')
       cy.findByRole('combobox').type('Phoenix{enter}')
-      cy.findByRole('combobox').type(
-        'Applications by Ethnicity and Sex{enter}',
-      )
+      cy.findByRole('combobox').type('Applications by Ethnicity and Sex{enter}')
 
       // Report Content
       cy.get('tbody > :nth-child(3) > :nth-child(2)').should(

--- a/cypress/e2e/data-publication/DisclosureReports.spec.js
+++ b/cypress/e2e/data-publication/DisclosureReports.spec.js
@@ -1,7 +1,7 @@
 import { onlyOn } from '@cypress/skip-test'
-import { isBeta } from '../../support/helpers'
+import { addLocalhostIntercepts, isBeta } from '../../support/helpers'
 
-const { HOST } = Cypress.env()
+const { HOST, ENVIRONMENT } = Cypress.env()
 
 onlyOn(isBeta(HOST), () => {
   describe('Disclosure Reports', function () {
@@ -11,564 +11,712 @@ onlyOn(isBeta(HOST), () => {
 
 onlyOn(!isBeta(HOST), () => {
   // extending the timeout to account for slower API calls
-  describe('Disclosure Reports', { defaultCommandTimeout: 45000 }, () => {
-    it('Fetches a 2025 Applications by Tract Report', () => {
-      const institution = 'CYPRESS BANK STATE SAVINGS BANK'
-      const institutionName = institution.split(' - ')[0]
-      const msaMd = 'Dallas-Plano-Irving, TX - 19124'
-      const msaMdCityOnly = msaMd.split(', ')[0]
-      const msaMdZipCodeFirst = `${msaMd.split(' - ')[1]} - ${msaMd.split(' - ')[0]}`
+  describe(
+    'Disclosure Reports',
+    { defaultCommandTimeout: 45000, tags: ['@localhost'] },
+    () => {
+      beforeEach(() => {
+        addLocalhostIntercepts()
+      })
+      it('Fetches a 2025 Applications by Tract Report', () => {
+        const institution = 'CYPRESS BANK STATE SAVINGS BANK'
+        const institutionName = institution.split(' - ')[0]
+        const msaMd = 'Dallas-Plano-Irving, TX - 19124'
+        const msaMdCityOnly = msaMd.split(', ')[0]
+        const msaMdZipCodeFirst = `${msaMd.split(' - ')[1]} - ${msaMd.split(' - ')[0]}`
 
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1680, 916)
-      cy.visit(`${HOST}/data-publication/disclosure-reports/2025`)
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1680, 916)
+        cy.visit(`${HOST}/data-publication/disclosure-reports/2025`)
 
-      cy.get('#institution-name').click({ force: true })
-      cy.get('#institution-name').type(institutionName)
-      cy.findByText('View MSA/MDs').click({ force: true })
-      cy.findByText('Loading...').should('not.exist')
-      cy.findByRole('combobox').type(msaMdCityOnly)
-      cy.findByText(msaMdZipCodeFirst).click({ force: true })
-      cy.findByRole('combobox').type('Applications by Tract{enter}')
+        cy.get('#institution-name').click({ force: true })
+        cy.get('#institution-name').type(institutionName)
+        cy.findByText('View MSA/MDs').click({ force: true })
+        cy.findByText('Loading...').should('not.exist')
+        cy.findByRole('combobox').type(msaMdCityOnly)
+        cy.findByText(msaMdZipCodeFirst).click({ force: true })
+        cy.findByRole('combobox').type('Applications by Tract{enter}')
 
-      /* Check Report Params */
+        /* Check Report Params */
 
-      // Year
-      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2025')
+        // Year
+        cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2025')
 
-      // Institution
-      cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
-        'contain.text',
-        institution,
-      )
+        // Institution
+        cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
+          'contain.text',
+          institution,
+        )
 
-      // MSA/MD
-      cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
-        'contain.text',
-        msaMd,
-      )
+        // MSA/MD
+        cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
+          'contain.text',
+          msaMd,
+        )
 
-      // Report Type
-      cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
-        'contain.text',
-        'Applications by Tract',
-      )
+        // Report Type
+        cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
+          'contain.text',
+          'Applications by Tract',
+        )
 
-      // Validate a row - Third row called "Applications Denied by Financial Institution"
-      cy.get('tbody > :nth-child(2) > :nth-child(2)').should('have.text', '0')
-      cy.get('tbody > :nth-child(2) > :nth-child(3)').should('have.text', '0')
-      cy.get('tbody > :nth-child(2) > :nth-child(4)').should('have.text', '1')
-      cy.get('tbody > :nth-child(2) > :nth-child(5)').should(
-        'have.text',
-        '55000',
-      )
-      cy.get('tbody > :nth-child(2) > :nth-child(6)').should('have.text', '0')
-      cy.get('tbody > :nth-child(2) > :nth-child(7)').should('have.text', '0')
-      cy.get('tbody > :nth-child(2) > :nth-child(8)').should('have.text', '0')
-      cy.get('tbody > :nth-child(2) > :nth-child(9)').should('have.text', '0')
-      cy.get('tbody > :nth-child(2) > :nth-child(10)').should('have.text', '0')
-      cy.get('tbody > :nth-child(2) > :nth-child(11)').should('have.text', '0')
-      cy.get('tbody > :nth-child(2) > :nth-child(12)').should('have.text', '0')
-      cy.get('tbody > :nth-child(2) > :nth-child(13)').should('have.text', '0')
-      cy.get('tbody > :nth-child(2) > :nth-child(14)').should('have.text', '1')
-      cy.get('tbody > :nth-child(2) > :nth-child(15)').should(
-        'have.text',
-        '55000',
-      )
-    })
+        // Validate a row - Third row called "Applications Denied by Financial Institution"
+        cy.get('tbody > :nth-child(2) > :nth-child(2)').should('have.text', '0')
+        cy.get('tbody > :nth-child(2) > :nth-child(3)').should('have.text', '0')
+        cy.get('tbody > :nth-child(2) > :nth-child(4)').should('have.text', '1')
+        cy.get('tbody > :nth-child(2) > :nth-child(5)').should(
+          'have.text',
+          '55000',
+        )
+        cy.get('tbody > :nth-child(2) > :nth-child(6)').should('have.text', '0')
+        cy.get('tbody > :nth-child(2) > :nth-child(7)').should('have.text', '0')
+        cy.get('tbody > :nth-child(2) > :nth-child(8)').should('have.text', '0')
+        cy.get('tbody > :nth-child(2) > :nth-child(9)').should('have.text', '0')
+        cy.get('tbody > :nth-child(2) > :nth-child(10)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(2) > :nth-child(11)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(2) > :nth-child(12)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(2) > :nth-child(13)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(2) > :nth-child(14)').should(
+          'have.text',
+          '1',
+        )
+        cy.get('tbody > :nth-child(2) > :nth-child(15)').should(
+          'have.text',
+          '55000',
+        )
+      })
 
-    it('Fetches a 2024 Applications by Tract Report', () => {
-      const institution = 'CYPRESS BANK STATE SAVINGS BANK'
-      const institutionName = institution.split(' - ')[0]
-      const msaMd = 'Dallas-Plano-Irving, TX - 19124'
-      const msaMdCityOnly = msaMd.split(', ')[0]
-      const msaMdZipCodeFirst = `${msaMd.split(' - ')[1]} - ${msaMd.split(' - ')[0]}`
+      it('Fetches a 2024 Applications by Tract Report', () => {
+        const institution = 'CYPRESS BANK STATE SAVINGS BANK'
+        const institutionName = institution.split(' - ')[0]
+        const msaMd = 'Dallas-Plano-Irving, TX - 19124'
+        const msaMdCityOnly = msaMd.split(', ')[0]
+        const msaMdZipCodeFirst = `${msaMd.split(' - ')[1]} - ${msaMd.split(' - ')[0]}`
 
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1680, 916)
-      cy.visit(`${HOST}/data-publication/disclosure-reports/2024`)
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1680, 916)
+        cy.visit(`${HOST}/data-publication/disclosure-reports/2024`)
 
-      cy.get('#institution-name').click({ force: true })
-      cy.get('#institution-name').type(institutionName)
-      cy.findByText('View MSA/MDs').click({ force: true })
-      cy.findByText('Loading...').should('not.exist')
-      cy.findByRole('combobox').type(msaMdCityOnly)
-      cy.findByText(msaMdZipCodeFirst).click({ force: true })
-      cy.findByRole('combobox').type('Applications by Tract{enter}')
+        cy.get('#institution-name').click({ force: true })
+        cy.get('#institution-name').type(institutionName)
+        cy.findByText('View MSA/MDs').click({ force: true })
+        cy.findByText('Loading...').should('not.exist')
+        cy.findByRole('combobox').type(msaMdCityOnly)
+        cy.findByText(msaMdZipCodeFirst).click({ force: true })
+        cy.findByRole('combobox').type('Applications by Tract{enter}')
 
-      /* Check Report Params */
+        /* Check Report Params */
 
-      // Year
-      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2024')
+        // Year
+        cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2024')
 
-      // Institution
-      cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
-        'contain.text',
-        institution,
-      )
+        // Institution
+        cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
+          'contain.text',
+          institution,
+        )
 
-      // MSA/MD
-      cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
-        'contain.text',
-        msaMd,
-      )
+        // MSA/MD
+        cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
+          'contain.text',
+          msaMd,
+        )
 
-      // Report Type
-      cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
-        'contain.text',
-        'Applications by Tract',
-      )
+        // Report Type
+        cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
+          'contain.text',
+          'Applications by Tract',
+        )
 
-      // Validate a row - Third row called "Applications Denied by Financial Institution"
-      cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '1')
-      cy.get('tbody > :nth-child(4) > :nth-child(5)').should(
-        'have.text',
-        '665000',
-      )
-      cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(10)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(11)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(12)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(13)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(14)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(15)').should('have.text', '0')
-    })
+        // Validate a row - Third row called "Applications Denied by Financial Institution"
+        cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '1')
+        cy.get('tbody > :nth-child(4) > :nth-child(5)').should(
+          'have.text',
+          '665000',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(10)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(11)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(12)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(13)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(14)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(15)').should(
+          'have.text',
+          '0',
+        )
+      })
 
-    it('Fetches a 2023 Applications by Tract Report', () => {
-      const institution = 'LIBERTYVILLE BANK & TRUST NA'
-      const institutionName = institution.split(' - ')[0]
-      const msaMd = 'Chicago-Naperville-Evanston, IL - 16984'
-      const msaMdCityOnly = msaMd.split(', ')[0]
-      const msaMdZipCodeFirst = `${msaMd.split(' - ')[1]} - ${msaMd.split(' - ')[0]}`
+      it('Fetches a 2023 Applications by Tract Report', () => {
+        const institution = 'LIBERTYVILLE BANK & TRUST NA'
+        const institutionName = institution.split(' - ')[0]
+        const msaMd = 'Chicago-Naperville-Evanston, IL - 16984'
+        const msaMdCityOnly = msaMd.split(', ')[0]
+        const msaMdZipCodeFirst = `${msaMd.split(' - ')[1]} - ${msaMd.split(' - ')[0]}`
 
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1680, 916)
-      cy.visit(`${HOST}/data-publication/disclosure-reports/2023`)
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1680, 916)
+        cy.visit(`${HOST}/data-publication/disclosure-reports/2023`)
 
-      cy.get('#institution-name').click({ force: true })
-      cy.get('#institution-name').type(institutionName)
-      cy.findByText('View MSA/MDs').click({ force: true })
-      cy.findByText('Loading...').should('not.exist')
-      cy.findByRole('combobox').type(msaMdCityOnly)
-      cy.findByText(msaMdZipCodeFirst).click({ force: true })
-      cy.findByRole('combobox').type('Applications by Tract{enter}')
+        cy.get('#institution-name').click({ force: true })
+        cy.get('#institution-name').type(institutionName)
+        cy.findByText('View MSA/MDs').click({ force: true })
+        cy.findByText('Loading...').should('not.exist')
+        cy.findByRole('combobox').type(msaMdCityOnly)
+        cy.findByText(msaMdZipCodeFirst).click({ force: true })
+        cy.findByRole('combobox').type('Applications by Tract{enter}')
 
-      /* Check Report Params */
+        /* Check Report Params */
 
-      // Year
-      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2023')
+        // Year
+        cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2023')
 
-      // Institution
-      cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
-        'contain.text',
-        institution,
-      )
+        // Institution
+        cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
+          'contain.text',
+          institution,
+        )
 
-      // MSA/MD
-      cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
-        'contain.text',
-        msaMd,
-      )
+        // MSA/MD
+        cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
+          'contain.text',
+          msaMd,
+        )
 
-      // Report Type
-      cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
-        'contain.text',
-        'Applications by Tract',
-      )
+        // Report Type
+        cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
+          'contain.text',
+          'Applications by Tract',
+        )
 
-      // Validate a row - Third row called "Applications Denied by Financial Institution"
-      cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(10)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(11)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(12)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(13)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(14)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(15)').should('have.text', '0')
-    })
+        // Validate a row - Third row called "Applications Denied by Financial Institution"
+        cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(10)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(11)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(12)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(13)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(14)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(15)').should(
+          'have.text',
+          '0',
+        )
+      })
 
-    it('Fetches a 2022 Applications by Tract Report', () => {
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1680, 916)
-      cy.visit(`${HOST}/data-publication/disclosure-reports/2022`)
+      it('Fetches a 2022 Applications by Tract Report', () => {
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1680, 916)
+        cy.visit(`${HOST}/data-publication/disclosure-reports/2022`)
 
-      cy.get('#institution-name').click({ force: true })
-      cy.get('#institution-name').type('LIBERTY MORTGAGE CORPORATION')
-      cy.findByText('View MSA/MDs').click({ force: true })
-      cy.findByText('Loading...').should('not.exist')
-      cy.findByRole('combobox').type('Anniston{enter}')
-      cy.findByRole('combobox').type('Applications by Tract{enter}')
+        cy.get('#institution-name').click({ force: true })
+        cy.get('#institution-name').type('LIBERTY MORTGAGE CORPORATION')
+        cy.findByText('View MSA/MDs').click({ force: true })
+        cy.findByText('Loading...').should('not.exist')
+        cy.findByRole('combobox').type('Anniston{enter}')
+        cy.findByRole('combobox').type('Applications by Tract{enter}')
 
-      /* Check Report Params */
+        /* Check Report Params */
 
-      // Year
-      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2022')
+        // Year
+        cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2022')
 
-      // Institution
-      cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
-        'contain.text',
-        'LIBERTY MORTGAGE CORPORATION - 2549008SGDIASSJGSR05',
-      )
+        // Institution
+        cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
+          'contain.text',
+          'LIBERTY MORTGAGE CORPORATION - 2549008SGDIASSJGSR05',
+        )
 
-      // MSA/MD
-      cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
-        'contain.text',
-        'Anniston-Oxford, AL - 11500',
-      )
+        // MSA/MD
+        cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
+          'contain.text',
+          'Anniston-Oxford, AL - 11500',
+        )
 
-      // Report Type
-      cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
-        'contain.text',
-        'Applications by Tract',
-      )
+        // Report Type
+        cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
+          'contain.text',
+          'Applications by Tract',
+        )
 
-      // Validate a row - Third row called "Applications Denied by Financial Institution"
-      cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(10)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(11)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(12)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(13)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(14)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(15)').should('have.text', '0')
-    })
+        // Validate a row - Third row called "Applications Denied by Financial Institution"
+        cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(10)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(11)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(12)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(13)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(14)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(15)').should(
+          'have.text',
+          '0',
+        )
+      })
 
-    it('Fetches a 2021 Applications by Tract Report', () => {
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1680, 916)
-      cy.visit(`${HOST}/data-publication/disclosure-reports/2021`)
+      it('Fetches a 2021 Applications by Tract Report', () => {
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1680, 916)
+        cy.visit(`${HOST}/data-publication/disclosure-reports/2021`)
 
-      cy.get('#institution-name').click({ force: true })
-      cy.get('#institution-name').type('cypress bank, ssb')
-      cy.findByText('View MSA/MDs').click({ force: true })
-      cy.findByText('Loading...').should('not.exist')
-      cy.findByRole('combobox').type('Dallas{enter}')
-      cy.findByRole('combobox').type('Applications by Tract{enter}')
+        cy.get('#institution-name').click({ force: true })
+        cy.get('#institution-name').type('cypress bank, ssb')
+        cy.findByText('View MSA/MDs').click({ force: true })
+        cy.findByText('Loading...').should('not.exist')
+        cy.findByRole('combobox').type('Dallas{enter}')
+        cy.findByRole('combobox').type('Applications by Tract{enter}')
 
-      /* Check Report Params */
+        /* Check Report Params */
 
-      // Year
-      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2021')
+        // Year
+        cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2021')
 
-      // Institution
-      cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
-        'contain.text',
-        'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06',
-      )
+        // Institution
+        cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
+          'contain.text',
+          'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06',
+        )
 
-      // MSA/MD
-      cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
-        'contain.text',
-        'Dallas-Plano-Irving, TX - 19124',
-      )
+        // MSA/MD
+        cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
+          'contain.text',
+          'Dallas-Plano-Irving, TX - 19124',
+        )
 
-      // Report Type
-      cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
-        'contain.text',
-        'Applications by Tract',
-      )
+        // Report Type
+        cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
+          'contain.text',
+          'Applications by Tract',
+        )
 
-      // Validate a row - Third row called "Applications Denied by Financial Institution"
-      cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(10)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(11)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(12)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(13)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(14)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(15)').should('have.text', '0')
-    })
+        // Validate a row - Third row called "Applications Denied by Financial Institution"
+        cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(10)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(11)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(12)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(13)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(14)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(15)').should(
+          'have.text',
+          '0',
+        )
+      })
 
-    it('Fetches a 2020 Applications by Tract Report', () => {
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1680, 916)
-      cy.visit(`${HOST}/data-publication/disclosure-reports/2020`)
+      it('Fetches a 2020 Applications by Tract Report', () => {
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1680, 916)
+        cy.visit(`${HOST}/data-publication/disclosure-reports/2020`)
 
-      cy.get('#institution-name').click({ force: true })
-      cy.get('#institution-name').type('cypress bank, ssb')
-      cy.findByText('View MSA/MDs').click({ force: true })
-      cy.findByText('Loading...').should('not.exist')
-      cy.findByRole('combobox').type('Dallas{enter}')
-      cy.findByRole('combobox').type('Applications by Tract{enter}')
+        cy.get('#institution-name').click({ force: true })
+        cy.get('#institution-name').type('cypress bank, ssb')
+        cy.findByText('View MSA/MDs').click({ force: true })
+        cy.findByText('Loading...').should('not.exist')
+        cy.findByRole('combobox').type('Dallas{enter}')
+        cy.findByRole('combobox').type('Applications by Tract{enter}')
 
-      /* Check Report Params */
+        /* Check Report Params */
 
-      // Year
-      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2020')
+        // Year
+        cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2020')
 
-      // Institution
-      cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
-        'contain.text',
-        'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06',
-      )
+        // Institution
+        cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
+          'contain.text',
+          'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06',
+        )
 
-      // MSA/MD
-      cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
-        'contain.text',
-        'Dallas-Fort Worth, TX-OK - 19124',
-      )
+        // MSA/MD
+        cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
+          'contain.text',
+          'Dallas-Fort Worth, TX-OK - 19124',
+        )
 
-      // Report Type
-      cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
-        'contain.text',
-        'Applications by Tract',
-      )
+        // Report Type
+        cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
+          'contain.text',
+          'Applications by Tract',
+        )
 
-      // Validate a row - Third row called "Applications Denied by Financial Institution"
-      cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '1')
-      cy.get('tbody > :nth-child(4) > :nth-child(7)').should(
-        'have.text',
-        '55000',
-      )
-      cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(10)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(11)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(12)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(13)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(14)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(15)').should('have.text', '0')
-    })
+        // Validate a row - Third row called "Applications Denied by Financial Institution"
+        cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(5)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '1')
+        cy.get('tbody > :nth-child(4) > :nth-child(7)').should(
+          'have.text',
+          '55000',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(10)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(11)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(12)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(13)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(14)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(15)').should(
+          'have.text',
+          '0',
+        )
+      })
 
-    it('Fetches a 2019 Applications by Tract Report', () => {
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1680, 916)
-      cy.visit(`${HOST}/data-publication/disclosure-reports/2019`)
+      it('Fetches a 2019 Applications by Tract Report', () => {
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1680, 916)
+        cy.visit(`${HOST}/data-publication/disclosure-reports/2019`)
 
-      cy.get('#institution-name').click({ force: true })
-      cy.get('#institution-name').type('cypress bank, ssb')
-      cy.findByText('View MSA/MDs').click({ force: true })
-      cy.findByText('Loading...').should('not.exist')
-      cy.findByRole('combobox').type('Dallas{enter}')
-      cy.findByRole('combobox').type('Applications by Tract{enter}')
+        cy.get('#institution-name').click({ force: true })
+        cy.get('#institution-name').type('cypress bank, ssb')
+        cy.findByText('View MSA/MDs').click({ force: true })
+        cy.findByText('Loading...').should('not.exist')
+        cy.findByRole('combobox').type('Dallas{enter}')
+        cy.findByRole('combobox').type('Applications by Tract{enter}')
 
-      /* Check Report Params */
+        /* Check Report Params */
 
-      // Year
-      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2019')
+        // Year
+        cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2019')
 
-      // Institution
-      cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
-        'contain.text',
-        'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06',
-      )
+        // Institution
+        cy.get('.ProgressCards > :nth-child(2) .heading > p').should(
+          'contain.text',
+          'CYPRESS BANK, SSB - 549300I4IUWMEMGLST06',
+        )
 
-      // MSA/MD
-      cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
-        'contain.text',
-        'Dallas-Fort Worth, TX-OK - 19124',
-      )
+        // MSA/MD
+        cy.get('.ProgressCards > :nth-child(3) .heading > p').should(
+          'contain.text',
+          'Dallas-Fort Worth, TX-OK - 19124',
+        )
 
-      // Report Type
-      cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
-        'contain.text',
-        'Applications by Tract',
-      )
+        // Report Type
+        cy.get('.ProgressCards > :nth-child(4) .heading > p').should(
+          'contain.text',
+          'Applications by Tract',
+        )
 
-      // Validate a row - Third row called "Applications Denied by Financial Institution"
-      cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '3')
-      cy.get('tbody > :nth-child(4) > :nth-child(5)').should(
-        'have.text',
-        '1845000',
-      )
-      cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(10)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(11)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(12)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(13)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(14)').should('have.text', '0')
-      cy.get('tbody > :nth-child(4) > :nth-child(15)').should('have.text', '0')
-    })
+        // Validate a row - Third row called "Applications Denied by Financial Institution"
+        cy.get('tbody > :nth-child(4) > :nth-child(2)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(3)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(4)').should('have.text', '3')
+        cy.get('tbody > :nth-child(4) > :nth-child(5)').should(
+          'have.text',
+          '1845000',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(6)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(7)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(8)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(9)').should('have.text', '0')
+        cy.get('tbody > :nth-child(4) > :nth-child(10)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(11)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(12)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(13)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(14)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(4) > :nth-child(15)').should(
+          'have.text',
+          '0',
+        )
+      })
 
-    it('Fetches a 2018 Applications by Tract Report', () => {
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1680, 867)
-      cy.visit(`${HOST}/data-publication/disclosure-reports/2018`)
+      it('Fetches a 2018 Applications by Tract Report', () => {
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1680, 867)
+        cy.visit(`${HOST}/data-publication/disclosure-reports/2018`)
 
-      cy.get('#institution-name').click({ force: true })
-      cy.get('#institution-name').type('cypress bank, state savings bank')
+        cy.get('#institution-name').click({ force: true })
+        cy.get('#institution-name').type('cypress bank, state savings bank')
 
-      cy.get(
-        '#main-content > .SearchList > .Results > li > .button-link',
-      ).click()
-      cy.findByText('Loading...').should('not.exist')
+        cy.get(
+          '#main-content > .SearchList > .Results > li > .button-link',
+        ).click()
+        cy.findByText('Loading...').should('not.exist')
 
-      cy.get('#react-select-2-option-2').click({ force: true })
-      cy.get('#react-select-3-option-0').click({ force: true })
+        cy.get('#react-select-2-option-2').click({ force: true })
+        cy.get('#react-select-3-option-0').click({ force: true })
 
-      /* 
+        /* 
         Check Report Params 
       */
 
-      // Year
-      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2018')
+        // Year
+        cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2018')
 
-      // Institution
-      cy.get('.ProgressCards > :nth-child(2)').should(
-        'contain.text',
-        'CYPRESS BANK, STATE SAVINGS BANK - 549300I4IUWMEMGLST06',
-      )
+        // Institution
+        cy.get('.ProgressCards > :nth-child(2)').should(
+          'contain.text',
+          'CYPRESS BANK, STATE SAVINGS BANK - 549300I4IUWMEMGLST06',
+        )
 
-      // MSA/MD
-      cy.get('.ProgressCards > :nth-child(3)').should(
-        'contain.text',
-        'TAMPA-ST. PETERSBURG-CLEARWATER,FL - 45300',
-      )
+        // MSA/MD
+        cy.get('.ProgressCards > :nth-child(3)').should(
+          'contain.text',
+          'TAMPA-ST. PETERSBURG-CLEARWATER,FL - 45300',
+        )
 
-      // Report Type
-      cy.get('.ProgressCards > :nth-child(4)').should(
-        'contain.text',
-        'Applications by Tract',
-      )
+        // Report Type
+        cy.get('.ProgressCards > :nth-child(4)').should(
+          'contain.text',
+          'Applications by Tract',
+        )
 
-      /* 
+        /* 
         Check Report Content 
       */
 
-      // County
-      cy.get('tbody > :nth-child(1) > th').should(
-        'have.text',
-        'Pinellas County/Florida/027606',
-      )
+        // County
+        cy.get('tbody > :nth-child(1) > th').should(
+          'have.text',
+          'Pinellas County/Florida/027606',
+        )
 
-      // Verify the Applications Received row of the report content contains expected data
-      cy.get('tbody > :nth-child(7) > :nth-child(2)').should('have.text', '0')
-      cy.get('tbody > :nth-child(7) > :nth-child(3)').should('have.text', '0')
-      cy.get('tbody > :nth-child(7) > :nth-child(4)').should('have.text', '1')
-      cy.get('tbody > :nth-child(7) > :nth-child(5)').should(
-        'have.text',
-        '455000',
-      )
-      cy.get('tbody > :nth-child(7) > :nth-child(6)').should('have.text', '0')
-      cy.get('tbody > :nth-child(7) > :nth-child(7)').should('have.text', '0')
-      cy.get('tbody > :nth-child(7) > :nth-child(8)').should('have.text', '0')
-      cy.get('tbody > :nth-child(7) > :nth-child(9)').should('have.text', '0')
-      cy.get('tbody > :nth-child(7) > :nth-child(10)').should('have.text', '0')
-      cy.get('tbody > :nth-child(7) > :nth-child(11)').should('have.text', '0')
-      cy.get('tbody > :nth-child(7) > :nth-child(12)').should('have.text', '1')
-      cy.get('tbody > :nth-child(7) > :nth-child(13)').should(
-        'have.text',
-        '455000',
-      )
-      cy.get('tbody > :nth-child(7) > :nth-child(14)').should('have.text', '0')
-      cy.get('tbody > :nth-child(7) > :nth-child(15)').should('have.text', '0')
+        // Verify the Applications Received row of the report content contains expected data
+        cy.get('tbody > :nth-child(7) > :nth-child(2)').should('have.text', '0')
+        cy.get('tbody > :nth-child(7) > :nth-child(3)').should('have.text', '0')
+        cy.get('tbody > :nth-child(7) > :nth-child(4)').should('have.text', '1')
+        cy.get('tbody > :nth-child(7) > :nth-child(5)').should(
+          'have.text',
+          '455000',
+        )
+        cy.get('tbody > :nth-child(7) > :nth-child(6)').should('have.text', '0')
+        cy.get('tbody > :nth-child(7) > :nth-child(7)').should('have.text', '0')
+        cy.get('tbody > :nth-child(7) > :nth-child(8)').should('have.text', '0')
+        cy.get('tbody > :nth-child(7) > :nth-child(9)').should('have.text', '0')
+        cy.get('tbody > :nth-child(7) > :nth-child(10)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(7) > :nth-child(11)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(7) > :nth-child(12)').should(
+          'have.text',
+          '1',
+        )
+        cy.get('tbody > :nth-child(7) > :nth-child(13)').should(
+          'have.text',
+          '455000',
+        )
+        cy.get('tbody > :nth-child(7) > :nth-child(14)').should(
+          'have.text',
+          '0',
+        )
+        cy.get('tbody > :nth-child(7) > :nth-child(15)').should(
+          'have.text',
+          '0',
+        )
 
-      // TODO: Test 'Save as CSV' button
-      /* Test CSV Download */
-      // Possible method
-      //  https://github.com/cypress-io/cypress/issues/949
-      //  Just clicking the button brings up a 'save' dialogue, which is not helpful
-      // cy.get(".heading > button").click()
-    })
+        // TODO: Test 'Save as CSV' button
+        /* Test CSV Download */
+        // Possible method
+        //  https://github.com/cypress-io/cypress/issues/949
+        //  Just clicking the button brings up a 'save' dialogue, which is not helpful
+        // cy.get(".heading > button").click()
+      })
 
-    // TODO: re-enable after re-implementing through file proxy, see GHE #5336
-    it.skip('Fetches a 2017 Conv Price Info Nationwide report', () => {
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1680, 916)
+      // TODO: re-enable after re-implementing through file proxy, see GHE #5336
+      it.skip('Fetches a 2017 Conv Price Info Nationwide report', () => {
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1680, 916)
 
-      cy.visit(`${HOST}/data-publication/disclosure-reports/2017`)
+        cy.visit(`${HOST}/data-publication/disclosure-reports/2017`)
 
-      cy.get('#institution-name').click({ force: true })
-      cy.get('#institution-name').type('cypress bank, ssb')
+        cy.get('#institution-name').click({ force: true })
+        cy.get('#institution-name').type('cypress bank, ssb')
 
-      cy.get(
-        '#main-content > .SearchList > .Results > li > .button-link',
-      ).click({ force: true })
+        cy.get(
+          '#main-content > .SearchList > .Results > li > .button-link',
+        ).click({ force: true })
 
-      cy.get('#react-select-2-option-5').click({ force: true })
-      cy.get('#react-select-3-option-1').click({ force: true })
+        cy.get('#react-select-2-option-5').click({ force: true })
+        cy.get('#react-select-3-option-1').click({ force: true })
 
-      /* 
+        /* 
         Check Report Params 
       */
 
-      // Year
-      cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2017')
+        // Year
+        cy.get('.ProgressCards > :nth-child(1)').should('contain.text', '2017')
 
-      // Institution
-      cy.get('.ProgressCards > :nth-child(2)').should(
-        'contain.text',
-        'CYPRESS BANK, SSB - 31905',
-      )
+        // Institution
+        cy.get('.ProgressCards > :nth-child(2)').should(
+          'contain.text',
+          'CYPRESS BANK, SSB - 31905',
+        )
 
-      // MSA/MD
-      cy.get('.ProgressCards > :nth-child(3)').should(
-        'contain.text',
-        'nationwide',
-      )
+        // MSA/MD
+        cy.get('.ProgressCards > :nth-child(3)').should(
+          'contain.text',
+          'nationwide',
+        )
 
-      // Report Type
-      cy.get('.ProgressCards > :nth-child(4)').should(
-        'contain.text',
-        'Conv Price Info by Incidence and Level - Nationwide - BW',
-      )
+        // Report Type
+        cy.get('.ProgressCards > :nth-child(4)').should(
+          'contain.text',
+          'Conv Price Info by Incidence and Level - Nationwide - BW',
+        )
 
-      /* 
+        /* 
         Check Report Content 
       */
 
-      // County
-      cy.get('tbody > :nth-child(1) > th').should(
-        'have.text',
-        '1- TO 4-FAMILY OWNER OCCUPIED DWELLINGS (EXCLUDES MANUFACTURED HOMES)',
-      )
+        // County
+        cy.get('tbody > :nth-child(1) > th').should(
+          'have.text',
+          '1- TO 4-FAMILY OWNER OCCUPIED DWELLINGS (EXCLUDES MANUFACTURED HOMES)',
+        )
 
-      // Verify the Applications Received row of the report contains expected data
-      cy.get('tbody > :nth-child(6) > :nth-child(2)').should(
-        'have.text',
-        '1.77',
-      )
-      cy.get('tbody > :nth-child(6) > :nth-child(3)').should('have.text', '0')
-      cy.get('tbody > :nth-child(6) > :nth-child(4)').should('have.text', '0')
-      cy.get('tbody > :nth-child(6) > :nth-child(5)').should(
-        'have.text',
-        '1.95',
-      )
-      cy.get('tbody > :nth-child(6) > :nth-child(6)').should('have.text', '0')
-      cy.get('tbody > :nth-child(6) > :nth-child(7)').should('have.text', '0')
-      cy.get('tbody > :nth-child(6) > :nth-child(8)').should(
-        'have.text',
-        '1.98',
-      )
-      cy.get('tbody > :nth-child(6) > :nth-child(9)').should(
-        'have.text',
-        '6.85',
-      )
-      cy.get('tbody > :nth-child(6) > :nth-child(10)').should('have.text', '0')
+        // Verify the Applications Received row of the report contains expected data
+        cy.get('tbody > :nth-child(6) > :nth-child(2)').should(
+          'have.text',
+          '1.77',
+        )
+        cy.get('tbody > :nth-child(6) > :nth-child(3)').should('have.text', '0')
+        cy.get('tbody > :nth-child(6) > :nth-child(4)').should('have.text', '0')
+        cy.get('tbody > :nth-child(6) > :nth-child(5)').should(
+          'have.text',
+          '1.95',
+        )
+        cy.get('tbody > :nth-child(6) > :nth-child(6)').should('have.text', '0')
+        cy.get('tbody > :nth-child(6) > :nth-child(7)').should('have.text', '0')
+        cy.get('tbody > :nth-child(6) > :nth-child(8)').should(
+          'have.text',
+          '1.98',
+        )
+        cy.get('tbody > :nth-child(6) > :nth-child(9)').should(
+          'have.text',
+          '6.85',
+        )
+        cy.get('tbody > :nth-child(6) > :nth-child(10)').should(
+          'have.text',
+          '0',
+        )
 
-      // TODO: Test 'Save as CSV' button
-    })
-  })
+        // TODO: Test 'Save as CSV' button
+      })
+    },
+  )
 })

--- a/cypress/e2e/data-publication/ModifiedLAR.spec.js
+++ b/cypress/e2e/data-publication/ModifiedLAR.spec.js
@@ -1,6 +1,13 @@
-import { onlyOn } from '@cypress/skip-test';
-import { isBeta, isDev, isStaging } from '../../support/helpers';
-const { HOST, YEARS } = Cypress.env()
+import { onlyOn } from '@cypress/skip-test'
+import {
+  addLocalhostIntercepts,
+  isBeta,
+  isDev,
+  isLocal,
+  isStaging,
+} from '../../support/helpers'
+
+const { HOST, YEARS, ENVIRONMENT } = Cypress.env()
 
 const downloadsFolder = Cypress.config('downloadsFolder')
 
@@ -9,34 +16,32 @@ const years = (YEARS && YEARS.toString().split(',')) || [
   2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017,
 ]
 
-const testCases = 
-  years.map(year => {
-
-    // special case for 2017 on both dev, staging, and prod
-    if (year === 2017) {
-      return {
-        year,
-        name: 'cypress bank, ssb',
-        institution: '729178',
-      }
+const testCases = years.map((year) => {
+  // special case for 2017 on both dev, staging, and prod
+  if (year === 2017) {
+    return {
+      year,
+      name: 'cypress bank, ssb',
+      institution: '729178',
     }
+  }
 
-    // special case for 2018 on prod or staging
-    if (year === 2018 && (isStaging(HOST) || !isDev(HOST))) {
-      return {
-        year,
-        name: 'cypress bank, state savings bank',
-        institution: '549300I4IUWMEMGLST06',
-      }
+  // special case for 2018 on prod or staging
+  if (year === 2018 && (isStaging(HOST) || !isDev(HOST) || isLocal(HOST))) {
+    return {
+      year,
+      name: 'cypress bank, state savings bank',
+      institution: '549300I4IUWMEMGLST06',
     }
+  }
 
-    if ([2025, 2024, 2023].includes(year) && !isDev(HOST)) {
-      return {
-        year,
-        name: 'cypress bank state savings bank',
-        institution: '549300I4IUWMEMGLST06',
-      }
+  if ([2025, 2024, 2023].includes(year) && (isLocal(HOST) || !isDev(HOST))) {
+    return {
+      year,
+      name: 'cypress bank state savings bank',
+      institution: '549300I4IUWMEMGLST06',
     }
+  }
 
   const getDefaultCaseInstitution = () => {
     const prodTestInstitution = {
@@ -51,7 +56,7 @@ const testCases =
     }
 
     // explicitly set staging to have prod instead of dev data
-    if (isStaging(HOST)) return prodTestInstitution
+    if (isStaging(HOST) || isLocal(HOST)) return prodTestInstitution
     if (isDev(HOST)) return devTestInstitution
     return prodTestInstitution
   }
@@ -62,7 +67,6 @@ const testCases =
   }
 })
 
-
 onlyOn(isBeta(HOST), () => {
   describe('Modified LAR', function () {
     it('Does not run in Beta environments', () => {})
@@ -70,9 +74,12 @@ onlyOn(isBeta(HOST), () => {
 })
 
 onlyOn(!isBeta(HOST), () => {
-  describe('Modified LAR', { tags: ['@smoke'] }, function () {
+  describe('Modified LAR', { tags: ['@localhost', '@smoke'] }, function () {
+    beforeEach(() => {
+      addLocalhostIntercepts()
+    })
     testCases.forEach(({ year, name, institution }) => {
-      it(`Searches and finds correct links for ${year}`,() => {
+      it(`Searches and finds correct links for ${year}`, () => {
         cy.get({ HOST }).logEnv()
         cy.visit(`${HOST}/data-publication/modified-lar/${year}`)
 
@@ -84,19 +91,21 @@ onlyOn(!isBeta(HOST), () => {
         cy.get('#main-content .SearchList > .Results > li > p').contains(
           institution,
         )
-        cy.get('#main-content .SearchList > .Results > li > .font-small').then(
-          ($el) => {
+        cy.get('#main-content .SearchList > .Results > li > .font-small')
+          .then(($el) => {
             expect($el).to.have.text('Download Modified LAR ')
             expect($el).to.have.attr(
               'href',
               `/file/modifiedLar/year/${year}/institution/${institution}/txt`,
             )
-          },
-        ).click()
+          })
+          .click()
 
         const fileName = `${institution}.txt`
         // Read the downloaded file and confirm there are hella pipes in it (at least 50)
-        cy.readFile(`${downloadsFolder}/${fileName}`, { timeout: 10000 }).should((content) => {
+        cy.readFile(`${downloadsFolder}/${fileName}`, {
+          timeout: 10000,
+        }).should((content) => {
           const pipeCount = (content.match(/\|/g) || []).length
           expect(pipeCount).to.be.greaterThan(50)
         })

--- a/cypress/e2e/data-publication/NationalAggregateReports.spec.js
+++ b/cypress/e2e/data-publication/NationalAggregateReports.spec.js
@@ -1,7 +1,7 @@
 import { onlyOn } from '@cypress/skip-test'
-import { isBeta } from '../../support/helpers'
+import { addLocalhostIntercepts, isBeta } from '../../support/helpers'
 
-const { HOST } = Cypress.env()
+const { HOST, ENVIRONMENT } = Cypress.env()
 
 onlyOn(isBeta(HOST), () => {
   describe('National Aggregate Reports', function () {
@@ -10,21 +10,30 @@ onlyOn(isBeta(HOST), () => {
 })
 
 onlyOn(!isBeta(HOST), () => {
-  describe('National Aggregate Report - Not Generated', () => {
-    ;['2021', '2020', '2019', '2018'].forEach((year) => {
-      it(`${year} does not have Reports`, () => {
-        cy.get({ HOST }).logEnv()
-        cy.viewport(1000, 867)
-        cy.visit(`${HOST}/data-publication/national-aggregate-reports/${year}`)
-        cy.get('#main-content h3')
-          .last()
-          .should(
-            'have.text',
-            `National Aggregate reports are not produced for data collected in or after 2018.`,
-          )
+  describe(
+    'National Aggregate Report - Not Generated',
+    { tags: ['@localhost'] },
+    () => {
+      beforeEach(() => {
+        addLocalhostIntercepts()
       })
-    })
-  })
+      ;['2021', '2020', '2019', '2018'].forEach((year) => {
+        it(`${year} does not have Reports`, () => {
+          cy.get({ HOST }).logEnv()
+          cy.viewport(1000, 867)
+          cy.visit(
+            `${HOST}/data-publication/national-aggregate-reports/${year}`,
+          )
+          cy.get('#main-content h3')
+            .last()
+            .should(
+              'have.text',
+              `National Aggregate reports are not produced for data collected in or after 2018.`,
+            )
+        })
+      })
+    },
+  )
 })
 
 onlyOn(!isBeta(HOST), () => {

--- a/cypress/e2e/data-publication/ZeroValueReportNotice.spec.js
+++ b/cypress/e2e/data-publication/ZeroValueReportNotice.spec.js
@@ -1,7 +1,7 @@
 import { onlyOn } from '@cypress/skip-test'
-import { isBeta } from '../../support/helpers'
+import { addLocalhostIntercepts, isBeta } from '../../support/helpers'
 
-const { HOST } = Cypress.env()
+const { HOST, ENVIRONMENT } = Cypress.env()
 
 // setting this to something in the 2025 data publication for now to match data that will be shared
 // between staging and prod
@@ -18,24 +18,31 @@ onlyOn(isBeta(HOST), () => {
 })
 
 onlyOn(!isBeta(HOST), () => {
-  describe('Zero Value Report Notice', { defaultCommandTimeout: 45000 }, () => {
-    it('Shows the notice when a report contains only zeros', () => {
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1680, 916)
-      cy.visit(ALL_ZERO_REPORT)
+  describe(
+    'Zero Value Report Notice',
+    { defaultCommandTimeout: 45000, tags: ['@localhost'] },
+    () => {
+      beforeEach(() => {
+        addLocalhostIntercepts()
+      })
+      it('Shows the notice when a report contains only zeros', () => {
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1680, 916)
+        cy.visit(ALL_ZERO_REPORT)
 
-      cy.get('.all-zero-data-notice')
-        .should('be.visible')
-        .should('contain', 'All values in the table below are 0')
-    })
+        cy.get('.all-zero-data-notice')
+          .should('be.visible')
+          .should('contain', 'All values in the table below are 0')
+      })
 
-    it('Does not show the notice when a report contains any data', () => {
-      cy.get({ HOST }).logEnv()
-      cy.viewport(1680, 916)
-      cy.visit(REPORT_WITH_DATA)
+      it('Does not show the notice when a report contains any data', () => {
+        cy.get({ HOST }).logEnv()
+        cy.viewport(1680, 916)
+        cy.visit(REPORT_WITH_DATA)
 
-      cy.get('.Report table').should('exist')
-      cy.get('.all-zero-data-notice').should('not.exist')
-    })
-  })
+        cy.get('.Report table').should('exist')
+        cy.get('.all-zero-data-notice').should('not.exist')
+      })
+    },
+  )
 })

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -1,4 +1,5 @@
 export const cleanHost = (host) => host.replace(/^https?:\/\//, '')
+export const isLocal = (host) => !!cleanHost(host).match(/localhost:3000/)
 export const isCI = (env) => env === 'CI'
 export const isProd = (host) => !!cleanHost(host).match(/^ffiec(\.beta)?\.cfpb/)
 export const isBeta = (host) => !!cleanHost(host).match(/beta/)
@@ -25,8 +26,13 @@ export function withFormData(method, url, formData, done) {
 }
 
 export function urlExists(url) {
-  return cy.request({ url, method: 'HEAD', failOnStatusCode: false, timeout: 30000 })
-           .then((response) => ({ url, status: response.status < 400, statusCode: response.status }))
+  return cy
+    .request({ url, method: 'HEAD', failOnStatusCode: false, timeout: 30000 })
+    .then((response) => ({
+      url,
+      status: response.status < 400,
+      statusCode: response.status,
+    }))
 }
 
 /* Data Browser Helpers */
@@ -81,5 +87,39 @@ export const logEnv = (obj) => {
   keys.forEach((key) => {
     if (ENV_HIDDEN_KEYS.indexOf(key) > -1) return
     cy.log(`${key}: ${obj[key]}`)
+  })
+}
+
+const PROD_API_HOST = 'https://ffiec.cfpb.gov'
+const LOCAL_HOST = 'http://localhost:3000'
+
+/**
+ * Sets up cy.intercept() handlers that redirect API calls from the local
+ * dev server to the production ffiec.cfpb.gov endpoint.
+ */
+export function addLocalhostIntercepts() {
+  const routes = [
+    '/v2/data-browser-api/**',
+    '/v2/reporting/**',
+    '/quarterly-data/**',
+    '/v2/public/institutions/**',
+    '/file/**',
+  ]
+
+  routes.forEach((route) => {
+    cy.intercept(route, (req) => {
+      req.url = req.url.replace(LOCAL_HOST, PROD_API_HOST)
+      req.continue()
+    })
+  })
+
+  // Geographic data files for maps (/2025/county.json, etc.)
+  cy.intercept('/**/county.json', (req) => {
+    req.url = req.url.replace(LOCAL_HOST, PROD_API_HOST)
+    req.continue()
+  })
+  cy.intercept('/**/state.json', (req) => {
+    req.url = req.url.replace(LOCAL_HOST, PROD_API_HOST)
+    req.continue()
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11020,11 +11020,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes

- Adds a helper function, [`addLocalhostIntercepts()`](https://github.com/cfpb/hmda-frontend/pull/2827/changes#diff-56779aa56c3177d96cabaf13b86833d4b9c9dd2cfb940c249154804cda808b01R100-R125), that tells cypress to swap out `http://localhost:3000` API calls with `https://ffiec.cfpb.gov`.
- Adds a `@localhost` tag to eight tests that are now able to run locally due to the aforementioned helper function running in a `beforeEach` hook.
- Adds a [`isLocal()`](https://github.com/cfpb/hmda-frontend/pull/2827/changes#diff-56779aa56c3177d96cabaf13b86833d4b9c9dd2cfb940c249154804cda808b01R2) helper function (similar to `isDev()` and `isProd()`) for the MLAR spec because the test data is different for staging/beta/prod environments and `localhost:3000` now receives prod data.
- Updates the test github workflow to [preserve cypress artifacts](https://github.com/cfpb/hmda-frontend/pull/2827/changes#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R47-R54) for review if e2e tests fail
- Upgraded a [nanoid transitive dep](https://github.com/cfpb/hmda-frontend/pull/2827/commits/a34e40606a7124f7e7c00a947c71e3ca96852ed7) (`yarn up nanoid -R`) that Veracode was complaining about.
- Eight trillion automatic indentation corrections I'm sorry oh my

## Testing

1. PR checks should pass as github runs `@localhost`-tagged tests via `yarn test-localhost`
